### PR TITLE
feat(volumes): promote to first-class table with integrated limits

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/limits/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/limits/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { volumeLimits } from "@/lib/db/schema";
+import { volumes } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { nanoid } from "nanoid";
 import { z } from "zod";
 import { verifyAppAccess } from "@/lib/api/verify-access";
 
@@ -23,7 +22,8 @@ const volumeLimitSchema = z.object({
   warnAtPercent: z.number().int().min(1).max(100).default(80),
 });
 
-// GET — return the volume limit for an app (or null if not set)
+// GET — return the aggregate volume limit for an app
+// (reads maxSizeBytes/warnAtPercent from the first volume that has a limit set)
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId, appId } = await params;
@@ -33,17 +33,28 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    const limit = await db.query.volumeLimits.findFirst({
-      where: eq(volumeLimits.appId, appId),
+    // Find any volume with a limit set
+    const volWithLimit = await db.query.volumes.findFirst({
+      where: eq(volumes.appId, appId),
+      columns: { maxSizeBytes: true, warnAtPercent: true },
     });
 
-    return NextResponse.json({ limit: limit ?? null });
+    if (volWithLimit?.maxSizeBytes) {
+      return NextResponse.json({
+        limit: {
+          maxSizeBytes: volWithLimit.maxSizeBytes,
+          warnAtPercent: volWithLimit.warnAtPercent ?? 80,
+        },
+      });
+    }
+
+    return NextResponse.json({ limit: null });
   } catch (error) {
     return handleRouteError(error, "Error fetching volume limit");
   }
 }
 
-// PUT — set/update the volume limit
+// PUT — set/update the volume limit on all volumes for this app
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId, appId } = await params;
@@ -63,41 +74,28 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Upsert: try to update first, insert if not exists
-    const existing = await db.query.volumeLimits.findFirst({
-      where: eq(volumeLimits.appId, appId),
+    // Apply limit to all volumes for this app
+    await db
+      .update(volumes)
+      .set({
+        maxSizeBytes: parsed.data.maxSizeBytes,
+        warnAtPercent: parsed.data.warnAtPercent,
+        updatedAt: new Date(),
+      })
+      .where(eq(volumes.appId, appId));
+
+    return NextResponse.json({
+      limit: {
+        maxSizeBytes: parsed.data.maxSizeBytes,
+        warnAtPercent: parsed.data.warnAtPercent,
+      },
     });
-
-    let limit;
-    if (existing) {
-      [limit] = await db
-        .update(volumeLimits)
-        .set({
-          maxSizeBytes: parsed.data.maxSizeBytes,
-          warnAtPercent: parsed.data.warnAtPercent,
-          updatedAt: new Date(),
-        })
-        .where(eq(volumeLimits.id, existing.id))
-        .returning();
-    } else {
-      [limit] = await db
-        .insert(volumeLimits)
-        .values({
-          id: nanoid(),
-          appId,
-          maxSizeBytes: parsed.data.maxSizeBytes,
-          warnAtPercent: parsed.data.warnAtPercent,
-        })
-        .returning();
-    }
-
-    return NextResponse.json({ limit });
   } catch (error) {
     return handleRouteError(error, "Error setting volume limit");
   }
 }
 
-// DELETE — remove the volume limit
+// DELETE — remove the volume limit from all volumes for this app
 export async function DELETE(_request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId, appId } = await params;
@@ -107,14 +105,14 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    const [deleted] = await db
-      .delete(volumeLimits)
-      .where(eq(volumeLimits.appId, appId))
-      .returning({ id: volumeLimits.id });
-
-    if (!deleted) {
-      return NextResponse.json({ error: "No limit set" }, { status: 404 });
-    }
+    await db
+      .update(volumes)
+      .set({
+        maxSizeBytes: null,
+        warnAtPercent: 80,
+        updatedAt: new Date(),
+      })
+      .where(eq(volumes.appId, appId));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { apps } from "@/lib/db/schema";
+import { apps, volumes } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq, and } from "drizzle-orm";
 import { listContainers, inspectContainer } from "@/lib/docker/client";
 import { z } from "zod";
+import { nanoid } from "nanoid";
 import { exec } from "child_process";
 import { promisify } from "util";
 
