### PR TITLE
feat(workflow): add self-improving review skills

### DIFF
--- a/.claude/commands/review-architecture.md
+++ b/.claude/commands/review-architecture.md
@@ -1,0 +1,48 @@
+# review-architecture
+
+Architecture review for PR #$ARGUMENTS.
+
+## What this checks
+
+Gating review. Must pass before merge.
+
+- **Patterns** -- does the code follow established patterns in the codebase? Server actions, API routes, Drizzle queries, component structure -- are they consistent with what's already there?
+- **Duplication** -- is logic duplicated that should be extracted? Conversely, is something over-abstracted that should just be inlined?
+- **Ports and adapters** -- are infrastructure concerns (database, auth, external APIs) behind clean boundaries? Or is Drizzle leaking into components?
+- **Separation of concerns** -- are server and client responsibilities clear? Is business logic in the right layer?
+- **Type safety** -- are types flowing end-to-end? Any `any` types, type assertions, or missing return types on public functions?
+- **Dead code** -- unused imports, unreachable branches, commented-out blocks, orphaned files
+- **Dependency direction** -- do dependencies point inward (UI -> domain -> infra), or is there a cycle?
+- **Module boundaries** -- does this change respect bounded context boundaries, or does it reach across them?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+Use this structure for findings:
+- Lead with severity (critical / warning / note)
+- Name the file and line
+- Say what's wrong and why it matters
+- Suggest the fix in one sentence
+
+If nothing is found, say so in one line. Don't pad the review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/architecture` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Understand the codebase context.** For any files touched in the diff, read the surrounding directory to understand existing patterns. Don't review in isolation -- compare against how similar things are already done.
+
+4. **Review the diff.** Walk through every changed file. For each change, check every item in the checklist above. Pay special attention to:
+   - New files -- do they follow the established directory structure and naming conventions?
+   - New abstractions -- do they earn their complexity? Would a simpler approach work?
+   - Cross-cutting changes -- do they touch too many bounded contexts at once?
+   - Import paths -- are they reaching across module boundaries inappropriately?
+
+5. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your findings. Format as a markdown checklist grouped by severity. Prefix the comment with `## Architecture review`.
+
+6. **Log learnings.** Write a summary of what you found (or didn't find) to the knowledge server at `host/review-learnings/architecture` via `knowledge_write`. Include the PR number, date, and any new patterns worth watching for.
+
+7. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-database.md
+++ b/.claude/commands/review-database.md
@@ -1,0 +1,46 @@
+# review-database
+
+Database review for PR #$ARGUMENTS.
+
+## What this checks
+
+Gating review. Must pass before merge.
+
+- **Schema design** -- are tables normalized appropriately? Are column types correct? Are nullable columns intentional? Are foreign keys and cascades set up right?
+- **Indexes** -- are queries backed by indexes? Are there missing indexes on foreign keys, frequently filtered columns, or compound query patterns?
+- **Migration safety** -- can the migration run without downtime? Are there destructive operations (DROP COLUMN, DROP TABLE) that need a multi-step rollout? Are defaults set for new NOT NULL columns?
+- **Query patterns** -- are queries using Drizzle's query builder correctly? Any raw SQL that should be parameterized? Any overly complex joins that could be simplified?
+- **Data integrity** -- are constraints enforced at the database level, not just application level? Are there race conditions in read-then-write patterns?
+- **N+1 queries** -- are there loops that execute individual queries instead of batching? Are relations loaded eagerly when needed?
+- **Multi-tenancy** -- are all queries scoped by `organization_id`? Could a user access another org's data through this change?
+- **Drizzle conventions** -- are schema changes using the project's established Drizzle patterns? Are `relations` exports updated when schema changes?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+Use this structure for findings:
+- Lead with severity (critical / warning / note)
+- Name the file and line
+- Say what's wrong and why it matters
+- Suggest the fix in one sentence
+
+If nothing is found, say so in one line. Don't pad the review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/database` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Review the diff.** Walk through every changed file. For each change, check every item in the checklist above. Pay special attention to:
+   - Files in `lib/db/` -- schema changes, new queries, migration files
+   - Server actions and API routes -- how they query the database
+   - Any file that imports from `@/lib/db` -- check query patterns
+   - New tables or columns -- do they have appropriate constraints and indexes?
+
+4. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your findings. Format as a markdown checklist grouped by severity. Prefix the comment with `## Database review`.
+
+5. **Log learnings.** Write a summary of what you found (or didn't find) to the knowledge server at `host/review-learnings/database` via `knowledge_write`. Include the PR number, date, and any new patterns worth watching for.
+
+6. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-docs.md
+++ b/.claude/commands/review-docs.md
@@ -1,0 +1,45 @@
+# review-docs
+
+Documentation review for PR #$ARGUMENTS. This is a generative review -- it creates follow-up work, not blocking feedback.
+
+## What this checks
+
+Generative review. Evaluates whether the feature needs user-facing docs, and drafts them if so.
+
+- **New features** -- does this PR introduce something a user would need to know about? New UI, new API endpoints, new config options?
+- **Changed behavior** -- does this PR change how something works in a way that existing users would notice?
+- **New concepts** -- does this PR introduce terminology or mental models that need explaining?
+- **API surface** -- are there new or changed API endpoints that need documenting?
+- **Configuration** -- are there new environment variables, settings, or options?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs.
+
+For the review comment: state what docs are needed and why.
+
+For drafted docs: write them in the same voice -- brief, outcome-focused, scannable. Use headers, code blocks, and short paragraphs.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/docs` from the knowledge server via `knowledge_read`.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Evaluate docs need.** Read through the diff and determine:
+   - Does this feature need user-facing documentation?
+   - If yes, what kind? (guide, reference, changelog entry, API docs)
+   - If no, say so in the review comment and stop.
+
+4. **Draft the docs.** If docs are needed, draft them. Keep them concise and practical -- what does the user need to know to use this feature?
+
+5. **Create follow-up issues.** For each doc that's needed, run:
+   ```
+   gh issue create --title "docs: [description]" --body "[drafted content or outline]" --label "docs"
+   ```
+
+6. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your assessment and links to the created issues. Prefix the comment with `## Docs review`.
+
+7. **Log learnings.** Write a summary to the knowledge server at `host/review-learnings/docs` via `knowledge_write`. Include the PR number, date, and what you learned about the project's documentation needs.
+
+8. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-final.md
+++ b/.claude/commands/review-final.md
@@ -1,0 +1,48 @@
+# review-final
+
+Final gate review for PR #$ARGUMENTS. This is the last review before merge.
+
+## What this checks
+
+Gating review. The approval gate -- this review can approve or kick back the PR.
+
+- **Regression check** -- does this change break anything that was working? Are there side effects on existing features?
+- **Scope fit** -- does the PR do what it says it does, and nothing more? Are there unrelated changes mixed in?
+- **Schema bleed** -- are there database schema changes from other branches accidentally included? Check migration files and schema diffs carefully.
+- **Clean commit history** -- are commits logical units with conventional prefixes? Are there fixup commits that should be squashed?
+- **Conventional prefix** -- does every commit message use the right prefix (feat, fix, chore, docs)?
+- **PR hygiene** -- does the title match the change? Is the description accurate? Are review labels correct?
+- **Previous review findings** -- have all issues raised in other reviews been addressed?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+For approvals: keep it short. "Looks good -- clean diff, stays on scope." is enough.
+
+For kick-backs: be specific about what needs to change before re-review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/final` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the full picture.** Run these commands:
+   - `gh pr diff $ARGUMENTS` -- the full diff
+   - `gh pr view $ARGUMENTS --json title,body,labels,files,commits,reviews,comments` -- PR metadata and prior review comments
+   - `gh pr checks $ARGUMENTS` -- CI status
+
+3. **Check for schema bleed.** Look at any files in `lib/db/` -- are there schema changes that don't belong to this PR's feature? Compare against the PR description.
+
+4. **Check commit history.** Review each commit message for conventional prefix and logical grouping. Flag fixup commits or commits that should be squashed.
+
+5. **Check prior reviews.** Read through all review comments on the PR. Verify that flagged issues have been addressed in subsequent commits.
+
+6. **Make the call.** Either:
+   - **Approve**: `gh pr review $ARGUMENTS --approve --body "..."` -- brief summary of why it's good to go
+   - **Request changes**: `gh pr review $ARGUMENTS --request-changes --body "..."` -- specific list of what needs fixing
+
+   Prefix the comment with `## Final review`.
+
+7. **Log learnings.** Write a summary to the knowledge server at `host/review-learnings/final` via `knowledge_write`. Include the PR number, date, and any patterns worth watching for.
+
+8. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-frontend.md
+++ b/.claude/commands/review-frontend.md
@@ -1,0 +1,46 @@
+# review-frontend
+
+Frontend review for PR #$ARGUMENTS.
+
+## What this checks
+
+Gating review. Must pass before merge.
+
+- **Component patterns** -- are components following shadcn/ui conventions? Are they using the `squircle` class where appropriate? Are client/server component boundaries correct?
+- **Performance** -- unnecessary re-renders from unstable references, missing `useMemo`/`useCallback` where it matters, large components that should be split, unoptimized images
+- **Accessibility** -- missing labels, roles, aria attributes. Interactive elements without keyboard support. Color contrast issues. Missing focus management.
+- **Responsive design** -- does the layout work across breakpoints? Are there hardcoded widths or heights that break on mobile?
+- **Design system compliance** -- are colors, spacing, typography using design tokens? Any magic numbers or one-off styles?
+- **Loading and error states** -- are async operations showing loading indicators? Are errors caught and displayed? Are empty states handled?
+- **Client bundle** -- are server-only imports accidentally pulled into client components? Are large libraries imported without tree-shaking?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+Use this structure for findings:
+- Lead with severity (critical / warning / note)
+- Name the file and line
+- Say what's wrong and why it matters
+- Suggest the fix in one sentence
+
+If nothing is found, say so in one line. Don't pad the review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/frontend` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Review the diff.** Walk through every changed file. For each change, check every item in the checklist above. Pay special attention to:
+   - New components -- do they follow the component patterns already in the codebase?
+   - `"use client"` directives -- are they at the right boundary, or too high up the tree?
+   - Event handlers -- are they stable references, or recreated every render?
+   - Imports from `@/components/ui` -- are they using shadcn primitives correctly?
+   - Sonner toast usage -- following the project's toast patterns?
+
+4. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your findings. Format as a markdown checklist grouped by severity. Prefix the comment with `## Frontend review`.
+
+5. **Log learnings.** Write a summary of what you found (or didn't find) to the knowledge server at `host/review-learnings/frontend` via `knowledge_write`. Include the PR number, date, and any new patterns worth watching for.
+
+6. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-performance.md
+++ b/.claude/commands/review-performance.md
@@ -1,0 +1,47 @@
+# review-performance
+
+Performance review for PR #$ARGUMENTS.
+
+## What this checks
+
+Gating review. Must pass before merge.
+
+- **Bundle size** -- are new dependencies justified? Are they tree-shakeable? Are large libraries imported where a lighter alternative exists? Are server-only deps leaking into client bundles?
+- **Query efficiency** -- are database queries fetching only what's needed? Are there SELECT * patterns? Are aggregations done in the database or in JS?
+- **Caching** -- are expensive operations cached? Are cache keys correct? Are there stale cache risks? Is `unstable_cache` or `revalidatePath` used appropriately?
+- **Hot paths** -- are frequently-called functions doing unnecessary work? Are there synchronous operations that should be async? Are there blocking calls in request handlers?
+- **Unnecessary work** -- redundant computations, duplicate API calls, fetching data that's already available, re-computing derived state
+- **N+1 patterns** -- loops with individual queries, waterfall requests, sequential awaits that could be parallel
+- **Image and asset optimization** -- are images using Next.js Image component? Are assets appropriately sized? Are fonts loaded efficiently?
+- **Server vs client** -- is work happening on the client that should happen on the server (or vice versa)?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+Use this structure for findings:
+- Lead with severity (critical / warning / note)
+- Name the file and line
+- Say what's wrong and why it matters
+- Suggest the fix in one sentence
+
+If nothing is found, say so in one line. Don't pad the review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/performance` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Review the diff.** Walk through every changed file. For each change, check every item in the checklist above. Pay special attention to:
+   - New `import` statements -- what's being pulled in, and how big is it?
+   - Database queries -- are they efficient? Could they be batched?
+   - `useEffect` and `useState` -- are they causing unnecessary work?
+   - API route handlers -- are they doing sequential work that could be parallel?
+   - `Promise.all` vs sequential `await` -- are independent operations parallelized?
+
+4. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your findings. Format as a markdown checklist grouped by severity. Prefix the comment with `## Performance review`.
+
+5. **Log learnings.** Write a summary of what you found (or didn't find) to the knowledge server at `host/review-learnings/performance` via `knowledge_write`. Include the PR number, date, and any new patterns worth watching for.
+
+6. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-security.md
+++ b/.claude/commands/review-security.md
@@ -1,0 +1,46 @@
+# review-security
+
+Security review for PR #$ARGUMENTS.
+
+## What this checks
+
+Gating review. Must pass before merge.
+
+- **Injection** -- SQL injection via raw queries or string interpolation, command injection via exec/spawn, XSS via dangerouslySetInnerHTML or unescaped output
+- **Auth gaps** -- missing auth checks on API routes, org-scoping bypasses, privilege escalation paths
+- **Secret exposure** -- hardcoded credentials, API keys, tokens in client bundles or logs
+- **Rate limiting** -- unprotected endpoints that accept unbounded input (login, signup, forgot-password, API routes)
+- **Input validation** -- missing or incomplete Zod schemas, unvalidated path params, unchecked file uploads
+- **Headers** -- missing CSRF protection, permissive CORS, absent security headers
+- **Dependencies** -- known CVEs in direct deps, unnecessary permissions
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs. State findings plainly -- if something's fine, don't mention it. Only flag what matters.
+
+Use this structure for findings:
+- Lead with severity (critical / warning / note)
+- Name the file and line
+- Say what's wrong and why it matters
+- Suggest the fix in one sentence
+
+If nothing is found, say so in one line. Don't pad the review.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/security` from the knowledge server via `knowledge_read`. Check what was missed in past reviews -- actively look for those patterns in this diff.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Review the diff.** Walk through every changed file. For each change, check every item in the checklist above. Pay special attention to:
+   - Server actions and API route handlers -- are they authed and org-scoped?
+   - Database queries -- are they parameterized via Drizzle, or raw?
+   - Client components -- do they render user input safely?
+   - Environment variable usage -- are secrets kept server-side?
+   - New dependencies -- do they have known vulnerabilities?
+
+4. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your findings. Format as a markdown checklist grouped by severity. Prefix the comment with `## Security review`.
+
+5. **Log learnings.** Write a summary of what you found (or didn't find) to the knowledge server at `host/review-learnings/security` via `knowledge_write`. Include the PR number, date, and any new patterns worth watching for.
+
+6. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review-testing.md
+++ b/.claude/commands/review-testing.md
@@ -1,0 +1,50 @@
+# review-testing
+
+Testing review for PR #$ARGUMENTS. This is a generative review -- it creates follow-up work, not blocking feedback.
+
+## What this checks
+
+Generative review. Evaluates what tests the feature needs and specs them out as issues.
+
+- **Unit tests** -- are there pure functions or utilities that should have unit tests? Business logic, validation, transformations?
+- **Integration tests** -- are there API routes, server actions, or database queries that should be tested end-to-end?
+- **E2E tests** -- are there user flows that should be tested in a browser? Critical paths, form submissions, auth flows?
+- **Edge cases** -- are there boundary conditions, error paths, or race conditions that need test coverage?
+- **Existing test gaps** -- does this PR touch code that already lacks tests? Is this a good time to add them?
+
+## Voice
+
+Write as Joey. Casual, direct, em dashes for asides. Contractions always. No filler, no hedging, no sign-offs.
+
+For the review comment: state what tests are needed and why. Prioritize -- not everything needs a test, but critical paths do.
+
+For test specs: write clear descriptions of what each test should verify. Include setup, action, and assertion. Don't write the full test code -- just enough that someone (or an agent) can implement it.
+
+## Steps
+
+1. **Load past learnings.** Read `host/review-learnings/testing` from the knowledge server via `knowledge_read`.
+
+2. **Get the diff.** Run `gh pr diff $ARGUMENTS` to get the full PR diff. Also run `gh pr view $ARGUMENTS --json title,body,labels,files` for context.
+
+3. **Evaluate test needs.** Read through the diff and determine:
+   - What's the critical path this feature introduces?
+   - What could break silently without tests?
+   - What edge cases exist?
+   - Are there existing tests that need updating?
+
+4. **Spec the tests.** For each needed test, write a brief spec:
+   - **Type**: unit / integration / e2e
+   - **What it tests**: one sentence
+   - **Setup**: what state or mocks are needed
+   - **Key assertions**: what should be true after the action
+
+5. **Create follow-up issues.** For each test (or group of related tests), run:
+   ```
+   gh issue create --title "test: [description]" --body "[test spec]" --label "testing"
+   ```
+
+6. **Post findings.** Run `gh pr review $ARGUMENTS --comment --body "..."` with your assessment and links to the created issues. Prefix the comment with `## Testing review`.
+
+7. **Log learnings.** Write a summary to the knowledge server at `host/review-learnings/testing` via `knowledge_write`. Include the PR number, date, and what you learned about the project's testing needs.
+
+8. **Self-evaluate.** Before posting, ask yourself: "What did I miss in past reviews that I should check for now?" Cross-reference the learnings from step 1.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,53 @@
+# review
+
+Dispatch review skills for PR #$ARGUMENTS.
+
+## What this does
+
+Reads the PR's labels and runs the matching review skills. Acts as the entry point for all PR reviews.
+
+## Steps
+
+1. **Get PR metadata.** Run `gh pr view $ARGUMENTS --json labels,files,title,body` to read the PR's labels and changed files.
+
+2. **Map labels to skills.** Match each `review:*` label to its skill:
+
+   | Label | Skill |
+   |-------|-------|
+   | `review:security` | `/review-security` |
+   | `review:architecture` | `/review-architecture` |
+   | `review:frontend` | `/review-frontend` |
+   | `review:database` | `/review-database` |
+   | `review:performance` | `/review-performance` |
+   | `review:final` | `/review-final` |
+   | `review:docs` | `/review-docs` |
+   | `review:testing` | `/review-testing` |
+   | `review:full` | All gating reviews (security, architecture, frontend, database, performance) |
+
+3. **Handle missing labels.** If the PR has no `review:*` labels, treat it as `review:full` -- run all gating reviews.
+
+4. **Suggest additional reviews.** After mapping labels, scan the changed files and suggest reviews that might be missing:
+   - Files in `lib/db/` or migration files --> suggest `review:database` if not already labeled
+   - Files in `components/` or `app/` with JSX --> suggest `review:frontend` if not already labeled
+   - Files in `app/api/` or server actions --> suggest `review:security` if not already labeled
+   - New dependencies in `package.json` --> suggest `review:performance` if not already labeled
+
+   Post suggestions as a comment: `gh pr comment $ARGUMENTS --body "..."`. Don't add labels automatically -- just suggest.
+
+5. **Run the reviews.** Execute each matched skill in sequence, passing the PR number. Run gating reviews first, then generative reviews.
+
+   The order for gating reviews:
+   1. `review-security`
+   2. `review-database`
+   3. `review-architecture`
+   4. `review-performance`
+   5. `review-frontend`
+
+   Then generative reviews:
+   6. `review-docs`
+   7. `review-testing`
+
+   Then the final gate (only if explicitly labeled):
+   8. `review-final`
+
+6. **Post summary.** After all reviews complete, post a summary comment listing which reviews ran and their outcomes.


### PR DESCRIPTION
## Summary

- 9 review skills as reusable `/review-*` slash commands in `.claude/commands/`
- Dispatcher (`/review`) reads PR labels and runs matching review skills
- Each skill has a defined checklist, posts findings via `gh pr review`, and logs learnings to the knowledge server
- Self-evaluation prompt on every review -- checks past learnings before posting
- Gating reviews (security, architecture, frontend, database, performance) must pass before merge
- Generative reviews (docs, testing) create follow-up issues
- Final gate (`/review-final`) can approve or kick back

## How it works

1. Add `review:*` labels to a PR (per CONTRIBUTING.md taxonomy)
2. Run `/review {pr-number}` -- dispatcher reads labels, runs matching skills in order
3. Each skill reads the diff, reviews against its checklist, posts findings, logs learnings
4. No labels? Defaults to `review:full` (all gating reviews)
5. Dispatcher suggests missing reviews based on changed files

## Test plan

- [ ] Run `/review-security` on a PR with auth changes -- verify it flags missing org-scoping
- [ ] Run `/review-architecture` on a PR with new abstractions -- verify pattern checks
- [ ] Run `/review` on a PR with no labels -- verify it defaults to full review
- [ ] Run `/review` on a PR with `review:frontend` label -- verify only frontend review runs
- [ ] Verify learnings are written to knowledge server after each review