### PR TITLE
feat(apps): add CPU and memory resource limits

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -144,6 +144,8 @@ type App = {
   restartPolicy: string | null;
   connectionInfo: { label: string; value: string; copyRef?: string }[] | null;
   exposedPorts: { internal: number; external?: number; description?: string }[] | null;
+  cpuLimit: number | null;
+  memoryLimit: number | null;
   projectId: string | null;
   cloneStrategy: string | null;
   dependsOn: string[] | null;
@@ -594,6 +596,8 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
   const [gitBranch, setGitBranch] = useState(app.gitBranch || "");
   const [rootDirectory, setRootDirectory] = useState(app.rootDirectory || "");
   const [editParentId, setEditParentId] = useState<string | null>(app.projectId ?? null);
+  const [cpuLimit, setCpuLimit] = useState(app.cpuLimit?.toString() || "");
+  const [memoryLimit, setMemoryLimit] = useState(app.memoryLimit?.toString() || "");
 
   // New environment form state
   const [newEnvOpen, setNewEnvOpen] = useState(false);
@@ -981,6 +985,8 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
       }
       if (editImageName.trim()) body.imageName = editImageName.trim();
       body.restartPolicy = restartPolicy;
+      body.cpuLimit = cpuLimit ? parseFloat(cpuLimit) : null;
+      body.memoryLimit = memoryLimit ? parseInt(memoryLimit, 10) : null;
       if (editParentId) {
         body.projectId = editParentId;
       } else {
@@ -2454,6 +2460,20 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                     <SelectItem value="no">Never</SelectItem>
                   </SelectContent>
                 </Select>
+              </div>
+
+              {/* Resource Limits */}
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-cpu-limit">CPU Limit (cores)</Label>
+                  <Input id="edit-cpu-limit" type="number" step="0.1" min="0.1" placeholder="No limit" value={cpuLimit} onChange={(e) => setCpuLimit(e.target.value)} />
+                  <p className="text-xs text-muted-foreground">{cpuLimit ? cpuLimit + " CPU core(s)" : "No limit"}</p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-memory-limit">Memory Limit (MB)</Label>
+                  <Input id="edit-memory-limit" type="number" step="64" min="64" placeholder="No limit" value={memoryLimit} onChange={(e) => setMemoryLimit(e.target.value)} />
+                  <p className="text-xs text-muted-foreground">{memoryLimit ? memoryLimit + " MB" : "No limit"}</p>
+                </div>
               </div>
 
               {/* Toggles */}

--- a/app/(app)/apps/new/new-app-flow.tsx
+++ b/app/(app)/apps/new/new-app-flow.tsx
@@ -62,6 +62,8 @@ type Template = {
   defaultConnectionInfo:
     | { label: string; value: string; copyRef?: string }[]
     | null;
+  defaultCpuLimit: number | null;
+  defaultMemoryLimit: number | null;
 };
 
 type Installation = {
@@ -161,6 +163,8 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
   >([]);
   const [exposePort, setExposePort] = useState(false);
   const [createRepo, setCreateRepo] = useState(false);
+  const [cpuLimit, setCpuLimit] = useState("");
+  const [memoryLimit, setMemoryLimit] = useState("");
 
   // Domain
   const [generateDomain, setGenerateDomain] = useState(true);
@@ -288,6 +292,8 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
     setPersistData(alwaysPersist.includes(template.category));
     setTemplateVolumes(template.defaultVolumes || []);
     setTemplateConnectionInfo(template.defaultConnectionInfo || []);
+    setCpuLimit(template.defaultCpuLimit?.toString() || "");
+    setMemoryLimit(template.defaultMemoryLimit?.toString() || "");
     if (template.defaultEnvVars?.length) {
       const slug = slugify(template.name);
       const lines: string[] = [`# ${template.displayName} configuration`];
@@ -388,6 +394,8 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
           : undefined,
       };
       if (containerPort) body.containerPort = parseInt(containerPort, 10);
+      if (cpuLimit) body.cpuLimit = parseFloat(cpuLimit);
+      if (memoryLimit) body.memoryLimit = parseInt(memoryLimit, 10);
       if (rootDirectory.trim()) body.rootDirectory = rootDirectory.trim();
 
       // Create GitHub repo if opted in
@@ -827,6 +835,18 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
                 />
               </div>
             )}