@@ -16,6 +17,10 @@ const volumeSchema = z.object({
   mountPath: z.string().min(1)
     .refine((p) => p.startsWith("/"), "Mount path must be absolute")
     .refine((p) => !p.includes(".."), "Mount path must not contain '..'"),
+  persistent: z.boolean().default(true),
+  description: z.string().optional(),
+  maxSizeBytes: z.number().int().positive().nullable().optional(),
+  warnAtPercent: z.number().int().min(1).max(100).optional(),
 });
 
 type RouteParams = {
@@ -23,15 +28,20 @@ type RouteParams = {
 };
 
 type VolumeInfo = {
+  id: string | null;
   name: string;
   mountPath: string;
   type: "named" | "anonymous" | "bind";
   persistent: boolean;
+  shared: boolean;
+  description: string | null;
+  maxSizeBytes: number | null;
+  warnAtPercent: number | null;
   source: string;
   sizeBytes: number | null;
 };
 
-// GET — list all volumes for this app (from Docker + saved config)
+// GET — list all volumes for this app (from Docker + volumes table)
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId, appId } = await params;
@@ -42,12 +52,18 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 
     const app = await db.query.apps.findFirst({
       where: and(eq(apps.id, appId), eq(apps.organizationId, orgId)),
-      columns: { id: true, name: true, persistentVolumes: true },
+      columns: { id: true, name: true },
     });
 
     if (!app) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
+
+    // Load saved volumes from the volumes table
+    const savedVolumes = await db.query.volumes.findMany({
+      where: eq(volumes.appId, appId),
+    });
+    const savedByName = new Map(savedVolumes.map((v) => [v.name, v]));
 
     // Get volumes from running containers
     const dockerVolumes: VolumeInfo[] = [];
@@ -57,11 +73,18 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
         try {
           const info = await inspectContainer(container.id);
           for (const mount of info.mounts) {
+            const name = mount.type === "volume" ? mount.source.split("/").pop() || mount.source : mount.source;
+            const saved = savedByName.get(name);
             dockerVolumes.push({
-              name: mount.type === "volume" ? mount.source.split("/").pop() || mount.source : mount.source,
+              id: saved?.id ?? null,
+              name,
               mountPath: mount.destination,
               type: mount.type === "volume" ? "named" : "bind",
-              persistent: false,
+              persistent: saved?.persistent ?? false,
+              shared: saved?.shared ?? false,
+              description: saved?.description ?? null,
+              maxSizeBytes: saved?.maxSizeBytes ?? null,
+              warnAtPercent: saved?.warnAtPercent ?? null,
               source: mount.source,
               sizeBytes: null,
             });
@@ -97,30 +120,33 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
               dockerVolumes[measurable[i].idx].sizeBytes = bytes;
             }
           }
-          // If rejected (timeout or error), sizeBytes stays null
         }
       }
     } catch { /* Docker not available */ }
 
-    // Merge with saved persistent volume config
-    const savedVolumes = (app.persistentVolumes as { name: string; mountPath: string }[] | null) || [];
-    const persistentNames = new Set(savedVolumes.map((v) => v.name));
-
     // Mark Docker volumes as persistent if they match saved config
+    const dockerNames = new Set(dockerVolumes.map((v) => v.name));
     for (const vol of dockerVolumes) {
-      if (persistentNames.has(vol.name)) {
-        vol.persistent = true;
+      const saved = savedByName.get(vol.name);
+      if (saved) {
+        vol.persistent = saved.persistent;
+        vol.id = saved.id;
       }
     }
 
     // Add saved volumes that aren't running (may not be deployed yet)
     for (const saved of savedVolumes) {
-      if (!dockerVolumes.find((v) => v.name === saved.name)) {
+      if (!dockerNames.has(saved.name)) {
         dockerVolumes.push({
+          id: saved.id,
           name: saved.name,
           mountPath: saved.mountPath,
           type: "named",
-          persistent: true,
+          persistent: saved.persistent,
+          shared: saved.shared,
+          description: saved.description,
+          maxSizeBytes: saved.maxSizeBytes,
+          warnAtPercent: saved.warnAtPercent,
           source: saved.name,
           sizeBytes: null,
         });
@@ -133,7 +159,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   }
 }
 
-// PUT — update persistent volumes config
+// PUT — sync volumes config (replaces all volumes for this app)
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId, appId } = await params;
@@ -147,17 +173,67 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
     }
-    const volumes = parsed.data;
+    const incoming = parsed.data;
 
