### PR TITLE
Wire deploy log streaming via Redis pub/sub and SSE

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -788,41 +788,97 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
     setDeploying(true);
     setDeployStartTime(new Date(serverRunningDeploy.startedAt).getTime());
     setActiveTab("deployments");
-    setExpandedDeployLog(false);
+    setExpandedDeployLog(true);
 
-    let stopped = false;
-    async function poll() {
-      while (!stopped) {
-        await new Promise((r) => setTimeout(r, 3000));
-        if (stopped) break;
-        try {
-          const res = await fetch(
-            `/api/v1/organizations/${orgId}/apps/${app.id}`,
-          );
-          if (!res.ok) continue;
-          const { app: updated } = await res.json();
-          const dep = updated.deployments?.find((d: { id: string }) => d.id === serverRunningDeploy!.id);
-          if (dep?.log) {
-            setDeployLog(dep.log.split("\n"));
-          }
-          if (dep?.status === "success" || dep?.status === "failed") {
-            if (dep.status === "success") {
-              toast.success(`Deployed in ${dep.durationMs ? Math.round(dep.durationMs / 1000) + "s" : "—"}`);
-            } else {
-              toast.error("Deployment failed");
-            }
-            setViewingLogId(dep.id);
-            stopped = true;
-          }
-        } catch { /* retry */ }
-      }
+    // Connect to the deploy stream SSE endpoint for real-time logs
+    const streamUrl = `/api/v1/organizations/${orgId}/apps/${app.id}/deploy/stream`;
+    const es = new EventSource(streamUrl);
+    let finished = false;
+
+    es.addEventListener("log", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.message) {
+          setDeployLog((prev) => [...prev, data.message]);
+        }
+      } catch { /* skip malformed */ }
+    });
+
+    es.addEventListener("stage", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.stage && data.status) {
+          setDeployStages((prev) => ({ ...prev, [data.stage]: data.status }));
+        }
+      } catch { /* skip malformed */ }
+    });
+
+    es.addEventListener("done", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        finished = true;
+        if (data.success) {
+          toast.success(`Deployed in ${data.durationMs ? Math.round(data.durationMs / 1000) + "s" : "---"}`);
+        } else {
+          toast.error("Deployment failed");
+        }
+        if (data.deploymentId) {
+          setViewingLogId(data.deploymentId);
+        }
+      } catch { /* skip malformed */ }
+      es.close();
       setDeploying(false);
       setDeployAbort(null);
       router.refresh();
-    }
+    });
 
