### PR TITLE
Docker logs fallback with source indicator

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/logs/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/logs/route.ts
@@ -69,6 +69,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       const containers = await listContainers(app.name).catch(() => []);
 
       return NextResponse.json({
+        source: "loki",
         logs: entries.map((e) => e.line).join("\n"),
         entries: entries.map((e) => ({
           timestamp: e.timestamp,
@@ -89,6 +90,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (containers.length === 0) {
       return NextResponse.json({
+        source: "docker",
         logs: "No running containers found for this app.",
         containers: [],
       });
@@ -109,6 +111,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     return NextResponse.json({
+      source: "docker",
       logs: allLogs.join("\n"),
       containers: containers.map((c) => ({
         id: c.id,

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/logs/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/logs/stream/route.ts
@@ -62,6 +62,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       });
 
       return createSSEResponse(request, async (sendEvent) => {
+        sendEvent("source", "loki");
+
         // Backfill recent history so the viewer has content immediately
         try {
           const tailCount = parseInt(tail);
@@ -92,6 +94,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Docker compose logs fallback
     return createSSEResponse(request, async (sendEvent) => {
+      sendEvent("source", "docker");
+
       let appDir = resolve(PROJECTS_DIR, app.name, environmentName);
       let activeSlot = "blue";
       try {

--- a/components/log-viewer.tsx
+++ b/components/log-viewer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
-import { Loader2, Pause, Play, ArrowDown, X, Copy, Check } from "lucide-react";
+import { Loader2, Pause, Play, ArrowDown, X, Copy, Check, Database, HardDrive } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useVisibilityKey } from "@/lib/hooks/use-visible";
@@ -345,6 +345,8 @@ export function DeploymentLog({ log, maxHeight = "max-h-96" }: StaticLogProps) {
 
 // --- Streaming log viewer ---
 
+type LogSource = "loki" | "docker" | null;
+
 type LogViewerProps = {
   streamUrl: string;
   historyUrl?: string;
@@ -357,6 +359,7 @@ export function LogViewer({ streamUrl, historyUrl, maxLines = 1000 }: LogViewerP
   const [timedOut, setTimedOut] = useState(false);
   const [paused, setPaused] = useState(false);
   const [manualReconnect, setManualReconnect] = useState(0);
+  const [logSource, setLogSource] = useState<LogSource>(null);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
   const visKey = useVisibilityKey();
@@ -364,6 +367,8 @@ export function LogViewer({ streamUrl, historyUrl, maxLines = 1000 }: LogViewerP
   useEffect(() => {
     // Don't connect if tab is hidden
     if (typeof document !== "undefined" && document.hidden) return;
+
+    setLogSource(null);
 
     // The SSE stream now backfills history automatically when Loki is available,
     // but if a separate historyUrl is provided, pre-load from it for instant content
@@ -392,6 +397,17 @@ export function LogViewer({ streamUrl, historyUrl, maxLines = 1000 }: LogViewerP
     const es = new EventSource(streamUrl);
 
     es.onopen = () => setConnected(true);
+
+    es.addEventListener("source", (event: MessageEvent) => {
+      try {
+        const src = JSON.parse(event.data) as string;
+        if (src === "loki" || src === "docker") {
+          setLogSource(src);
+        }
+      } catch {
+        // skip malformed source event
+      }
+    });
 
     function handleLogEvent(event: MessageEvent) {
       if (pausedRef.current) return;
@@ -440,6 +456,15 @@ export function LogViewer({ streamUrl, historyUrl, maxLines = 1000 }: LogViewerP
           <span className="text-xs text-muted-foreground">
             {connected ? "Streaming" : timedOut ? "Paused" : "Disconnected"}
           </span>
+          {logSource && (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground border border-zinc-800 rounded px-1.5 py-0.5">
+              {logSource === "loki" ? (
+                <><Database className="size-3" />Loki</>
+              ) : (
+                <><HardDrive className="size-3" />Container logs</>
+              )}
+            </span>
+          )}
           {timedOut && (
             <Button
               size="xs"


### PR DESCRIPTION
## Summary

- Add `source` field (`"loki"` or `"docker"`) to the logs GET endpoint JSON response so consumers know which backend served the data
- Emit an SSE `source` event at the start of the logs stream so the LogViewer can display the active backend before any log lines arrive
- Show a subtle badge in the LogViewer toolbar (Loki with database icon or Container logs with hard drive icon) to set user expectations about log persistence and query capability

## Context

The logs API and stream routes already fall back from Loki to Docker container logs when Loki is unreachable. This change makes the fallback visible in the UI so users understand why LogQL queries are unavailable and that Docker logs are ephemeral.

## Test plan

- [ ] With Loki running: verify the LogViewer shows a Loki badge and the GET endpoint returns source loki
- [ ] With Loki stopped: verify the LogViewer shows a Container logs badge and the GET endpoint returns source docker
- [ ] With FEATURE_LOGS=false: verify both endpoints return 404 (existing behavior, unchanged)
- [ ] Verify badge resets on reconnect (tab visibility change, manual resume)