-    const [updated] = await db
-      .update(apps)
-      .set({ persistentVolumes: volumes, updatedAt: new Date() })
-      .where(and(eq(apps.id, appId), eq(apps.organizationId, orgId)))
-      .returning({ id: apps.id });
-
-    if (!updated) {
+    // Verify app exists
+    const app = await db.query.apps.findFirst({
+      where: and(eq(apps.id, appId), eq(apps.organizationId, orgId)),
+      columns: { id: true },
+    });
+    if (!app) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
+
+    // Load existing volumes
+    const existing = await db.query.volumes.findMany({
+      where: eq(volumes.appId, appId),
+    });
+    const existingByName = new Map(existing.map((v) => [v.name, v]));
+    const incomingNames = new Set(incoming.map((v) => v.name));
+
+    // Delete volumes not in the incoming list
+    for (const vol of existing) {
+      if (!incomingNames.has(vol.name)) {
+        await db.delete(volumes).where(eq(volumes.id, vol.id));
+      }
+    }
+
+    // Upsert incoming volumes
+    for (const vol of incoming) {
+      const prev = existingByName.get(vol.name);
+      if (prev) {
+        await db.update(volumes)
+          .set({
+            mountPath: vol.mountPath,
+            persistent: vol.persistent,
+            description: vol.description ?? prev.description,
+            maxSizeBytes: vol.maxSizeBytes !== undefined ? vol.maxSizeBytes : prev.maxSizeBytes,
+            warnAtPercent: vol.warnAtPercent ?? prev.warnAtPercent,
+            updatedAt: new Date(),
+          })
+          .where(eq(volumes.id, prev.id));
+      } else {
+        await db.insert(volumes).values({
+          id: nanoid(),
+          appId,
+          organizationId: orgId,
+          name: vol.name,
+          mountPath: vol.mountPath,
+          persistent: vol.persistent,
+          description: vol.description,
+          maxSizeBytes: vol.maxSizeBytes ?? null,
+          warnAtPercent: vol.warnAtPercent ?? 80,
+        });
+      }
+    }
+
+    // Keep legacy JSONB in sync during migration period
+    const persistentList = incoming
+      .filter((v) => v.persistent)
+      .map((v) => ({ name: v.name, mountPath: v.mountPath }));
+    await db.update(apps)
+      .set({ persistentVolumes: persistentList, updatedAt: new Date() })
+      .where(eq(apps.id, appId));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/v1/organizations/[orgId]/apps/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { apps, projects, domains, organizations, environments } from "@/lib/db/schema";
+import { apps, projects, domains, organizations, environments, volumes } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { and, desc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -204,6 +204,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       type: "production",
       isDefault: true,
     });
