### PR TITLE
Security hardening: injection fixes, headers, deduplication

### DIFF
--- a/app/api/v1/admin/backup-targets/route.ts
+++ b/app/api/v1/admin/backup-targets/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { backupTargets, user } from "@/lib/db/schema";
-import { requireSession } from "@/lib/auth/session";
-import { eq, isNull } from "drizzle-orm";
+import { backupTargets } from "@/lib/db/schema";
+import { isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { requireAppAdmin } from "@/lib/auth/admin";
 
 const s3ConfigSchema = z.object({
   bucket: z.string().min(1),
@@ -50,20 +50,6 @@ const createTargetSchema = z.discriminatedUnion("type", [
     isDefault: z.boolean().default(false),
   }),
 ]);
-
-async function requireAppAdmin() {
-  const session = await requireSession();
-  const dbUser = await db.query.user.findFirst({
-    where: eq(user.id, session.user.id),
-    columns: { isAppAdmin: true },
-  });
-
-  if (!dbUser?.isAppAdmin) {
-    throw new Error("Forbidden");
-  }
-
-  return session;
-}
 
 // GET /api/v1/admin/backup-targets — list app-level targets
 export async function GET() {

--- a/app/api/v1/admin/stats/route.ts
+++ b/app/api/v1/admin/stats/route.ts
@@ -1,26 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { user, apps } from "@/lib/db/schema";
-import { requireSession } from "@/lib/auth/session";
-import { eq } from "drizzle-orm";
+import { apps } from "@/lib/db/schema";
 import { fetchAllContainerMetrics } from "@/lib/metrics/cadvisor";
 import { queryAllPoints } from "@/lib/metrics/store";
 import { isMetricsEnabled } from "@/lib/metrics/config";
+import { requireAppAdmin } from "@/lib/auth/admin";
 
 // GET /api/v1/admin/stats
 // System-wide metrics: all containers across all orgs
 // Supports live snapshot or historical query via ?from=&to=
 export async function GET(request: NextRequest) {
   try {
-    const session = await requireSession();
-    const dbUser = await db.query.user.findFirst({
-      where: eq(user.id, session.user.id),
-      columns: { isAppAdmin: true },
-    });
-    if (!dbUser?.isAppAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    await requireAppAdmin();
 
     if (!isMetricsEnabled()) {
       return NextResponse.json({ series: {}, system: null, disk: null });
@@ -71,6 +63,9 @@ export async function GET(request: NextRequest) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     return handleRouteError(error, "Error fetching admin stats");
   }
 }

--- a/app/api/v1/admin/users/route.ts
+++ b/app/api/v1/admin/users/route.ts
@@ -2,26 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
 import { user } from "@/lib/db/schema";
-import { requireSession } from "@/lib/auth/session";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { createHash } from "crypto";
-
-// Hash password with bcrypt-compatible approach via Better Auth's internal method
-// Since Better Auth uses its own password hashing, we'll use the auth API to create users
-import { auth } from "@/lib/auth";
-
-async function requireAppAdmin() {
-  const session = await requireSession();
-  const dbUser = await db.query.user.findFirst({
-    where: eq(user.id, session.user.id),
-    columns: { isAppAdmin: true },
-  });
-  if (!dbUser?.isAppAdmin) {
-    throw new Error("Forbidden");
-  }
-  return session;
-}
+import { requireAppAdmin } from "@/lib/auth/admin";
 
 // GET /api/v1/admin/users
 // List all users (admin only)

--- a/lib/backup/engine.ts
+++ b/lib/backup/engine.ts
@@ -11,6 +11,7 @@ import { mkdir, rm } from "fs/promises";
 import { resolve, join } from "path";
 import type { BackupStorage } from "./storage-port";
 import { createBackupStorage } from "./storage-factory";
+import { assertSafeName } from "@/lib/docker/validate";
 
 const execAsync = promisify(exec);
 
@@ -62,6 +63,9 @@ async function backupVolume(
   const archiveFile = "volume.tar.gz";
 
   try {
+    // Validate volume name before interpolating into shell command
+    assertSafeName(dockerVolumeName);
+
     // Tar the volume contents using a temporary Alpine container
     logFn(`Archiving volume ${dockerVolumeName}`);
     await execAsync(
@@ -148,6 +152,8 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
       // The actual Docker volume name follows the blue/green slot pattern:
       // {appName}-blue_{volumeName} or {appName}-green_{volumeName}
       // We try blue first (production slot), then green
+      assertSafeName(app.name);
+      assertSafeName(vol.name);
       const blueVolume = `${app.name}-blue_${vol.name}`;
       const greenVolume = `${app.name}-green_${vol.name}`;
 
@@ -322,6 +328,8 @@ export async function restoreBackup(
     log("Download complete");
 
     // 2. Determine the Docker volume name (try blue first, then green)
+    assertSafeName(backup.app.name);
+    assertSafeName(backup.volumeName);
     const blueVolume = `${backup.app.name}-blue_${backup.volumeName}`;
     const greenVolume = `${backup.app.name}-green_${backup.volumeName}`;
 

--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -30,7 +30,7 @@ export type ContainerInspect = {
 // Connection helpers
 // ---------------------------------------------------------------------------
 
-function getConnectionOptions(): { socketPath?: string; host?: string; port?: number } {
+export function getConnectionOptions(): { socketPath?: string; host?: string; port?: number } {
   const dockerHost = process.env.DOCKER_HOST;
   if (dockerHost) {
     // tcp://host:port

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -19,6 +19,7 @@ import {
   type ComposeFile,
 } from "./compose";
 import { ensureNetwork, detectExposedPorts, listContainers, inspectContainer } from "./client";
+import { assertSafeName, assertSafeBranch } from "./validate";
 import { getInstallationToken } from "@/lib/github/app";
 import { githubAppInstallations, memberships } from "@/lib/db/schema";
 import { detectPreventiveFixes, detectCompatIssues, applyCompatFixes } from "./compat";
@@ -29,19 +30,6 @@ const execAsync = promisify(exec);
 const PROJECTS_DIR = resolve(process.env.HOST_PROJECTS_DIR || "./.host/projects");
 const NETWORK_NAME = "host-network";
 
-// Validate shell-unsafe strings before interpolation into commands
-const SAFE_BRANCH_RE = /^[a-zA-Z0-9._\-/]+$/;
-function assertSafeBranch(branch: string): void {
-  if (!SAFE_BRANCH_RE.test(branch)) {
-    throw new Error(`Invalid branch name: ${branch}`);
-  }
-}
-const SAFE_NAME_RE = /^[a-zA-Z0-9._\-]+$/;
-function assertSafeName(name: string): void {
-  if (!SAFE_NAME_RE.test(name)) {
-    throw new Error(`Invalid name: ${name}`);
-  }
-}
 const HEALTH_CHECK_TIMEOUT_MS = 60000;
 const HEALTH_CHECK_INTERVAL_MS = 2000;
 

--- a/lib/docker/exec.ts
+++ b/lib/docker/exec.ts
@@ -1,18 +1,6 @@
 import http from "node:http";
 import net from "node:net";
-
-// ---------------------------------------------------------------------------
-// Connection helpers (mirrors client.ts)
-// ---------------------------------------------------------------------------
-
-function getConnectionOptions(): { socketPath?: string; host?: string; port?: number } {
-  const dockerHost = process.env.DOCKER_HOST;
-  if (dockerHost) {
-    const url = new URL(dockerHost);
-    return { host: url.hostname, port: Number(url.port) || 2375 };
-  }
-  return { socketPath: "/var/run/docker.sock" };
-}
+import { getConnectionOptions } from "./client";
 
 // ---------------------------------------------------------------------------
 // Create exec instance

--- a/lib/docker/validate.ts
+++ b/lib/docker/validate.ts
@@ -1,0 +1,25 @@
+// Shared validation helpers for shell-safe interpolation in Docker commands
+
+const SAFE_NAME_RE = /^[a-zA-Z0-9._\-]+$/;
+
+/**
+ * Assert that a name (volume, container, project, etc.) is safe to interpolate
+ * into shell commands. Throws if the name contains characters that could allow
+ * command injection.
+ */
+export function assertSafeName(name: string): void {
+  if (!SAFE_NAME_RE.test(name)) {
+    throw new Error(`Invalid name: ${name}`);
+  }
+}
+
+const SAFE_BRANCH_RE = /^[a-zA-Z0-9._\-/]+$/;
+
+/**
+ * Assert that a git branch name is safe for shell interpolation.
+ */
+export function assertSafeBranch(branch: string): void {
+  if (!SAFE_BRANCH_RE.test(branch)) {
+    throw new Error(`Invalid branch name: ${branch}`);
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,18 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Default security headers for all routes
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "X-XSS-Protection", value: "0" },
+        ],
+      },
+      {
         // Allow the widget bridge to be iframed from any origin
+        // (overrides the default X-Frame-Options for this route)
         source: "/widget/bridge",
         headers: [
           { key: "X-Frame-Options", value: "ALLOWALL" },


### PR DESCRIPTION
## Summary

- **Command injection fix**: Validate volume/container names with `assertSafeName()` before interpolation into `execAsync` shell commands in `lib/backup/engine.ts` (both `runBackup` and `restoreBackup`)
- **Security headers**: Add `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and `X-XSS-Protection: 0` to all routes via `next.config.ts` (widget bridge override preserved)
- **Deduplicate `requireAppAdmin`**: Replace inline copies in 3 admin routes with import from `lib/auth/admin.ts`
- **Deduplicate `getConnectionOptions`**: Export from `lib/docker/client.ts`, import in `exec.ts`
- **Extract validation helpers**: New `lib/docker/validate.ts` shared by `deploy.ts` and `engine.ts`
- **proxy.ts**: Already wired up natively by Next.js 16 -- no middleware.ts needed

## Test plan

- [ ] Verify `pnpm typecheck` passes (confirmed locally)
- [ ] Verify backup/restore still works with valid volume names
- [ ] Verify backup rejects names with shell metacharacters (e.g. `; rm -rf /`)
- [ ] Verify response headers include security headers on non-widget routes
- [ ] Verify `/widget/bridge` still allows framing
- [ ] Verify admin routes still return 403 for non-admin users