+
+            {/* Resource Limits */}
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="cpu-limit">CPU Limit (cores)</Label>
+                <Input id="cpu-limit" type="number" step="0.1" min="0.1" placeholder="No limit" value={cpuLimit} onChange={(e) => setCpuLimit(e.target.value)} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="memory-limit">Memory Limit (MB)</Label>
+                <Input id="memory-limit" type="number" step="64" min="64" placeholder="No limit" value={memoryLimit} onChange={(e) => setMemoryLimit(e.target.value)} />
+              </div>
+            </div>
 
             {/* Root directory — only for git/repo sources */}
             {(selectedSource === "github" || (selectedSource === "compose" && contentMode === "url")) && (

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
@@ -31,6 +31,8 @@ const updateAppSchema = z.object({
     protocol: z.string().optional(),
     description: z.string().optional(),
   })).nullable().optional(),
+  cpuLimit: z.number().positive().max(64).nullable().optional(),
+  memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
   projectId: z.string().nullable().optional(),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
   cloneStrategy: z.enum(["clone", "clone_data", "empty", "skip"]).optional(),

--- a/app/api/v1/organizations/[orgId]/apps/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/route.ts
@@ -50,6 +50,8 @@ const createAppSchema = z
       value: z.string(),
       copyRef: z.string().optional(),
     })).optional(),
+    cpuLimit: z.number().positive().max(64).nullable().optional(),
+    memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
     projectId: z.string().optional(),
   })
   .refine(
@@ -189,6 +191,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           return data.exposedPorts;
         })() : undefined,
         connectionInfo: data.connectionInfo,
+        cpuLimit: data.cpuLimit ?? null,
+        memoryLimit: data.memoryLimit ?? null,
       })
       .returning();
 

--- a/lib/config/host-config.ts
+++ b/lib/config/host-config.ts
@@ -16,6 +16,8 @@ export type HostConfig = {
     autoDeploy?: boolean;
     branch?: string;
     restartPolicy?: string;
+    cpuLimit?: number;
+    memoryLimit?: number;
   };
   envVars?: { key: string; value: string }[];
   volumes?: { name: string; mountPath: string }[];