+
+    // Create volume records from persistentVolumes input
+    if (data.persistentVolumes?.length) {
+      for (const vol of data.persistentVolumes) {
+        await db.insert(volumes).values({
+          id: nanoid(),
+          appId,
+          organizationId: orgId,
+          name: vol.name,
+          mountPath: vol.mountPath,
+          persistent: true,
+        });
+      }
+    }
 
     // Auto-create domain if requested
     if (data.generateDomain) {

--- a/components/volumes-panel.tsx
+++ b/components/volumes-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import {
   Loader2,
   HardDrive,
@@ -39,10 +39,15 @@ import {
 import { volumeThreshold, type ThresholdLevel } from "@/lib/volumes/threshold";
 
 type Volume = {
+  id: string | null;
   name: string;
   mountPath: string;
   type: "named" | "anonymous" | "bind";
   persistent: boolean;
+  shared: boolean;
+  description: string | null;
+  maxSizeBytes: number | null;
+  warnAtPercent: number | null;
   source: string;
   sizeBytes: number | null;
 };
@@ -75,7 +80,6 @@ function toBytes(value: number, unit: "MB" | "GB"): number {
 function fromBytes(bytes: number): { value: number; unit: "MB" | "GB" } {
   if (bytes >= 1024 * 1024 * 1024) {
     const gb = bytes / (1024 * 1024 * 1024);
-    // Use GB if it's a clean number
     if (gb === Math.floor(gb) || gb >= 1) {
       return { value: parseFloat(gb.toFixed(1)), unit: "GB" };
     }
@@ -103,7 +107,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
   const [newName, setNewName] = useState("");
   const [newMountPath, setNewMountPath] = useState("");
 
-  // Volume limit state
+  // Volume limit state (applied to all volumes for this app)
   const [limit, setLimit] = useState<VolumeLimit>(null);
   const [limitLoading, setLimitLoading] = useState(true);
   const [limitEditing, setLimitEditing] = useState(false);
@@ -156,10 +160,11 @@ export function VolumesPanel({ appId, orgId }: Props) {
     );
     setVolumes(updated);
 
-    // Save persistent volumes config
-    const persistent = updated
-      .filter((v) => v.persistent)
-      .map((v) => ({ name: v.name, mountPath: v.mountPath }));
+    const volumePayload = updated.map((v) => ({
+      name: v.name,
+      mountPath: v.mountPath,
+      persistent: v.persistent,
+    }));
 
     setSaving(true);
     try {
@@ -168,7 +173,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ volumes: persistent }),
+          body: JSON.stringify({ volumes: volumePayload }),
         }
       );
       if (res.ok) {
@@ -188,21 +193,30 @@ export function VolumesPanel({ appId, orgId }: Props) {
   async function addVolume() {
     if (!newName.trim() || !newMountPath.trim()) return;
 
+    const sanitizedName = newName.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+
     const newVol: Volume = {
-      name: newName.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-"),
+      id: null,
+      name: sanitizedName,
       mountPath: newMountPath.trim(),
       type: "named",
       persistent: true,
-      source: newName.trim(),
+      shared: false,
+      description: null,
+      maxSizeBytes: null,
+      warnAtPercent: null,
+      source: sanitizedName,
       sizeBytes: null,
     };
 
     const updated = [...volumes, newVol];
     setVolumes(updated);
 
-    const persistent = updated
-      .filter((v) => v.persistent)
-      .map((v) => ({ name: v.name, mountPath: v.mountPath }));
+    const volumePayload = updated.map((v) => ({
+      name: v.name,
+      mountPath: v.mountPath,
+      persistent: v.persistent,
+    }));
 
     setSaving(true);
     try {
@@ -211,7 +225,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ volumes: persistent }),
+          body: JSON.stringify({ volumes: volumePayload }),
         }
       );
       if (res.ok) {
@@ -231,9 +245,11 @@ export function VolumesPanel({ appId, orgId }: Props) {
     const updated = volumes.filter((v) => v.name !== volumeName);
     setVolumes(updated);
 
-    const persistent = updated
-      .filter((v) => v.persistent)
-      .map((v) => ({ name: v.name, mountPath: v.mountPath }));
+    const volumePayload = updated.map((v) => ({
+      name: v.name,
+      mountPath: v.mountPath,
+      persistent: v.persistent,
+    }));
 
     try {
       await fetch(
@@ -241,7 +257,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ volumes: persistent }),
+          body: JSON.stringify({ volumes: volumePayload }),
         }
       );
       toast.success("Volume removed");
@@ -471,7 +487,6 @@ export function VolumesPanel({ appId, orgId }: Props) {
                     <Select
                       value={limitUnit}
                       onValueChange={(val: "MB" | "GB") => {
-                        // Convert the current value when switching units
                         const current = parseFloat(limitSize);
                         if (current && !isNaN(current)) {
                           if (val === "GB" && limitUnit === "MB") {

--- a/lib/backup/engine.ts
+++ b/lib/backup/engine.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import {
   backupJobs,
   backups,
+  volumes,
 } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -134,14 +135,19 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
   for (const bja of job.backupJobApps) {
     const app = bja.app;
     const orgSlug = app.organization.slug;
-    const volumes = app.persistentVolumes ?? [];
 
-    if (volumes.length === 0) {
+    // Query persistent volumes from the volumes table
+    const appVolumes = await db.query.volumes.findMany({
+      where: eq(volumes.appId, app.id),
+    });
+    const persistentVols = appVolumes.filter((v) => v.persistent);
+
+    if (persistentVols.length === 0) {
       // No persistent volumes declared, nothing to back up
       continue;
     }
 
-    for (const vol of volumes) {
+    for (const vol of persistentVols) {
       const backupId = nanoid();
       const startedAt = new Date();
       const logLines: string[] = [];

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -315,6 +315,9 @@ export const apps = pgTable(
     autoTraefikLabels: boolean("auto_traefik_labels").default(false),
     containerPort: integer("container_port"),
     autoDeploy: boolean("auto_deploy").default(false),
+    // DEPRECATED: persistentVolumes JSONB replaced by the `volumes` table.
+    // Column retained temporarily for migration; will be dropped once all data
+    // has been migrated via `scripts/migrate-volumes.ts`.
     persistentVolumes: jsonb("persistent_volumes").$type<
       { name: string; mountPath: string }[]
     >(),
@@ -654,9 +657,38 @@ export const backups = pgTable("backup", {
 });
 
 // ---------------------------------------------------------------------------
-// Host: Volume Limits (per-app storage constraints)
+// Host: Volumes (first-class volume records with integrated limits)
 // ---------------------------------------------------------------------------
 
+export const volumes = pgTable(
+  "volume",
+  {
+    id: text("id").primaryKey(),
+    appId: text("app_id")
+      .notNull()
+      .references(() => apps.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(), // e.g. "data", "uploads"
+    mountPath: text("mount_path").notNull(), // e.g. "/var/lib/postgresql/data"
+    persistent: boolean("persistent").default(true).notNull(), // survives deploys
+    shared: boolean("shared").default(false).notNull(), // can be mounted by other apps in project
+    description: text("description"),
+    maxSizeBytes: bigint("max_size_bytes", { mode: "number" }), // nullable = no limit
+    warnAtPercent: integer("warn_at_percent").default(80),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    unique("volume_app_name_uniq").on(t.appId, t.name),
+    unique("volume_app_mount_uniq").on(t.appId, t.mountPath),
+    index("volume_app_id_idx").on(t.appId),
+    index("volume_org_id_idx").on(t.organizationId),
+  ]
+);
+
+// DEPRECATED: kept for migration only — will be dropped after migrate-volumes.ts runs
 export const volumeLimits = pgTable("volume_limit", {
   id: text("id").primaryKey(),
   appId: text("app_id")
@@ -905,6 +937,7 @@ export const appsRelations = relations(apps, ({ one, many }) => ({
   appTags: many(appTags),
   backupJobApps: many(backupJobApps),
   backups: many(backups),
+  volumes: many(volumes),
   volumeLimit: many(volumeLimits),
   cronJobs: many(cronJobs),
   transfers: many(appTransfers),
@@ -1100,6 +1133,17 @@ export const backupsRelations = relations(backups, ({ one }) => ({
   target: one(backupTargets, {
     fields: [backups.targetId],
     references: [backupTargets.id],
+  }),
+}));
+
+export const volumesRelations = relations(volumes, ({ one }) => ({
+  app: one(apps, {
+    fields: [volumes.appId],
+    references: [apps.id],
+  }),
+  organization: one(organizations, {
+    fields: [volumes.organizationId],
+    references: [organizations.id],
   }),
 }));
 

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { deployments, apps, orgEnvVars, organizations, environments, volumeLimits } from "@/lib/db/schema";
+import { deployments, apps, orgEnvVars, organizations, environments, volumes } from "@/lib/db/schema";
 import { encrypt, decryptOrFallback } from "@/lib/crypto/encrypt";
 import { parseEnvToMap } from "@/lib/env/parse-env";
 import { eq, and, isNull } from "drizzle-orm";
@@ -221,21 +221,27 @@ export async function runDeployment(
     const appDir = join(appBaseDir, envName);
     await mkdir(appDir, { recursive: true });
 
+    // Load volumes from the volumes table
+    const appVolumes = await db.query.volumes.findMany({
+      where: eq(volumes.appId, opts.appId),
+    });
+    const volumesList = appVolumes.filter((v) => v.persistent).map((v) => ({ name: v.name, mountPath: v.mountPath }));
+
     if (app.deployType === "image" && app.imageName) {
       // Image deploy — no clone needed
       stage("clone", "skipped");
       stage("build", "running");
-      const volumes = (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? undefined;
+      const volsForCompose = volumesList.length > 0 ? volumesList : undefined;
       const exposedPorts = (app.exposedPorts as { internal: number; external?: number; protocol?: string }[] | null) ?? undefined;
       compose = generateComposeForImage({
         projectName: app.name,
         imageName: app.imageName,
         containerPort: app.containerPort ?? undefined,
         envVars: envMap,
-        volumes,
+        volumes: volsForCompose,
         exposedPorts,
       });
-      if (volumes?.length) log(`[deploy] ${volumes.length} persistent volume(s)`);
+      if (volsForCompose?.length) log(`[deploy] ${volsForCompose.length} persistent volume(s)`);
       if (exposedPorts?.length) log(`[deploy] ${exposedPorts.length} exposed port(s)`);
       log(`[deploy] Generated compose for image: ${app.imageName}`);
     } else if (app.source === "git" && app.gitUrl) {
@@ -364,6 +370,23 @@ export async function runDeployment(
           log(`[deploy] host.toml: ${applied.envVars.length} env var(s)`);
         }
         if (applied.persistentVolumes) {
+          // Insert host.toml volumes into the volumes table
+          for (const vol of applied.persistentVolumes) {
+            await db.insert(volumes).values({
+              id: nanoid(),
+              appId: opts.appId,
+              organizationId: opts.organizationId,
+              name: vol.name,
+              mountPath: vol.mountPath,
+              persistent: true,
+            }).onConflictDoNothing();
+          }
+          // Refresh the volumes list so compose generation picks them up
+          const refreshed = await db.query.volumes.findMany({
+            where: eq(volumes.appId, opts.appId),
+          });
+          volumesList.length = 0;
+          volumesList.push(...refreshed.filter((v) => v.persistent).map((v) => ({ name: v.name, mountPath: v.mountPath })));
           log(`[deploy] host.toml: ${applied.persistentVolumes.length} volume(s)`);
         }
       }
@@ -400,8 +423,7 @@ export async function runDeployment(
 
         // Detect declared volumes from compose YAML before deploy starts
         if (compose.volumes && Object.keys(compose.volumes).length > 0) {
-          const existing = (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? [];
-          const existingNames = new Set(existing.map(v => v.name));
+          const existingNames = new Set(appVolumes.map(v => v.name));
           const newVols: { name: string; mountPath: string }[] = [];
 
           for (const svc of Object.values(compose.services)) {
@@ -419,8 +441,16 @@ export async function runDeployment(
           }
 
           if (newVols.length > 0) {
-            const merged = [...existing, ...newVols];
-            await db.update(apps).set({ persistentVolumes: merged }).where(eq(apps.id, opts.appId));
+            for (const vol of newVols) {
+              await db.insert(volumes).values({
+                id: nanoid(),
+                appId: opts.appId,
+                organizationId: opts.organizationId,
+                name: vol.name,
+                mountPath: vol.mountPath,
+                persistent: true,
+              }).onConflictDoNothing();
+            }
             log(`[deploy] Detected ${newVols.length} compose volume(s): ${newVols.map(v => `${v.name}:${v.mountPath}`).join(", ")}`);
           }
         }
@@ -477,7 +507,7 @@ export async function runDeployment(
           imageName,
           containerPort: app.containerPort ?? undefined,
           envVars: envMap,
-          volumes: (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? undefined,
+          volumes: volumesList.length > 0 ? volumesList : undefined,
           exposedPorts: (app.exposedPorts as { internal: number; external?: number; protocol?: string }[] | null) ?? undefined,
         });
       }
@@ -488,8 +518,7 @@ export async function runDeployment(
 
       // Detect declared volumes from compose YAML before deploy starts
       if (compose.volumes && Object.keys(compose.volumes).length > 0) {
-        const existing = (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? [];
-        const existingNames = new Set(existing.map(v => v.name));
+        const existingNames = new Set(appVolumes.map(v => v.name));
         const newVols: { name: string; mountPath: string }[] = [];
 
         for (const svc of Object.values(compose.services)) {
@@ -507,8 +536,16 @@ export async function runDeployment(
         }
 
         if (newVols.length > 0) {
-          const merged = [...existing, ...newVols];
-          await db.update(apps).set({ persistentVolumes: merged }).where(eq(apps.id, opts.appId));
+          for (const vol of newVols) {
+            await db.insert(volumes).values({
+              id: nanoid(),
+              appId: opts.appId,
+              organizationId: opts.organizationId,
+              name: vol.name,
+              mountPath: vol.mountPath,
+              persistent: true,
+            }).onConflictDoNothing();
+          }
           log(`[deploy] Detected ${newVols.length} compose volume(s): ${newVols.map(v => `${v.name}:${v.mountPath}`).join(", ")}`);
         }
       }
@@ -819,10 +856,8 @@ export async function runDeployment(
         for (const mount of info.mounts) {
           if (mount.type === "volume" && !seen.has(mount.destination)) {
             seen.add(mount.destination);
-            // Extract volume name from source path (last segment)
             const parts = mount.source.split("/");
             const rawName = parts[parts.length - 1];
-            // Strip compose project prefix (e.g. "redis-green_data" → "data")
             const name = rawName.replace(/^[^_]*_/, "");
             detectedVolumes.push({ name, mountPath: mount.destination });
           }
@@ -830,31 +865,40 @@ export async function runDeployment(
       }
 
       if (detectedVolumes.length > 0) {
-        const existing = (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? [];
-        const existingPaths = new Set(existing.map((v) => v.mountPath));
-        const newVolumes = detectedVolumes.filter((v) => !existingPaths.has(v.mountPath));
+        // Re-fetch current volumes from the table (may have been updated during deploy)
+        const currentVolumes = await db.query.volumes.findMany({
+          where: eq(volumes.appId, opts.appId),
+        });
+        const existingPaths = new Set(currentVolumes.map((v) => v.mountPath));
+        const newDetected = detectedVolumes.filter((v) => !existingPaths.has(v.mountPath));
 
-        if (newVolumes.length > 0) {
-          const merged = [...existing, ...newVolumes];
-          await db
-            .update(apps)
-            .set({ persistentVolumes: merged })
-            .where(eq(apps.id, opts.appId));
-          log(`[deploy] Detected ${newVolumes.length} volume(s): ${newVolumes.map((v) => v.mountPath).join(", ")}`);
+        if (newDetected.length > 0) {
+          for (const vol of newDetected) {
+            await db.insert(volumes).values({
+              id: nanoid(),
+              appId: opts.appId,
+              organizationId: opts.organizationId,
+              name: vol.name,
+              mountPath: vol.mountPath,
+              persistent: true,
+            }).onConflictDoNothing();
+          }
+          log(`[deploy] Detected ${newDetected.length} volume(s): ${newDetected.map((v) => v.mountPath).join(", ")}`);
         }
       }
     } catch {
       // Volume detection is best-effort
     }
 
-    // Check volume size limits
+    // Check volume size limits (reads limits directly from volume records)
     try {
-      const limit = await db.query.volumeLimits.findFirst({
-        where: eq(volumeLimits.appId, opts.appId),
+      const limitedVolumes = await db.query.volumes.findMany({
+        where: eq(volumes.appId, opts.appId),
       });
-      if (limit) {
+      const anyLimited = limitedVolumes.some((v) => v.maxSizeBytes != null);
+
+      if (anyLimited) {
         const { formatBytes } = await import("@/lib/metrics/format");
-        const warnThreshold = limit.warnAtPercent ?? 80;
         const runningContainers = await listContainers(app.name);
 
         // Collect all named volumes across containers
@@ -871,6 +915,13 @@ export async function runDeployment(
             }
           }
         }
+
+        // Build a lookup of limit config by volume name
+        const limitByName = new Map(
+          limitedVolumes
+            .filter((v) => v.maxSizeBytes != null)
+            .map((v) => [v.name, { maxSizeBytes: v.maxSizeBytes!, warnAtPercent: v.warnAtPercent ?? 80 }])
+        );
 
         // Measure all volumes in parallel
         if (volEntries.length > 0) {
@@ -890,8 +941,11 @@ export async function runDeployment(
             const sizeBytes = parseInt(result.value.stdout.split("\t")[0]);
             if (isNaN(sizeBytes)) continue;
             const { displayName } = volEntries[i];
+            const limit = limitByName.get(displayName);
+            if (!limit) continue;
+
             const percent = Math.round((sizeBytes / limit.maxSizeBytes) * 100);
-            const level = volumeThreshold(sizeBytes, limit.maxSizeBytes, warnThreshold);
+            const level = volumeThreshold(sizeBytes, limit.maxSizeBytes, limit.warnAtPercent);
 
             if (level === "critical") {
               log(`[deploy] Volume '${displayName}': ${formatBytes(sizeBytes)} / ${formatBytes(limit.maxSizeBytes)} (${percent}%) -- OVER LIMIT, deploy blocked`);

--- a/scripts/migrate-volumes.ts
+++ b/scripts/migrate-volumes.ts
@@ -1,0 +1,82 @@
+/**
+ * Migration script: promote persistentVolumes JSONB and volume_limits rows
+ * into the new first-class `volumes` table.
+ *
+ * Run with: npx tsx scripts/migrate-volumes.ts
+ *
+ * Safe to run multiple times (idempotent via onConflictDoNothing).
+ */
+
+import { db } from "@/lib/db";
+import { volumes, volumeLimits } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+async function migrate() {
+  const allApps = await db.query.apps.findMany({
+    columns: {
+      id: true,
+      name: true,
+      organizationId: true,
+      persistentVolumes: true,
+    },
+  });
+
+  console.log(`Found ${allApps.length} apps`);
+
+  let volumesMigrated = 0;
+  let limitsMerged = 0;
+  let skipped = 0;
+
+  for (const app of allApps) {
+    const jsonbVolumes = (app.persistentVolumes as { name: string; mountPath: string }[] | null) ?? [];
+
+    if (jsonbVolumes.length === 0) {
+      console.log(`  [skip] ${app.name} -- no persistentVolumes JSONB`);
+      skipped++;
+      continue;
+    }
+
+    // Load any existing volume_limits for this app
+    const limit = await db.query.volumeLimits.findFirst({
+      where: eq(volumeLimits.appId, app.id),
+    });
+
+    for (const vol of jsonbVolumes) {
+      try {
+        await db.insert(volumes).values({
+          id: nanoid(),
+          appId: app.id,
+          organizationId: app.organizationId,
+          name: vol.name,
+          mountPath: vol.mountPath,
+          persistent: true,
+          shared: false,
+          maxSizeBytes: limit?.maxSizeBytes ?? null,
+          warnAtPercent: limit?.warnAtPercent ?? 80,
+        }).onConflictDoNothing();
+
+        volumesMigrated++;
+      } catch (err) {
+        console.error(`  [error] ${app.name}/${vol.name}: ${err}`);
+      }
+    }
+
+    if (limit) {
+      limitsMerged++;
+      console.log(`  [migrated] ${app.name} -- ${jsonbVolumes.length} volume(s), limit merged (${limit.maxSizeBytes} bytes, ${limit.warnAtPercent}%)`);
+    } else {
+      console.log(`  [migrated] ${app.name} -- ${jsonbVolumes.length} volume(s)`);
+    }
+  }
+
+  console.log(`\nDone:`);
+  console.log(`  ${volumesMigrated} volume records created`);
+  console.log(`  ${limitsMerged} volume_limits merged into volume records`);
+  console.log(`  ${skipped} apps skipped (no JSONB data)`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. Verify data: SELECT * FROM volume;`);
+  console.log(`  2. Once confirmed, the persistentVolumes JSONB column and volume_limit table can be dropped.`);
+}
+
+migrate().catch(console.error);


### PR DESCRIPTION
## Summary
- New `volumes` table replaces `persistentVolumes` JSONB column and `volume_limits` table
- Each volume record carries name, mountPath, persistent/shared flags, and optional limits (maxSizeBytes, warnAtPercent)
- Deploy, backup, and compose engines updated to read/write the volumes table
- API routes updated: GET returns enriched volume data, PUT upserts records, limits endpoints operate on volume records directly
- Migration script (`scripts/migrate-volumes.ts`) converts existing JSONB + volume_limits data into volume records
- Legacy JSONB column and volume_limits table retained during migration period, synced on writes
- Shared volume column (`shared` boolean) is schema-ready; mounting logic is a follow-up

## Migration path
1. `pnpm db:push` to create the new `volume` table
2. `npx tsx scripts/migrate-volumes.ts` to populate from existing data
3. Verify with `SELECT * FROM volume`
4. In a future PR, drop the `persistent_volumes` JSONB column and `volume_limit` table

## Test plan
- [ ] Run `pnpm typecheck` -- passes clean
- [ ] Run migration script against a database with existing apps/volumes
- [ ] Create a new app with volumes via template -- verify volume records created
- [ ] Deploy an image-based app -- verify volumes detected and inserted into table
- [ ] Deploy a compose-based app -- verify compose volumes detected
- [ ] Toggle persistent flag in UI -- verify volume record updated
- [ ] Set/update/remove storage limits -- verify limits stored on volume records
- [ ] Run a backup job -- verify it reads persistent volumes from the table
- [ ] Verify host.toml volumes are inserted during deploy

Closes #19