-    poll();
-    return () => { stopped = true; };
+    es.addEventListener("timeout", () => {
+      es.close();
+      if (!finished) {
+        setDeploying(false);
+        setDeployAbort(null);
+        router.refresh();
+      }
+    });
+
+    es.onerror = () => {
+      // SSE connection failed -- fall back to polling
+      es.close();
+      if (finished) return;
+      let stopped = false;
+      async function poll() {
+        while (!stopped) {
+          await new Promise((r) => setTimeout(r, 3000));
+          if (stopped) break;
+          try {
+            const res = await fetch(
+              `/api/v1/organizations/${orgId}/apps/${app.id}`,
+            );
+            if (!res.ok) continue;
+            const { app: updated } = await res.json();
+            const dep = updated.deployments?.find((d: { id: string }) => d.id === serverRunningDeploy!.id);
+            if (dep?.log) {
+              setDeployLog(dep.log.split("\n"));
+            }
+            if (dep?.status === "success" || dep?.status === "failed") {
+              if (dep.status === "success") {
+                toast.success(`Deployed in ${dep.durationMs ? Math.round(dep.durationMs / 1000) + "s" : "---"}`);
+              } else {
+                toast.error("Deployment failed");
+              }
+              setViewingLogId(dep.id);
+              stopped = true;
+            }
+          } catch { /* retry */ }
+        }
+        setDeploying(false);
+        setDeployAbort(null);
+        router.refresh();
+      }
+      poll();
+    };
+
+    return () => { es.close(); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverRunningDeploy?.id]);
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/stream/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { apps, deployments } from "@/lib/db/schema";
+import { requireOrg } from "@/lib/auth/session";
+import { eq, and, desc } from "drizzle-orm";
+import { subscribe, appChannel } from "@/lib/events";
+
+type RouteParams = {
+  params: Promise<{ orgId: string; appId: string }>;
+};
+
+// GET /api/v1/organizations/[orgId]/apps/[appId]/deploy/stream
+// SSE stream of deploy log lines and stage transitions via Redis pub/sub.
+// Clients connect here to follow an in-progress deployment in real time.
+// On connect, backfills logs from the running deployment record.
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, appId } = await params;
+    const { organization } = await requireOrg();
+
+    if (organization.id !== orgId) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    const app = await db.query.apps.findFirst({
+      where: and(eq(apps.id, appId), eq(apps.organizationId, orgId)),
+      columns: { id: true },
+    });
+
+    if (!app) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const runningDeploy = await db.query.deployments.findFirst({
+      where: and(eq(deployments.appId, appId), eq(deployments.status, "running")),
+      columns: { id: true, log: true },
+      orderBy: [desc(deployments.startedAt)],
+    });
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        function send(event: string, data: unknown) {
+          try {
+            if (controller.desiredSize !== null && controller.desiredSize <= 0) return;
+            controller.enqueue(
+              encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+            );
+          } catch { /* client disconnected */ }
+        }
+
+        if (runningDeploy) {
+          send("backfill-start", { deploymentId: runningDeploy.id });
+          if (runningDeploy.log) {
+            for (const line of runningDeploy.log.split("\n")) {
+              if (line) send("log", { deploymentId: runningDeploy.id, message: line });
+            }
+          }
+          send("backfill-end", { deploymentId: runningDeploy.id });
+        }
+
+        const keepalive = setInterval(() => {
+          try { controller.enqueue(encoder.encode(": keepalive\n\n")); }
+          catch { clearInterval(keepalive); }
+        }, 30000);
+
+        const unsubscribe = subscribe(appChannel(appId), (data) => {
+          const event = data.event as string;
+          if (event === "deploy:log") {
+            send("log", { deploymentId: data.deploymentId, message: data.message });
+          } else if (event === "deploy:stage") {
+            send("stage", { deploymentId: data.deploymentId, stage: data.stage, status: data.status });
+          } else if (event === "deploy:complete") {
+            send("done", { deploymentId: data.deploymentId, success: data.success, durationMs: data.durationMs, status: data.status });
+          }
+        });
+
+        // Re-check after subscription is live to close the backfill race:
+        // if deploy finished between the initial query and subscribe(), we'd
+        // never receive the done event. Catch it here.
+        if (runningDeploy) {
+          db.query.deployments.findFirst({
+            where: eq(deployments.id, runningDeploy.id),
+            columns: { id: true, status: true },
+          }).then((latest) => {
+            if (latest && latest.status !== "running") {
+              send("done", { deploymentId: latest.id, success: latest.status === "success", status: latest.status });
+              cleanup();
+              try { controller.close(); } catch { /* already closed */ }
+            }
+          }).catch(() => { /* best-effort */ });
+        }
+
+        const timeout = setTimeout(() => {
+          send("timeout", { message: "Stream timed out" });
+          cleanup();
+          try { controller.close(); } catch { /* already closed */ }
+        }, 10 * 60 * 1000);
+
+        function cleanup() {
+          clearInterval(keepalive);
+          clearTimeout(timeout);
+          unsubscribe();
+        }
+
+        request.signal.addEventListener("abort", () => {
+          cleanup();
+          try { controller.close(); } catch { /* already closed */ }
+        });
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error streaming deploy logs");
+  }
+}

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -87,10 +87,27 @@ export async function runDeployment(
       .replace(/ghs_[A-Za-z0-9]+/g, "***");
     logLines.push(sanitized);
     opts.onLog?.(sanitized);
+
+    // Broadcast log line via Redis pub/sub for live viewers
+    publishEvent(appChannel(opts.appId), {
+      event: "deploy:log",
+      appId: opts.appId,
+      deploymentId,
+      message: sanitized,
+    }).catch(() => {});
   }
 
   function stage(s: DeployStage, status: "running" | "success" | "failed" | "skipped") {
     opts.onStage?.(s, status);
+
+    // Broadcast stage change via Redis pub/sub for live viewers
+    publishEvent(appChannel(opts.appId), {
+      event: "deploy:stage",
+      appId: opts.appId,
+      deploymentId,
+      stage: s,
+      status,
+    }).catch(() => {});
   }
 
   function checkAbort() {

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -2,14 +2,16 @@ import Redis from "ioredis";
 
 const url = process.env.REDIS_URL || "redis://localhost:6379";
 
+// Shared publish client — reused across all publishEvent calls
+const globalForPub = globalThis as unknown as { redisPub: Redis | undefined };
+const publishClient = globalForPub.redisPub ?? new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: true });
+if (process.env.NODE_ENV !== "production") {
+  globalForPub.redisPub = publishClient;
+}
+
 // Publish an event — use the shared redis client
 export async function publishEvent(channel: string, data: Record<string, unknown>) {
-  const pub = new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: true });
-  try {
-    await pub.publish(channel, JSON.stringify(data));
-  } finally {
-    pub.disconnect();
-  }
+  await publishClient.publish(channel, JSON.stringify(data));
 }
 
 // Subscribe to a channel — returns a cleanup function


### PR DESCRIPTION
## Summary

- **Redis pub/sub for deploy events**: The `runDeployment` function now publishes `deploy:log` and `deploy:stage` events to Redis pub/sub on every log line and stage transition, alongside the existing `deploy:complete` event. This enables any connected client to follow deploy progress in real time without needing the original SSE connection that triggered the deploy.

- **New SSE stream endpoint** (`GET /api/v1/.../deploy/stream`): Subscribes to the app's Redis pub/sub channel and forwards `deploy:log`, `deploy:stage`, and `deploy:complete` events to the client. On connect, backfills any logs already accumulated on the running deployment record so late-joining clients don't miss early output.

- **Frontend: SSE replaces polling for mid-deploy arrivals**: When a user loads the app detail page during an active deployment (server-detected running deploy), the UI now connects to the deploy stream SSE endpoint instead of polling the app API every 3 seconds. Logs and stage indicators appear in real time via the existing `InProgressDeployCard`. Falls back to polling if the SSE connection fails.

## Changed files

| File | Change |
|------|--------|
| `lib/docker/deploy.ts` | Publish `deploy:log` and `deploy:stage` to Redis pub/sub in `log()` and `stage()` helpers |
| `app/api/v1/.../deploy/stream/route.ts` | New SSE endpoint with backfill + Redis pub/sub subscription |
| `app/(app)/apps/[...slug]/app-detail.tsx` | Replace polling fallback with SSE streaming for mid-deploy detection |

## Test plan

- [ ] Trigger a deploy from the UI -- verify logs stream in real-time as before (no regression)
- [ ] Open the app detail page in a second browser tab during an active deploy -- verify logs and stage indicators appear in real time via SSE
- [ ] Kill the SSE connection (e.g. network tab) -- verify it falls back to polling
- [ ] Verify the deploy stream endpoint requires authentication and org membership
- [ ] Verify no duplicate log lines when backfill overlaps with live events