### PR TITLE
Backup job scheduler: run backups on cron schedule

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -28,6 +28,15 @@ export async function register() {
       console.error("[instrumentation] Failed to start cron scheduler:", err);
     }
 
+    console.log("[instrumentation] Starting backup scheduler...");
+    try {
+      const { startBackupScheduler } = await import("./lib/backup/scheduler");
+      startBackupScheduler();
+      console.log("[instrumentation] Backup scheduler started");
+    } catch (err) {
+      console.error("[instrumentation] Failed to start backup scheduler:", err);
+    }
+
     console.log("[instrumentation] Starting domain monitor...");
     try {
       setInterval(async () => {

--- a/lib/backup/scheduler.ts
+++ b/lib/backup/scheduler.ts
@@ -1,0 +1,24 @@
+import { tickBackupJobs } from "./tick";
+
+let interval: NodeJS.Timeout | null = null;
+
+export function startBackupScheduler(): void {
+  if (interval) return; // Already running
+
+  console.log("[backup] Scheduler started (60s interval)");
+  interval = setInterval(async () => {
+    try {
+      await tickBackupJobs();
+    } catch (err) {
+      console.error("[backup] Tick error:", err);
+    }
+  }, 60_000); // Every minute
+}
+
+export function stopBackupScheduler(): void {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+    console.log("[backup] Scheduler stopped");
+  }
+}

--- a/lib/backup/tick.ts
+++ b/lib/backup/tick.ts
@@ -1,0 +1,65 @@
+import { db } from "@/lib/db";
+import { backupJobs, backups } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { runBackup } from "./engine";
+import { shouldRunNow, isSameMinute } from "@/lib/cron/parse";
+
+// ---------------------------------------------------------------------------
+// Public tick
+// ---------------------------------------------------------------------------
+
+/**
+ * Check all enabled backup jobs and run any that are due.
+ * Call this every minute from the backup scheduler.
+ */
+export async function tickBackupJobs(): Promise<void> {
+  const now = new Date();
+
+  const jobs = await db.query.backupJobs.findMany({
+    where: eq(backupJobs.enabled, true),
+  });
+
+  for (const job of jobs) {
+    try {
+      // Check if this job should run now based on its cron schedule
+      if (!shouldRunNow(job.schedule, now)) continue;
+
+      // Avoid running the same job twice in the same minute
+      if (job.lastRunAt && isSameMinute(new Date(job.lastRunAt), now)) {
+        continue;
+      }
+
+      // Check if this job already has a backup in "running" state (still in progress)
+      const runningBackup = await db.query.backups.findFirst({
+        where: and(eq(backups.jobId, job.id), eq(backups.status, "running")),
+      });
+
+      if (runningBackup) {
+        console.log(
+          `[backup] Skipping job "${job.name}" — already running (backup ${runningBackup.id})`,
+        );
+        continue;
+      }
+
+      // Mark lastRunAt before executing so a concurrent tick won't double-fire
+      await db
+        .update(backupJobs)
+        .set({ lastRunAt: now, updatedAt: now })
+        .where(eq(backupJobs.id, job.id));
+
+      console.log(`[backup] Running job "${job.name}" (${job.id})`);
+
+      const results = await runBackup(job.id);
+
+      const succeeded = results.filter((r) => r.success).length;
+      const failed = results.filter((r) => !r.success).length;
+
+      console.log(
+        `[backup] Job "${job.name}" finished: ${succeeded} succeeded, ${failed} failed`,
+      );
+    } catch (err) {
+      console.error(`[backup] Job "${job.name}" (${job.id}) error:`, err);
+      // Continue to next job — don't let one failure crash the whole tick
+    }
+  }
+}

--- a/lib/cron/engine.ts
+++ b/lib/cron/engine.ts
@@ -5,52 +5,9 @@ import { nanoid } from "nanoid";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { listContainers } from "@/lib/docker/client";
+import { shouldRunNow } from "./parse";
 
 const execAsync = promisify(exec);
-
-/**
- * Parse a cron expression and check if it should run now.
- * Supports: minute hour dayOfMonth month dayOfWeek
- * Supports: *, *\/N, N, N-M, N,M
- */
-function shouldRunNow(schedule: string, now: Date): boolean {
-  const parts = schedule.trim().split(/\s+/);
-  if (parts.length !== 5) return false;
-
-  const checks = [
-    { value: now.getMinutes(), field: parts[0] },
-    { value: now.getHours(), field: parts[1] },
-    { value: now.getDate(), field: parts[2] },
-    { value: now.getMonth() + 1, field: parts[3] },
-    { value: now.getDay(), field: parts[4] },
-  ];
-
-  return checks.every(({ value, field }) => matchesCronField(value, field));
-}
-
-function matchesCronField(value: number, field: string): boolean {
-  if (field === "*") return true;
-
-  // */N — every N
-  if (field.startsWith("*/")) {
-    const interval = parseInt(field.slice(2));
-    return value % interval === 0;
-  }
-
-  // Comma-separated values
-  const parts = field.split(",");
-  for (const part of parts) {
-    // Range N-M
-    if (part.includes("-")) {
-      const [start, end] = part.split("-").map(Number);
-      if (value >= start && value <= end) return true;
-    } else {
-      if (parseInt(part) === value) return true;
-    }
-  }
-
-  return false;
-}
 
 /**
  * Run a command inside an app's container.

--- a/lib/cron/parse.ts
+++ b/lib/cron/parse.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared cron expression parsing used by both the cron engine and backup scheduler.
+ * Supports: minute hour dayOfMonth month dayOfWeek
+ * Supports: *, *\/N, N, N-M, N,M
+ */
+
+export function shouldRunNow(schedule: string, now: Date): boolean {
+  const parts = schedule.trim().split(/\s+/);
+  if (parts.length !== 5) return false;
+
+  const checks = [
+    { value: now.getMinutes(), field: parts[0] },
+    { value: now.getHours(), field: parts[1] },
+    { value: now.getDate(), field: parts[2] },
+    { value: now.getMonth() + 1, field: parts[3] },
+    { value: now.getDay(), field: parts[4] },
+  ];
+
+  return checks.every(({ value, field }) => matchesCronField(value, field));
+}
+
+export function matchesCronField(value: number, field: string): boolean {
+  if (field === "*") return true;
+
+  // */N — every N
+  if (field.startsWith("*/")) {
+    const step = parseInt(field.slice(2));
+    return value % step === 0;
+  }
+
+  // Comma-separated values
+  const segments = field.split(",");
+  for (const segment of segments) {
+    // Range N-M
+    if (segment.includes("-")) {
+      const [start, end] = segment.split("-").map(Number);
+      if (value >= start && value <= end) return true;
+    } else {
+      if (parseInt(segment) === value) return true;
+    }
+  }
+
+  return false;
+}
+
+export function isSameMinute(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate() &&
+    a.getHours() === b.getHours() &&
+    a.getMinutes() === b.getMinutes()
+  );
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -600,6 +600,7 @@ export const backupJobs = pgTable("backup_job", {
   // Notification settings
   notifyOnSuccess: boolean("notify_on_success").default(false),
   notifyOnFailure: boolean("notify_on_failure").default(true),
+  lastRunAt: timestamp("last_run_at"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

- Adds a 60-second interval backup scheduler that evaluates cron expressions on enabled backup jobs and triggers `runBackup()` when due
- Adds `lastRunAt` column to the `backupJobs` schema for same-minute deduplication
- Includes running-state guard: skips jobs that already have a backup record in `running` status
- Per-job error isolation ensures one failing job does not block others

## Changes

- `lib/db/schema.ts` — add `lastRunAt` timestamp column to `backupJobs`
- `lib/backup/tick.ts` — tick logic: query enabled jobs, cron match, duplicate guards, execute
- `lib/backup/scheduler.ts` — 60s `setInterval` wrapper (mirrors `lib/cron/scheduler.ts`)
- `instrumentation.ts` — wire `startBackupScheduler()` into app boot

## Test plan

- [ ] Run `pnpm db:push` to apply the new `last_run_at` column
- [ ] Create a backup job with a schedule like `* * * * *` (every minute) and verify it triggers within 60s
- [ ] Confirm `lastRunAt` is updated after each run
- [ ] Verify a job with a running backup record is skipped (no double execution)
- [ ] Disable a backup job and confirm it stops being picked up
- [ ] Check server logs for `[backup]` scheduler messages on boot and each tick