### PR TITLE
feat(apps): add dependency selector for project apps

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -175,7 +175,7 @@ type AppDetailProps = {
   allParentApps?: { id: string; name: string; color: string }[];
   allAppNames?: string[];
   orgVarKeys?: string[];
-  siblings?: { name: string; displayName: string; status: string }[];
+  siblings?: { id: string; name: string; displayName: string; status: string; dependsOn: string[] | null }[];
   initialTab?: string;
   initialEnv?: string;
   initialSubView?: string;
@@ -569,6 +569,154 @@ function formatDuration(ms: number) {
   const minutes = Math.floor(seconds / 60);
   const remaining = seconds % 60;
   return `${minutes}m ${remaining}s`;
+}
+
+
+function DependencySelector({
+  appId,
+  appName,
+  orgId,
+  currentDeps,
+  siblings,
+}: {
+  appId: string;
+  appName: string;
+  orgId: string;
+  currentDeps: string[];
+  siblings: { id: string; name: string; displayName: string; status: string; dependsOn: string[] | null }[];
+}) {
+  const router = useRouter();
+  const [deps, setDeps] = useState<string[]>(currentDeps);
+  const [saving, setSaving] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+
+  // Transitive circular dependency prevention — walk the full graph
+  function wouldCreateCycle(candidateDep: string): boolean {
+    const visited = new Set<string>();
+    const queue = [candidateDep];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (current === appName) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const app = siblings.find((a) => a.name === current);
+      if (app?.dependsOn) queue.push(...app.dependsOn);
+    }
+    return false;
+  }
+
+  const wouldCircular = new Set(
+    siblings
+      .filter((s) => wouldCreateCycle(s.name))
+      .map((s) => s.name)
+  );
+
+  // Available apps: siblings not already deps and not circular
+  const available = siblings.filter(
+    (s) => !deps.includes(s.name) && !wouldCircular.has(s.name)
+  );
+
+  async function saveDeps(updated: string[]) {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/organizations/${orgId}/apps/${appId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dependsOn: updated.length > 0 ? updated : null }),
+      });
+      if (!res.ok) {
+        toast.error("Failed to update dependencies");
+        return;
+      }
+      setDeps(updated);
+      toast.success("Dependencies updated");
+      router.refresh();
+    } catch {
+      toast.error("Failed to update dependencies");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleAdd(name: string) {
+    const updated = [...deps, name];
+    saveDeps(updated);
+    setAddOpen(false);
+  }
+
+  function handleRemove(name: string) {
+    saveDeps(deps.filter((d) => d !== name));
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <p className="text-xs font-medium text-muted-foreground">Deploy dependencies</p>
+        {saving && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+      </div>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {deps.map((depName) => {
+          const sibling = siblings.find((s) => s.name === depName);
+          return (
+            <span
+              key={depName}
+              className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs font-medium"
+            >
+              <span className={`size-1.5 rounded-full ${statusDotColor(sibling?.status ?? "stopped")}`} />
+              {sibling?.displayName ?? depName}
+              <button
+                type="button"
+                onClick={() => handleRemove(depName)}
+                disabled={saving}
+                className="ml-0.5 text-muted-foreground/60 hover:text-foreground transition-colors disabled:opacity-50"
+                aria-label={`Remove dependency on ${sibling?.displayName ?? depName}`}
+              >
+                <X className="size-3" />
+              </button>
+            </span>
+          );
+        })}
+        {available.length > 0 && (
+          <Popover open={addOpen} onOpenChange={setAddOpen}>
+            <PopoverTrigger asChild>
+              <button
+                className="inline-flex items-center justify-center size-5 rounded-full border border-dashed border-muted-foreground/20 text-muted-foreground/40 hover:text-muted-foreground hover:border-muted-foreground/40 transition-colors"
+                aria-label="Add dependency"
+              >
+                <Plus className="size-2.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-52 p-1.5">
+              {available.map((s) => (
+                <button
+                  key={s.name}
+                  onClick={() => handleAdd(s.name)}
+                  disabled={saving}
+                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent transition-colors disabled:opacity-50"
+                >
+                  <span className={`size-2 rounded-full shrink-0 ${statusDotColor(s.status)}`} />
+                  <span className="flex-1 text-left truncate">{s.displayName}</span>
+                </button>
+              ))}
+              {wouldCircular.size > 0 && (
+                <div className="border-t mt-1 pt-1 px-2 py-1">
+                  <p className="text-[10px] text-muted-foreground/60">
+                    {[...wouldCircular].length === 1 ? "1 app excluded" : `${[...wouldCircular].length} apps excluded`} (circular dependency)
+                  </p>
+                </div>
+              )}
+            </PopoverContent>
+          </Popover>
+        )}
+        {deps.length === 0 && available.length === 0 && siblings.length === 0 && (
+          <p className="text-xs text-muted-foreground/60">No sibling apps in this project</p>
+        )}
+        {deps.length === 0 && (available.length > 0 || siblings.length > 0) && (
+          <p className="text-xs text-muted-foreground/60">None</p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = [], allAppNames = [], orgVarKeys = [], siblings = [], initialTab = "deployments", initialEnv, initialSubView, featureFlags }: AppDetailProps) {
@@ -1662,6 +1810,18 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
           </div>
         </div>
       </div>
+
+      
+      {/* Deploy dependencies — only shown for apps in a project with siblings */}
+      {app.projectId && siblings.length > 0 && (
+        <DependencySelector
+          appId={app.id}
+          appName={app.name}
+          orgId={orgId}
+          currentDeps={app.dependsOn ?? []}
+          siblings={siblings}
+        />
+      )}
 
       {/* Tabbed sections */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>

--- a/app/(app)/apps/[...slug]/page.tsx
+++ b/app/(app)/apps/[...slug]/page.tsx
@@ -155,17 +155,34 @@ export default async function AppDetailPage({ params }: PageProps) {
     redirect(`/apps/${app.name}${envPath}${tabPath}`);
   }
 
-  // Load sibling apps if this app belongs to a project
-  let siblings: { name: string; displayName: string; status: string }[] = [];
+  // Load sibling apps if this app belongs to a project (includes dependsOn for circular dep detection)
+  let siblings: {
+    id: string;
+    name: string;
+    displayName: string;
+    status: string;
+    dependsOn: string[] | null;
+  }[] = [];
   if (app.projectId) {
     const siblingList = await db.query.apps.findMany({
       where: and(
         eq(apps.organizationId, orgId),
         eq(apps.projectId, app.projectId),
       ),
-      columns: { name: true, displayName: true, status: true },
+      columns: {
+        id: true,
+        name: true,
+        displayName: true,
+        status: true,
+        dependsOn: true,
+      },
     });
-    siblings = siblingList.filter((s) => s.name !== app.name);
+    siblings = siblingList
+      .filter((s) => s.name !== app.name)
+      .map((s) => ({
+        ...s,
+        dependsOn: s.dependsOn as string[] | null,
+      }));
   }
 
   // Build project options list from the projects table


### PR DESCRIPTION
## Summary

- Adds a **DependencySelector** component to the app detail page that lets users configure which sibling apps an app depends on for group deploy ordering
- Shows current dependencies as chips with remove buttons, with a popover dropdown to add new ones
- Prevents circular dependencies by excluding apps that already depend on the current app
- Only visible when the app belongs to a project with sibling apps
- Saves via PATCH to the existing `/api/v1/organizations/[orgId]/apps/[appId]` endpoint (which already accepts `dependsOn`)

## Details

The `dependsOn` field on the apps table drives the dependency-aware group deploy feature. Apps list which other apps they depend on, and the group deploy engine uses topological sorting to deploy in the right order (databases first, then services). This PR adds the missing UI for configuring these dependencies.

**Data flow**: The page server component now fetches `id`, `dependsOn`, and other fields for sibling apps in the same project. This data is passed to the client component which uses it to populate the selector and detect circular dependency candidates.

**Circular dependency prevention**: If app B already lists app A in its `dependsOn`, then app A's selector will exclude app B from the dropdown and show a note about excluded apps.

## Test plan

- [ ] Open an app that belongs to a project with multiple apps
- [ ] Verify the "Deploy dependencies" section appears between the overview and tabs
- [ ] Add a dependency via the + button popover
- [ ] Remove a dependency via the X button on a chip
- [ ] Verify circular dependencies are excluded from the dropdown
- [ ] Open an app that does NOT belong to a project -- verify no dependency section appears
- [ ] Open an app in a project with no siblings -- verify no dependency section appears