### PR TITLE
feat(infra): add Docker Compose profiles for optional services

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,10 @@ BETTER_AUTH_SECRET=host-dev-secret-change-in-production
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Docker Compose profiles — activate all optional services in dev.
+# In production, install.sh sets this in .env.prod based on user selection.
+COMPOSE_PROFILES=logs,metrics
+
 # Host PaaS
 HOST_BASE_DOMAIN=localhost
 HOST_EXPOSE_PORTS=true

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,24 @@ GITHUB_WEBHOOK_SECRET=
 GITHUB_PRIVATE_KEY=
 
 # ---------------------
+# Docker Compose Profiles
+# ---------------------
+# Controls which optional services start. Comma-separated list of profiles.
+# Available profiles:
+#   logs     — Loki + Promtail for persistent log collection
+#   metrics  — cAdvisor for container CPU/memory/network monitoring
+#
+# Examples:
+#   COMPOSE_PROFILES=logs,metrics   # All optional services (default in dev)
+#   COMPOSE_PROFILES=metrics        # Only container metrics
+#   COMPOSE_PROFILES=               # Core services only (host, postgres, redis, traefik)
+#
+# Set corresponding feature flags to "false" to hide disabled services from the UI.
+# COMPOSE_PROFILES=logs,metrics
+# FEATURE_METRICS=true
+# FEATURE_LOGS=true
+
+# ---------------------
 # Host PaaS (defaults in .env, override here if needed)
 # ---------------------
 # HOST_BASE_DOMAIN=localhost

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,9 @@
 # - Exposes service ports to localhost for direct access
 # - Disables TLS / ACME (uses insecure Traefik dashboard)
 # - Attaches all services to host-network so localhost can reach them
+#
+# All optional profiles (logs, metrics) are activated in .env via COMPOSE_PROFILES
+# so that `docker compose up` in dev starts everything by default.
 
 services:
   # Disable the host app in dev — use `pnpm dev` instead.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       - internal
 
   cadvisor:
+    profiles: [metrics]
     image: gcr.io/cadvisor/cadvisor:latest
     restart: unless-stopped
     privileged: true
@@ -96,6 +97,7 @@ services:
       - internal
 
   loki:
+    profiles: [logs]
     image: grafana/loki:3.4
     restart: unless-stopped
     command: -config.file=/etc/loki/loki.yml
@@ -107,6 +109,7 @@ services:
     mem_limit: 512m
 
   promtail:
+    profiles: [logs]
     image: grafana/promtail:3.4
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail.yml

--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,34 @@ if [ ! -f "$ENV_FILE" ]; then
     warn "Could not determine server IP — skipping DNS validation"
   fi
 
+  # ── Optional services ─────────────────────────────────────────────────────
+  echo ""
+  log "Optional services (can be changed later in .env.prod)"
+
+  COMPOSE_PROFILES=""
+  FEATURE_METRICS="true"
+  FEATURE_LOGS="true"
+
+  read -p "  Enable container metrics? (requires cAdvisor) [Y/n] " ENABLE_METRICS
+  if [ "$ENABLE_METRICS" = "n" ] || [ "$ENABLE_METRICS" = "N" ]; then
+    FEATURE_METRICS="false"
+  else
+    COMPOSE_PROFILES="metrics"
+  fi
+
+  read -p "  Enable persistent logs? (requires Loki + Promtail) [Y/n] " ENABLE_LOGS
+  if [ "$ENABLE_LOGS" = "n" ] || [ "$ENABLE_LOGS" = "N" ]; then
+    FEATURE_LOGS="false"
+  else
+    if [ -n "$COMPOSE_PROFILES" ]; then
+      COMPOSE_PROFILES="$COMPOSE_PROFILES,logs"
+    else
+      COMPOSE_PROFILES="logs"
+    fi
+  fi
+
+  echo ""
+
   # Generate secrets
   DB_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
   AUTH_SECRET=$(openssl rand -base64 32 | tr -d '/+=' | head -c 48)
@@ -317,6 +345,14 @@ ENCRYPTION_MASTER_KEY=$ENCRYPTION_MASTER_KEY
 GITHUB_WEBHOOK_SECRET=$GITHUB_WEBHOOK_SECRET
 ACME_EMAIL=$ACME_EMAIL
 TRAEFIK_DASHBOARD_AUTH=$TRAEFIK_DASHBOARD_AUTH
+
+# Optional services — controls which Docker Compose profiles are active.
+# Add/remove profiles to enable/disable: logs (Loki + Promtail), metrics (cAdvisor)
+COMPOSE_PROFILES=$COMPOSE_PROFILES
+
+# Feature flags — set to "false" to hide disabled services from the UI
+FEATURE_METRICS=$FEATURE_METRICS
+FEATURE_LOGS=$FEATURE_LOGS
 
 # GitHub App (optional — configure later in Settings)
 GITHUB_APP_ID=

--- a/update.sh
+++ b/update.sh
@@ -189,6 +189,8 @@ echo -e "${RESET}"
 
 step "Rebuilding containers"
 
+# COMPOSE_PROFILES from .env.prod controls which optional services start.
+# Docker Compose reads it automatically from the --env-file.
 log "Building images (this may take a few minutes)..."
 docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" build --quiet
 


### PR DESCRIPTION
## Summary

- Loki + Promtail gated behind `logs` profile, cAdvisor behind `metrics` profile
- Core services (host, postgres, redis, traefik) have no profile and always start
- `install.sh` interactively asks which optional services to enable, writes `COMPOSE_PROFILES` and `FEATURE_METRICS`/`FEATURE_LOGS` to `.env.prod`
- Dev environment activates all profiles by default via `.env`
- `update.sh` already respects `COMPOSE_PROFILES` from `.env.prod` via `--env-file` — added a clarifying comment
- `.env.example` documents available profiles with examples

## How it works

Docker Compose profiles let services stay defined in the compose file but only start when their profile is active. Setting `COMPOSE_PROFILES=logs,metrics` in the env file activates both. Omitting a profile means those containers won't start, and the corresponding feature flag hides the UI for that feature.

To re-enable a disabled service later, add the profile back to `COMPOSE_PROFILES` in `.env.prod`, set the feature flag to `true`, and run `docker compose up -d`.

## Test plan

- [ ] `bash -n install.sh` passes (verified)
- [ ] `docker compose config` with `COMPOSE_PROFILES=metrics` shows cadvisor but not loki/promtail
- [ ] `docker compose config` with `COMPOSE_PROFILES=logs,metrics` shows all services
- [ ] `docker compose config` with no profiles shows only core services
- [ ] Dev `docker compose up` starts everything (COMPOSE_PROFILES set in .env)
- [ ] Fresh install flow asks about metrics and logs, writes correct env vars