### PR TITLE
feat(notifications): add webhook and email notification channels

### DIFF
--- a/app/(app)/settings/notification-channels.tsx
+++ b/app/(app)/settings/notification-channels.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+import { Loader2, Plus, Trash2, Bell } from "lucide-react";
+
+type ChannelType = "email" | "webhook" | "slack";
+type Channel = { id: string; name: string; type: ChannelType; config: Record<string, unknown>; enabled: boolean };
+
+export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [name, setName] = useState("");
+  const [type, setType] = useState<ChannelType>("email");
+  const [recipients, setRecipients] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
+  const [slackUrl, setSlackUrl] = useState("");
+
+  const load = useCallback(async () => {
+    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications`); if (res.ok) { const d = await res.json(); setChannels(d.channels || []); } } catch {}
+    setLoading(false);
+  }, [orgId]);
+  useEffect(() => { load(); }, [load]);
+
+  const reset = () => { setName(""); setType("email"); setRecipients(""); setWebhookUrl(""); setWebhookSecret(""); setSlackUrl(""); setShowForm(false); };
+
+  const handleCreate = async () => {
+    setSaving(true);
+    try {
+      let config: Record<string, unknown> = {};
+      if (type === "email") config = { recipients: recipients.split(",").map(e => e.trim()).filter(Boolean) };
+      else if (type === "webhook") { config = { url: webhookUrl }; if (webhookSecret) config.secret = webhookSecret; }
+      else if (type === "slack") config = { webhookUrl: slackUrl };
+      const res = await fetch(`/api/v1/organizations/${orgId}/notifications`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, type, config, enabled: true }) });
+      if (!res.ok) { const d = await res.json(); toast.error(d.error || "Failed"); return; }
+      toast.success("Channel created"); reset(); load();
+    } catch { toast.error("Failed"); } finally { setSaving(false); }
+  };
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }); if (res.ok) setChannels(prev => prev.map(c => c.id === id ? { ...c, enabled } : c)); } catch { toast.error("Failed"); }
+  };
+
+  const handleDelete = async (id: string) => {
+    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "DELETE" }); if (res.ok) { setChannels(prev => prev.filter(c => c.id !== id)); toast.success("Deleted"); } } catch { toast.error("Failed"); }
+  };
+
+  if (loading) return <div className="flex items-center gap-2 text-muted-foreground py-8"><Loader2 className="h-4 w-4 animate-spin" />Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">Configure where notifications are sent for deploy, backup, and cron failures.</p>
+        {!showForm && <Button size="sm" onClick={() => setShowForm(true)} className="squircle"><Plus className="h-4 w-4 mr-1" />Add channel</Button>}
+      </div>
+      {showForm && (
+        <div className="border border-border rounded-lg p-4 space-y-4 bg-card">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2"><Label>Name</Label><Input value={name} onChange={e => setName(e.target.value)} placeholder="e.g. Team alerts" className="squircle" /></div>
+            <div className="space-y-2"><Label>Type</Label><Select value={type} onValueChange={v => setType(v as ChannelType)}><SelectTrigger className="squircle"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="email">Email</SelectItem><SelectItem value="webhook">Webhook</SelectItem><SelectItem value="slack">Slack</SelectItem></SelectContent></Select></div>
+          </div>
+          {type === "email" && <div className="space-y-2"><Label>Recipients (comma-separated)</Label><Input value={recipients} onChange={e => setRecipients(e.target.value)} placeholder="alice@example.com, bob@example.com" className="squircle" /></div>}
+          {type === "webhook" && <div className="space-y-4"><div className="space-y-2"><Label>URL</Label><Input value={webhookUrl} onChange={e => setWebhookUrl(e.target.value)} placeholder="https://example.com/webhook" className="squircle" /></div><div className="space-y-2"><Label>Secret <span className="text-muted-foreground">(optional)</span></Label><Input value={webhookSecret} onChange={e => setWebhookSecret(e.target.value)} placeholder="HMAC signing secret" type="password" className="squircle" /></div></div>}
+          {type === "slack" && <div className="space-y-2"><Label>Slack Webhook URL</Label><Input value={slackUrl} onChange={e => setSlackUrl(e.target.value)} placeholder="https://hooks.slack.com/services/..." className="squircle" /></div>}
+          <div className="flex gap-2"><Button size="sm" onClick={handleCreate} disabled={saving || !name} className="squircle">{saving && <Loader2 className="h-4 w-4 animate-spin mr-1" />}Create</Button><Button size="sm" variant="ghost" onClick={reset} className="squircle">Cancel</Button></div>
+        </div>
+      )}
+      {channels.length === 0 && !showForm ? (
+        <div className="border border-dashed border-border rounded-lg p-8 text-center text-muted-foreground"><Bell className="h-8 w-8 mx-auto mb-2 opacity-50" /><p className="text-sm">No notification channels configured.</p><p className="text-xs mt-1">Add an email, webhook, or Slack channel to receive alerts.</p></div>
+      ) : (
+        <div className="space-y-2">{channels.map(ch => (
+          <div key={ch.id} className="flex items-center justify-between border border-border rounded-lg p-3 bg-card">
+            <div className="flex items-center gap-3 min-w-0"><Switch checked={ch.enabled} onCheckedChange={checked => handleToggle(ch.id, checked)} /><div className="min-w-0"><div className="flex items-center gap-2"><span className="text-sm font-medium truncate">{ch.name}</span><span className="text-xs bg-muted px-1.5 py-0.5 rounded">{ch.type}</span></div></div></div>
+            <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => handleDelete(ch.id)}><Trash2 className="h-4 w-4" /></Button>
+          </div>
+        ))}</div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -8,6 +8,7 @@ import { OrgEnvVarsEditor } from "./org-env-vars";
 import { OrgSwitcher } from "@/components/layout/org-switcher";
 import { TeamMembers } from "@/app/(app)/team/team-members";
 import { OrgDomainEditor } from "./org-domain-editor";
+import { NotificationChannelsEditor } from "./notification-channels";
 
 export default async function SettingsPage({
   searchParams,
@@ -58,6 +59,7 @@ export default async function SettingsPage({
         <TabsList variant="line">
           <TabsTrigger value="variables">Shared Variables</TabsTrigger>
           <TabsTrigger value="domains">Domains</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
           <TabsTrigger value="team">Team</TabsTrigger>
         </TabsList>
 
@@ -72,6 +74,10 @@ export default async function SettingsPage({
             sslEnabled={orgData.organization.sslEnabled ?? true}
             serverIP={process.env.HOST_SERVER_IP}
           />
+        </TabsContent>
+
+        <TabsContent value="notifications" className="pt-4">
+          <NotificationChannelsEditor orgId={orgId} />
         </TabsContent>
 
         <TabsContent value="team" className="pt-4">

--- a/app/api/v1/organizations/[orgId]/notifications/[channelId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/notifications/[channelId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { notificationChannels } from "@/lib/db/schema";
+import { requireOrg } from "@/lib/auth/session";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import { maskChannelConfig } from "@/lib/notifications/mask-config";
+
+type RouteParams = { params: Promise<{ orgId: string; channelId: string }> };
+const updateSchema = z.object({ name: z.string().min(1).max(100).optional(), config: z.union([z.object({ recipients: z.array(z.string().email()).min(1) }), z.object({ url: z.string().url(), secret: z.string().optional() }), z.object({ webhookUrl: z.string().url() })]).optional(), enabled: z.boolean().optional() });
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, channelId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const channel = await db.query.notificationChannels.findFirst({ where: and(eq(notificationChannels.id, channelId), eq(notificationChannels.organizationId, orgId)) });
+    if (!channel) return NextResponse.json({ error: "Channel not found" }, { status: 404 });
+    return NextResponse.json({ channel: maskChannelConfig(channel) });
+  } catch (error) { return handleRouteError(error, "Error fetching channel"); }
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, channelId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const parsed = updateSchema.safeParse(await req.json());
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (parsed.data.name !== undefined) updates.name = parsed.data.name;
+    if (parsed.data.config !== undefined) updates.config = parsed.data.config;
+    if (parsed.data.enabled !== undefined) updates.enabled = parsed.data.enabled;
+    const [channel] = await db.update(notificationChannels).set(updates).where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organizationId, orgId))).returning();
+    if (!channel) return NextResponse.json({ error: "Channel not found" }, { status: 404 });
+    return NextResponse.json({ channel: maskChannelConfig(channel) });
+  } catch (error) { return handleRouteError(error, "Error updating channel"); }
+}
+
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, channelId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const [deleted] = await db.delete(notificationChannels).where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organizationId, orgId))).returning({ id: notificationChannels.id });
+    if (!deleted) return NextResponse.json({ error: "Channel not found" }, { status: 404 });
+    return NextResponse.json({ success: true });
+  } catch (error) { return handleRouteError(error, "Error deleting channel"); }
+}

--- a/app/api/v1/organizations/[orgId]/notifications/route.ts
+++ b/app/api/v1/organizations/[orgId]/notifications/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { notificationChannels } from "@/lib/db/schema";
+import { requireOrg } from "@/lib/auth/session";
+import { eq, asc } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { maskChannelConfig } from "@/lib/notifications/mask-config";
+
+type RouteParams = { params: Promise<{ orgId: string }> };
+const createSchema = z.object({ name: z.string().min(1).max(100), type: z.enum(["email", "webhook", "slack"]), config: z.union([z.object({ recipients: z.array(z.string().email()).min(1) }), z.object({ url: z.string().url(), secret: z.string().optional() }), z.object({ webhookUrl: z.string().url() })]), enabled: z.boolean().optional().default(true) });
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const channels = await db.query.notificationChannels.findMany({ where: eq(notificationChannels.organizationId, orgId), orderBy: [asc(notificationChannels.createdAt)] });
+    const masked = channels.map(maskChannelConfig);
+    return NextResponse.json({ channels: masked });
+  } catch (error) { return handleRouteError(error, "Error fetching notification channels"); }
+}
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const parsed = createSchema.safeParse(await req.json());
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    const [channel] = await db.insert(notificationChannels).values({ id: nanoid(), organizationId: orgId, name: parsed.data.name, type: parsed.data.type, config: parsed.data.config, enabled: parsed.data.enabled }).returning();
+    return NextResponse.json({ channel: maskChannelConfig(channel) }, { status: 201 });
+  } catch (error) { return handleRouteError(error, "Error creating notification channel"); }
+}

--- a/lib/backup/engine.ts
+++ b/lib/backup/engine.ts
@@ -281,6 +281,13 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
     .set({ updatedAt: new Date() })
     .where(eq(backupJobs.id, jobId));
 
+  try { const hasFailures = results.some((r) => !r.success); const allSuccess = results.every((r) => r.success);
+    if ((hasFailures && job.notifyOnFailure) || (allSuccess && job.notifyOnSuccess)) {
+      const { notify } = await import("@/lib/notifications/dispatch"); const appNames = job.backupJobApps.map((bja) => bja.app.name).join(", ");
+      if (hasFailures) { const failed = results.filter((r) => !r.success); await notify(job.organizationId, { type: "backup-failed", title: `Backup failed: ${job.name}`, message: `${failed.length} of ${results.length} backup(s) failed for: ${appNames}`, metadata: { jobId: job.id, jobName: job.name, failedCount: String(failed.length), totalCount: String(results.length), errors: failed.map((r) => `${r.volumeName}: ${r.error}`).join("; ") } }); }
+      else { await notify(job.organizationId, { type: "backup-success", title: `Backup successful: ${job.name}`, message: `${results.length} backup(s) completed for: ${appNames}`, metadata: { jobId: job.id, jobName: job.name, totalCount: String(results.length), totalSize: String(results.reduce((sum, r) => sum + r.sizeBytes, 0)) } }); }
+    }
+  } catch (err) { console.error("[notifications] Backup notification error:", err); }
   return results;
 }
 

--- a/lib/cron/engine.ts
+++ b/lib/cron/engine.ts
@@ -95,7 +95,7 @@ export async function tickCronJobs(): Promise<void> {
     where: eq(cronJobs.enabled, true),
     with: {
       app: {
-        columns: { id: true, name: true, status: true },
+        columns: { id: true, name: true, status: true, organizationId: true, displayName: true },
       },
     },
   });
@@ -178,6 +178,26 @@ export async function tickCronJobs(): Promise<void> {
     console.log(
       `[cron] ${job.name} (${job.app.name}): ${result.success ? "OK" : "FAILED"} in ${result.durationMs}ms`
     );
+
+    if (!result.success) {
+      try {
+        const { notify } = await import("@/lib/notifications/dispatch");
+        await notify(job.app.organizationId, {
+          type: "cron-failed",
+          title: `Cron failed: ${job.name} (${job.app.displayName || job.app.name})`,
+          message: result.log.slice(0, 500),
+          metadata: {
+            cronJobId: job.id,
+            cronJobName: job.name,
+            appId: job.app.id,
+            projectName: job.app.displayName || job.app.name,
+            durationMs: String(result.durationMs),
+          },
+        });
+      } catch (err) {
+        console.error(`[cron] Failed to send notification for ${job.name}:`, err);
+      }
+    }
   }
 }
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -73,6 +73,12 @@ export const transferStatusEnum = pgEnum("transfer_status", [
   "cancelled",
 ]);
 
+export const notificationChannelTypeEnum = pgEnum("notification_channel_type", [
+  "email",
+  "webhook",
+  "slack",
+]);
+
 // ---------------------------------------------------------------------------
 // Better Auth tables (snake_case columns, matching Scope's working schema)
 // ---------------------------------------------------------------------------
@@ -804,6 +810,25 @@ export const appTransfers = pgTable("app_transfer", {
 });
 
 // ---------------------------------------------------------------------------
+// Host: Notification Channels
+// ---------------------------------------------------------------------------
+
+export const notificationChannels = pgTable(
+  "notification_channel",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id").notNull().references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    type: notificationChannelTypeEnum("type").notNull(),
+    config: jsonb("config").notNull().$type<{ recipients: string[] } | { url: string; secret?: string } | { webhookUrl: string }>(),
+    enabled: boolean("enabled").default(true).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (t) => [index("notification_channel_org_idx").on(t.organizationId)]
+);
+
+// ---------------------------------------------------------------------------
 // Relations
 // ---------------------------------------------------------------------------
 
@@ -833,6 +858,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   orgDomains: many(orgDomains),
   outgoingTransfers: many(appTransfers, { relationName: "sourceOrg" }),
   incomingTransfers: many(appTransfers, { relationName: "destinationOrg" }),
+  notificationChannels: many(notificationChannels),
 }));
 
 export const membershipsRelations = relations(memberships, ({ one }) => ({
@@ -1139,3 +1165,5 @@ export const appTransfersRelations = relations(
     }),
   })
 );
+
+export const notificationChannelsRelations = relations(notificationChannels, ({ one }) => ({ organization: one(organizations, { fields: [notificationChannels.organizationId], references: [organizations.id] }) }));

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -924,7 +924,7 @@ export async function runDeployment(
 
     // Send failure notification (non-blocking) — app may not be fetched yet
     sendDeployNotification(
-      { id: opts.appId, name: "", displayName: "", domains: [] },
+      { id: opts.appId, name: "", displayName: "", organizationId: opts.organizationId, domains: [] },
       deploymentId, false, durationMs, message
     ).catch(() => {});
 
@@ -933,50 +933,28 @@ export async function runDeployment(
 }
 
 async function sendDeployNotification(
-  app: { id: string; name: string; displayName: string; domains: { domain: string }[] },
+  app: { id: string; name: string; displayName: string; organizationId?: string; domains: { domain: string }[] },
   deploymentId: string,
   success: boolean,
   durationMs: number,
   errorMessage?: string,
 ) {
   try {
-    const { sendEmail } = await import("@/lib/email/send");
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    const dashboardUrl = `${appUrl}/projects/${app.id}`;
-    const domain = app.domains[0]?.domain;
-
-    // TODO: send to app notification recipients (for now, skip if no MAILPACE_API_TOKEN)
-    if (!process.env.MAILPACE_API_TOKEN) return;
-
-    // Fetch deployment for git info
-    const deployment = await db.query.deployments.findFirst({
-      where: eq(deployments.id, deploymentId),
-      columns: { gitSha: true, gitMessage: true, triggeredBy: true },
-    });
-
-    // Fetch triggered by user name
+    if (!app.organizationId) return;
+    const { notify } = await import("@/lib/notifications/dispatch");
+    const deployment = await db.query.deployments.findFirst({ where: eq(deployments.id, deploymentId), columns: { gitSha: true, gitMessage: true, triggeredBy: true } });
     let triggeredByName: string | undefined;
-    if (deployment?.triggeredBy) {
-      const { user: userTable } = await import("@/lib/db/schema");
-      const u = await db.query.user.findFirst({
-        where: eq(userTable.id, deployment.triggeredBy),
-        columns: { name: true, email: true },
-      });
-      triggeredByName = u?.name || u?.email || undefined;
-    }
-
-    if (success) {
-      const { DeploySuccessEmail } = await import("@/lib/email/templates/deploy-success");
-      const duration = durationMs < 1000 ? `${durationMs}ms` : `${Math.round(durationMs / 1000)}s`;
-      // TODO: send to configured recipients
-      console.log(`[email] Would send deploy success notification for ${app.displayName}`);
-    } else {
-      const { DeployFailedEmail } = await import("@/lib/email/templates/deploy-failed");
-      console.log(`[email] Would send deploy failure notification for ${app.displayName}`);
-    }
-  } catch (err) {
-    console.error("[email] Notification error:", err);
-  }
+    if (deployment?.triggeredBy) { const { user: userTable } = await import("@/lib/db/schema"); const u = await db.query.user.findFirst({ where: eq(userTable.id, deployment.triggeredBy), columns: { name: true, email: true } }); triggeredByName = u?.name || u?.email || undefined; }
+    const duration = durationMs < 1000 ? `${durationMs}ms` : `${Math.round(durationMs / 1000)}s`;
+    const domain = app.domains[0]?.domain;
+    const metadata: Record<string, string> = { projectName: app.displayName || app.name, appId: app.id, deploymentId };
+    if (domain) metadata.domain = domain;
+    if (deployment?.gitSha) metadata.gitSha = deployment.gitSha;
+    if (deployment?.gitMessage) metadata.gitMessage = deployment.gitMessage;
+    if (triggeredByName) metadata.triggeredBy = triggeredByName;
+    if (success) { metadata.duration = duration; await notify(app.organizationId, { type: "deploy-success", title: `Deploy successful: ${app.displayName || app.name}`, message: `${app.displayName || app.name} was deployed successfully in ${duration}.`, metadata }); }
+    else { if (errorMessage) metadata.errorMessage = errorMessage; await notify(app.organizationId, { type: "deploy-failed", title: `Deploy failed: ${app.displayName || app.name}`, message: errorMessage || "Deployment failed with an unknown error.", metadata }); }
+  } catch (err) { console.error("[notifications] Deploy notification error:", err); }
 }
 
 export async function deployProject(opts: DeployOpts): Promise<DeployResult> {

--- a/lib/notifications/dispatch.ts
+++ b/lib/notifications/dispatch.ts
@@ -1,0 +1,15 @@
+import { db } from "@/lib/db";
+import { notificationChannels } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import type { NotificationEvent } from "./port";
+import { createChannel } from "./factory";
+
+export function notify(orgId: string, event: NotificationEvent): void {
+  Promise.resolve().then(async () => {
+    try {
+      const channels = await db.query.notificationChannels.findMany({ where: and(eq(notificationChannels.organizationId, orgId), eq(notificationChannels.enabled, true)) });
+      if (channels.length === 0) return;
+      await Promise.allSettled(channels.map(async (row) => { try { await createChannel(row).send(event); } catch (err) { console.error(`[notifications] Channel "${row.name}" failed:`, err); } }));
+    } catch (err) { console.error("[notifications] Dispatch error:", err); }
+  });
+}

--- a/lib/notifications/email-channel.ts
+++ b/lib/notifications/email-channel.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import type { NotificationChannel, NotificationEvent } from "./port";
+import { sendEmail } from "@/lib/email/send";
+import { DeploySuccessEmail } from "@/lib/email/templates/deploy-success";
+import { DeployFailedEmail } from "@/lib/email/templates/deploy-failed";
+
+type EmailConfig = { recipients: string[] };
+
+export class EmailNotificationChannel implements NotificationChannel {
+  constructor(private config: EmailConfig) {}
+  async send(event: NotificationEvent): Promise<void> {
+    for (const recipient of this.config.recipients) {
+      try {
+        const template = this.buildTemplate(event);
+        if (template) await sendEmail({ to: recipient, subject: event.title, template });
+      } catch (err) { console.error(`[notifications] Failed to send email to ${recipient}:`, err); }
+    }
+  }
+  private buildTemplate(event: NotificationEvent) {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const dashboardUrl = event.metadata.appId ? `${appUrl}/projects/${event.metadata.appId}` : appUrl;
+    switch (event.type) {
+      case "deploy-success": return DeploySuccessEmail({ projectName: event.metadata.projectName || "Unknown", deploymentId: event.metadata.deploymentId || "", domain: event.metadata.domain, duration: event.metadata.duration || "unknown", gitSha: event.metadata.gitSha, gitMessage: event.metadata.gitMessage, triggeredBy: event.metadata.triggeredBy, dashboardUrl });
+      case "deploy-failed": return DeployFailedEmail({ projectName: event.metadata.projectName || "Unknown", deploymentId: event.metadata.deploymentId || "", errorMessage: event.metadata.errorMessage, gitSha: event.metadata.gitSha, gitMessage: event.metadata.gitMessage, triggeredBy: event.metadata.triggeredBy, dashboardUrl });
+      default: return createElement("div", { style: { fontFamily: "sans-serif", padding: "20px", maxWidth: "600px" } },
+        createElement("h2", { style: { margin: "0 0 12px" } }, event.title),
+        createElement("p", { style: { color: "#374151", whiteSpace: "pre-wrap" } }, event.message),
+        createElement("hr", { style: { border: "none", borderTop: "1px solid #e5e7eb", margin: "20px 0" } }),
+        createElement("a", { href: dashboardUrl, style: { color: "#6366f1" } }, "View Dashboard")
+      );
+    }
+  }
+}

--- a/lib/notifications/factory.ts
+++ b/lib/notifications/factory.ts
@@ -1,0 +1,12 @@
+import type { NotificationChannel } from "./port";
+import { EmailNotificationChannel } from "./email-channel";
+import { WebhookNotificationChannel, SlackNotificationChannel } from "./webhook-channel";
+
+export function createChannel(row: { type: "email" | "webhook" | "slack"; config: unknown }): NotificationChannel {
+  switch (row.type) {
+    case "email": return new EmailNotificationChannel(row.config as { recipients: string[] });
+    case "webhook": return new WebhookNotificationChannel(row.config as { url: string; secret?: string });
+    case "slack": return new SlackNotificationChannel(row.config as { webhookUrl: string });
+    default: throw new Error(`Unknown channel type: ${row.type}`);
+  }
+}

--- a/lib/notifications/mask-config.ts
+++ b/lib/notifications/mask-config.ts
@@ -1,0 +1,26 @@
+/**
+ * Mask sensitive fields in a notification channel's config before returning to clients.
+ */
+export function maskChannelConfig<T extends { type: string; config: unknown }>(
+  channel: T,
+): T {
+  const config = channel.config as Record<string, unknown> | null;
+  if (!config) return channel;
+
+  if (channel.type === "webhook" && typeof config.secret === "string") {
+    const s = config.secret;
+    return {
+      ...channel,
+      config: { ...config, secret: s.length > 4 ? `****${s.slice(-4)}` : "****" },
+    };
+  }
+
+  if (channel.type === "slack" && typeof config.webhookUrl === "string") {
+    return {
+      ...channel,
+      config: { ...config, webhookUrl: "****" },
+    };
+  }
+
+  return channel;
+}

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -1,0 +1,3 @@
+export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed";
+export type NotificationEvent = { type: NotificationEventType; title: string; message: string; metadata: Record<string, string> };
+export interface NotificationChannel { send(event: NotificationEvent): Promise<void>; }

--- a/lib/notifications/webhook-channel.ts
+++ b/lib/notifications/webhook-channel.ts
@@ -1,0 +1,22 @@
+import { createHmac } from "crypto";
+import type { NotificationChannel, NotificationEvent } from "./port";
+
+export class WebhookNotificationChannel implements NotificationChannel {
+  constructor(private config: { url: string; secret?: string }) {}
+  async send(event: NotificationEvent): Promise<void> {
+    const payload = JSON.stringify({ type: event.type, title: event.title, message: event.message, metadata: event.metadata, timestamp: new Date().toISOString() });
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.config.secret) headers["X-Signature-256"] = `sha256=${createHmac("sha256", this.config.secret).update(payload).digest("hex")}`;
+    const c = new AbortController(); const t = setTimeout(() => c.abort(), 10_000);
+    try { const r = await fetch(this.config.url, { method: "POST", headers, body: payload, signal: c.signal }); if (!r.ok) console.error(`[notifications] Webhook returned ${r.status}`); } finally { clearTimeout(t); }
+  }
+}
+
+export class SlackNotificationChannel implements NotificationChannel {
+  constructor(private config: { webhookUrl: string }) {}
+  async send(event: NotificationEvent): Promise<void> {
+    const emoji = event.type.includes("success") ? ":white_check_mark:" : ":x:";
+    const c = new AbortController(); const t = setTimeout(() => c.abort(), 10_000);
+    try { const r = await fetch(this.config.webhookUrl, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ text: `${emoji} *${event.title}*\n${event.message}` }), signal: c.signal }); if (!r.ok) console.error(`[notifications] Slack returned ${r.status}`); } finally { clearTimeout(t); }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `notification_channels` table supporting email, webhook, and Slack channel types with per-org scoping
- Implement port/adapter pattern: `NotificationChannel` interface with `EmailNotificationChannel`, `WebhookNotificationChannel`, and `SlackNotificationChannel` adapters
- Add fire-and-forget `notify()` dispatcher that queries enabled channels for the org and dispatches in parallel
- Wire notification dispatch into `sendDeployNotification` (deploy success/failure), `runBackup` (backup success/failure), and `tickCronJobs` (cron failure)
- Webhook adapter supports optional HMAC-SHA256 signing via `X-Signature-256` header
- Email adapter reuses existing `sendEmail` + deploy success/failed React Email templates
- Add CRUD API routes at `/api/v1/organizations/[orgId]/notifications/` with Zod validation
- Add Notifications tab in org settings with channel create/toggle/delete UI

## Test plan

- [ ] Create an email notification channel and verify deploy notifications are sent
- [ ] Create a webhook channel with HMAC secret and verify payload + signature
- [ ] Create a Slack channel and verify message format
- [ ] Toggle channel enabled/disabled and verify notifications respect the flag
- [ ] Delete a channel and verify it stops receiving notifications
- [ ] Trigger a backup failure and verify backup-failed notification fires
- [ ] Trigger a cron failure and verify cron-failed notification fires
- [ ] Verify notification failures never block the calling operation (fire-and-forget)
- [ ] Run `pnpm db:push` to apply the new notification_channels table