@@ -50,6 +52,8 @@ export function applyHostConfig(config: HostConfig): {
   autoDeploy?: boolean;
   rootDirectory?: string;
   restartPolicy?: string;
+  cpuLimit?: number;
+  memoryLimit?: number;
   envVars?: { key: string; value: string }[];
   persistentVolumes?: { name: string; mountPath: string }[];
 } {
@@ -59,6 +63,8 @@ export function applyHostConfig(config: HostConfig): {
   if (config.project?.rootDirectory) result.rootDirectory = config.project.rootDirectory;
   if (config.deploy?.autoDeploy !== undefined) result.autoDeploy = config.deploy.autoDeploy;
   if (config.deploy?.restartPolicy) result.restartPolicy = config.deploy.restartPolicy;
+  if (config.deploy?.cpuLimit) result.cpuLimit = config.deploy.cpuLimit;
+  if (config.deploy?.memoryLimit) result.memoryLimit = config.deploy.memoryLimit;
   if (config.envVars?.length) result.envVars = config.envVars;
   if (config.volumes?.length) {
     result.persistentVolumes = config.volumes.map((v) => ({

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
   integer,
   pgEnum,
   pgTable,
+  real,
   text,
   timestamp,
   unique,
@@ -327,6 +328,8 @@ export const apps = pgTable(
     templateVersion: text("template_version"),
     status: appStatusEnum("status").notNull().default("stopped"),
     needsRedeploy: boolean("needs_redeploy").default(false),
+    cpuLimit: real("cpu_limit"), // CPU cores (e.g. 0.5, 1, 2)
+    memoryLimit: integer("memory_limit"), // Memory in MB (e.g. 256, 512, 1024)
     envContent: text("env_content"), // Encrypted env file blob (AES-256-GCM)
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -10,6 +10,11 @@
 // Types
 // ---------------------------------------------------------------------------
 
+export type ResourceLimits = {
+  cpus?: string;
+  memory?: string;
+};
+
 export type ComposeService = {
   name: string;
   image?: string;
@@ -20,6 +25,11 @@ export type ComposeService = {
   volumes?: string[];
   labels?: Record<string, string>;
   networks?: string[];
+  deploy?: {
+    resources?: {
+      limits?: ResourceLimits;
+    };
+  };
 };
 
 export type ComposeFile = {
@@ -195,6 +205,25 @@ export function injectNetwork(
 }
 
 // ---------------------------------------------------------------------------
+// Resource limit injection
+// ---------------------------------------------------------------------------
+
+export function injectResourceLimits(
+  compose: ComposeFile,
+  opts: { cpuLimit?: number | null; memoryLimit?: number | null },
+): ComposeFile {
+  if (!opts.cpuLimit && !opts.memoryLimit) return compose;
+  const limits: ResourceLimits = {};
+  if (opts.cpuLimit) limits.cpus = String(opts.cpuLimit);
+  if (opts.memoryLimit) limits.memory = `${opts.memoryLimit}M`;
+  const updatedServices: Record<string, ComposeService> = {};
+  for (const [key, svc] of Object.entries(compose.services)) {
+    updatedServices[key] = { ...svc, deploy: { ...svc.deploy, resources: { ...svc.deploy?.resources, limits: { ...svc.deploy?.resources?.limits, ...limits } } } };
+  }
+  return { ...compose, services: updatedServices };
+}
+
+// ---------------------------------------------------------------------------
 // Port detection
 // ---------------------------------------------------------------------------
 
@@ -342,6 +371,17 @@ export function parseCompose(yamlString: string): ComposeFile {
       }
     }
     if (Array.isArray(raw.networks)) svc.networks = raw.networks.map(String);
+    if (
+      raw.deploy &&
+      typeof raw.deploy === "object" &&
+      !Array.isArray(raw.deploy) &&
+      (
+        !("resources" in raw.deploy) ||
+        (typeof raw.deploy.resources === "object" && raw.deploy.resources !== null)
+      )
+    ) {
+      svc.deploy = raw.deploy as ComposeService["deploy"];
+    }
 
     services[name] = svc;
   }

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -14,6 +14,7 @@ import {
   generateComposeForImage,
   injectTraefikLabels,
   injectNetwork,
+  injectResourceLimits,
   parseCompose,
   composeToYaml,
   type ComposeFile,
@@ -469,6 +470,10 @@ export async function runDeployment(
       }
     } else {
       throw new Error("No image, git repo, or compose content configured");
+    }
+
+    if (app.cpuLimit || app.memoryLimit) {
+      compose = injectResourceLimits(compose, { cpuLimit: app.cpuLimit, memoryLimit: app.memoryLimit });
     }
 
     // Step 2: Detect container port

--- a/lib/templates/load.ts
+++ b/lib/templates/load.ts
@@ -32,6 +32,8 @@ export type Template = {
   defaultCronJobs:
     | { name: string; schedule: string; command: string }[]
     | null;
+  defaultCpuLimit: number | null;
+  defaultMemoryLimit: number | null;
   isBuiltIn: boolean;
 };
 
@@ -74,6 +76,8 @@ export async function loadTemplates(): Promise<Template[]> {
         defaultVolumes: (raw.volumes as Template["defaultVolumes"]) ?? null,
         defaultConnectionInfo: (raw.connectionInfo as Template["defaultConnectionInfo"]) ?? null,
         defaultCronJobs: (raw.cronJobs as Template["defaultCronJobs"]) ?? null,
+        defaultCpuLimit: (raw.cpuLimit as number) ?? null,
+        defaultMemoryLimit: (raw.memoryLimit as number) ?? null,
         isBuiltIn: true,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Add `cpuLimit` (real, cores) and `memoryLimit` (integer, MB) columns to the apps table
- Compose generation includes `deploy.resources.limits` when limits are set
- `injectResourceLimits()` applies limits to all services in compose-sourced apps
- API PATCH and POST endpoints accept and validate `cpuLimit` (> 0) and `memoryLimit` (>= 64 MB)
- App settings UI includes CPU and memory limit number inputs with "No limit" placeholder
- New app creation form includes optional resource limit fields
- Template TOML format supports `cpuLimit` and `memoryLimit` default values
- `host.toml` config-as-code supports `[deploy]` section `cpuLimit` and `memoryLimit`

## Test plan
- [ ] Create an app with resource limits set (e.g., 0.5 CPU, 512 MB)
- [ ] Deploy and verify `docker-compose.yml` includes `deploy.resources.limits`
- [ ] Update limits via app settings, redeploy, confirm new limits apply
- [ ] Create an app without limits, confirm no `deploy` block in compose
- [ ] Verify API validation rejects cpuLimit <= 0 and memoryLimit < 64
- [ ] Test template with `cpuLimit`/`memoryLimit` defaults