### PR TITLE
Enforce feature flags at the API layer

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -177,7 +177,7 @@ type AppDetailProps = {
   initialTab?: string;
   initialEnv?: string;
   initialSubView?: string;
-  featureFlags?: FeatureFlags;
+  featureFlags: FeatureFlags;
 };
 
 function statusDotColor(status: string) {

--- a/app/(app)/projects/[...slug]/project-detail.tsx
+++ b/app/(app)/projects/[...slug]/project-detail.tsx
@@ -532,7 +532,7 @@ export function ProjectDetail({
   project: Project;
   orgId: string;
   initialTab: string;
-  featureFlags?: FeatureFlags;
+  featureFlags: FeatureFlags;
 }) {
   const router = useRouter();
   const color = "#a1a1aa"; // neutral — project color is unused

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/cron/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/cron/route.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { verifyAppAccess } from "@/lib/api/verify-access";
 import { requireOrg } from "@/lib/auth/session";
 import { isAdmin } from "@/lib/auth/permissions";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; appId: string }>;
@@ -37,6 +38,10 @@ const deleteCronSchema = z.object({
 // GET /api/v1/organizations/[orgId]/apps/[appId]/cron
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("cron")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const app = await verifyAppAccess(orgId, appId);
 
@@ -58,6 +63,10 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 // POST /api/v1/organizations/[orgId]/apps/[appId]/cron
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("cron")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const { membership } = await requireOrg();
     if (!isAdmin(membership.role)) {
@@ -101,6 +110,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 // PATCH /api/v1/organizations/[orgId]/apps/[appId]/cron
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("cron")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const app = await verifyAppAccess(orgId, appId);
 
@@ -139,6 +152,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 // DELETE /api/v1/organizations/[orgId]/apps/[appId]/cron
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("cron")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const app = await verifyAppAccess(orgId, appId);
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/logs/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/logs/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { listContainers, getContainerLogs } from "@/lib/docker/client";
 import { isLokiAvailable, queryRange, buildLogQLQuery } from "@/lib/loki/client";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; appId: string }>;
@@ -14,6 +15,10 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/apps/[appId]/logs
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("logs")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/logs/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/logs/stream/route.ts
@@ -9,6 +9,7 @@ import { resolve } from "path";
 import { readFile } from "fs/promises";
 import { createSSEResponse } from "@/lib/api/sse";
 import { isLokiAvailable, queryRange, tailLogs, buildLogQLQuery } from "@/lib/loki/client";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 const PROJECTS_DIR = resolve(process.env.HOST_PROJECTS_DIR || "./.host/projects");
 
@@ -19,6 +20,13 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/apps/[appId]/logs/stream
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("logs")) {
+      return new Response(JSON.stringify({ error: "Feature not enabled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/stats/history/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/stats/history/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { queryMetricsPoints } from "@/lib/metrics/store";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; appId: string }>;
@@ -15,6 +16,10 @@ type RouteParams = {
 // Query params: from (ms), to (ms), metric (cpu|memory|networkRx|networkTx), bucket (ms)
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/stats/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/stats/route.ts
@@ -5,6 +5,7 @@ import { apps } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { fetchProjectMetrics } from "@/lib/metrics/cadvisor";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; appId: string }>;
@@ -13,6 +14,10 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/apps/[appId]/stats
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/stats/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/stats/stream/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { createSSEResponse } from "@/lib/api/sse";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { subscribe } from "@/lib/metrics/broadcast";
 import { aggregateContainers, containerToPoint } from "@/lib/metrics/aggregate";
 
@@ -16,6 +17,13 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/apps/[appId]/stats/stream
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return new Response(JSON.stringify({ error: "Feature not enabled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/terminal/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/terminal/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { listContainers } from "@/lib/docker/client";
 import { createExec, startExec, resizeExec } from "@/lib/docker/exec";
+import { isFeatureEnabled } from "@/lib/config/features";
 import net from "node:net";
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,13 @@ type RouteParams = {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("terminal")) {
+      return new Response(JSON.stringify({ error: "Feature not enabled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 
@@ -191,6 +199,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("terminal")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/backups/history/[backupId]/download/route.ts
+++ b/app/api/v1/organizations/[orgId]/backups/history/[backupId]/download/route.ts
@@ -3,6 +3,7 @@ import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
 import { backups } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { eq } from "drizzle-orm";
 import { getBackupDownloadUrl, downloadBackupToTemp } from "@/lib/backup/engine";
 import { createReadStream } from "fs";
@@ -15,6 +16,9 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/backups/[backupId]/download
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId, backupId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/backups/history/[backupId]/restore/route.ts
+++ b/app/api/v1/organizations/[orgId]/backups/history/[backupId]/restore/route.ts
@@ -3,6 +3,7 @@ import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
 import { backups } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { eq } from "drizzle-orm";
 import { restoreBackup } from "@/lib/backup/engine";
 
@@ -13,6 +14,9 @@ type RouteParams = {
 // POST /api/v1/organizations/[orgId]/backups/[backupId]/restore
 export async function POST(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId, backupId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/backups/jobs/[jobId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/backups/jobs/[jobId]/route.ts
@@ -5,6 +5,7 @@ import { backupJobs, backupJobApps } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; jobId: string }>;
@@ -27,6 +28,10 @@ const updateJobSchema = z.object({
 // GET /api/v1/organizations/[orgId]/backups/[jobId]
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, jobId } = await params;
     const { organization } = await requireOrg();
 
@@ -68,6 +73,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 // PATCH /api/v1/organizations/[orgId]/backups/[jobId]
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId, jobId } = await params;
     const { organization } = await requireOrg();
 
@@ -126,6 +134,9 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 // DELETE /api/v1/organizations/[orgId]/backups/[jobId]
 export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId, jobId } = await params;
     const { organization, membership } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/backups/route.ts
+++ b/app/api/v1/organizations/[orgId]/backups/route.ts
@@ -8,6 +8,7 @@ import {
   backups,
 } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { eq, and, or, desc, inArray, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -33,6 +34,10 @@ const createJobSchema = z.object({
 // GET /api/v1/organizations/[orgId]/backups
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 
@@ -94,6 +99,10 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 // POST /api/v1/organizations/[orgId]/backups
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/backups/targets/route.ts
+++ b/app/api/v1/organizations/[orgId]/backups/targets/route.ts
@@ -3,6 +3,7 @@ import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
 import { backupTargets } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { eq, or, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -58,6 +59,9 @@ const createTargetSchema = z.discriminatedUnion("type", [
 // GET /api/v1/organizations/[orgId]/backups/targets
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId } = await params;
     const { organization } = await requireOrg();
 
@@ -88,6 +92,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 // POST /api/v1/organizations/[orgId]/backups/targets
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("backups")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/history/route.ts
+++ b/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/history/route.ts
@@ -7,6 +7,7 @@ import { eq, and } from "drizzle-orm";
 import { queryMetricsPoints } from "@/lib/metrics/store";
 import type { MetricsPoint } from "@/lib/metrics/types";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; projectId: string }>;
@@ -16,6 +17,10 @@ type RouteParams = {
 // Aggregates historical metrics across all apps in the project
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, projectId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/route.ts
+++ b/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { fetchAllContainerMetrics } from "@/lib/metrics/cadvisor";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string; projectId: string }>;
@@ -14,6 +15,10 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/projects/[projectId]/stats
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId, projectId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/projects/[projectId]/stats/stream/route.ts
@@ -6,6 +6,7 @@ import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { createSSEResponse } from "@/lib/api/sse";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { subscribe } from "@/lib/metrics/broadcast";
 import { aggregateContainers } from "@/lib/metrics/aggregate";
 
@@ -16,6 +17,13 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/projects/[projectId]/stats/stream
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return new Response(JSON.stringify({ error: "Feature not enabled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const { orgId, projectId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/stats/business/route.ts
+++ b/app/api/v1/organizations/[orgId]/stats/business/route.ts
@@ -6,6 +6,7 @@ import {
   getLatestBusinessMetric,
   type BusinessMetricName,
 } from "@/lib/metrics/store";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string }>;
@@ -29,6 +30,10 @@ const VALID_METRICS: BusinessMetricName[] = [
 //   bucket: aggregation bucket in ms (default: 300000 = 5min)
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/stats/route.ts
+++ b/app/api/v1/organizations/[orgId]/stats/route.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import { fetchAllContainerMetrics } from "@/lib/metrics/cadvisor";
 import { queryMetrics, queryDiskHistory, queryMetricsPoints } from "@/lib/metrics/store";
 import type { MetricsPoint } from "@/lib/metrics/types";
+import { isFeatureEnabled } from "@/lib/config/features";
 
 type RouteParams = {
   params: Promise<{ orgId: string }>;
@@ -16,6 +17,10 @@ type RouteParams = {
 // Returns current stats for all projects in the org, or historical data with ?from=&to=
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/app/api/v1/organizations/[orgId]/stats/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/stats/stream/route.ts
@@ -9,6 +9,7 @@ import { isCollectorRunning, startCollector } from "@/lib/metrics/collector";
 import { getLatestProjectDiskUsage, getLatestDiskUsage } from "@/lib/metrics/store";
 import { createSSEResponse } from "@/lib/api/sse";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { isFeatureEnabled } from "@/lib/config/features";
 import { subscribe } from "@/lib/metrics/broadcast";
 import { aggregateContainers, containerToPoint } from "@/lib/metrics/aggregate";
 
@@ -19,6 +20,13 @@ type RouteParams = {
 // GET /api/v1/organizations/[orgId]/stats/stream
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    if (!isFeatureEnabled("metrics")) {
+      return new Response(JSON.stringify({ error: "Feature not enabled" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const { orgId } = await params;
     const { organization } = await requireOrg();
 

--- a/lib/config/features.ts
+++ b/lib/config/features.ts
@@ -71,15 +71,15 @@ export function isFeatureEnabled(flag: FeatureFlag): boolean {
 }
 
 /**
+ * Feature flags that gate UI tabs and their corresponding API endpoints.
+ */
+export type UIGatedFlag = "metrics" | "logs" | "terminal" | "cron" | "backups";
+
+/**
  * Subset of feature flags relevant to UI tab gating.
  * Passed from server components to client components as a serializable object.
  */
-export type FeatureFlags = {
-  metrics: boolean;
-  logs: boolean;
-  terminal: boolean;
-  cron: boolean;
-};
+export type FeatureFlags = Record<UIGatedFlag, boolean>;
 
 /**
  * Get the feature flags needed for UI tab gating.
@@ -91,6 +91,7 @@ export function getFeatureFlags(): FeatureFlags {
     logs: isFeatureEnabled("logs"),
     terminal: isFeatureEnabled("terminal"),
     cron: isFeatureEnabled("cron"),
+    backups: isFeatureEnabled("backups"),
   };
 }
 


### PR DESCRIPTION
## Summary
- API endpoints for disabled features now return 404 (previously only the UI tab was hidden)
- Adds `backups` to FeatureFlags type and gates backup API endpoints
- Makes `featureFlags` prop required in app-detail and project-detail components
- Derives FeatureFlags from a UIGatedFlag union to prevent type drift between flag definitions

## Review checklist
- [ ] All flaggable endpoints have a guard
- [ ] Existing non-flaggable endpoints are unaffected
- [ ] Feature flags default to enabled (no change in behavior unless explicitly disabled)