### PR TITLE
feat(compose): decompose docker-compose services into individual app cards

### DIFF
--- a/app/(app)/projects/[...slug]/page.tsx
+++ b/app/(app)/projects/[...slug]/page.tsx
@@ -58,6 +58,9 @@ export default async function ProjectDetailPage({
           deployType: true,
           source: true,
           dependsOn: true,
+          parentAppId: true,
+          composeService: true,
+          containerName: true,
         },
         with: {
           domains: { columns: { domain: true, isPrimary: true } },
@@ -83,6 +86,21 @@ export default async function ProjectDetailPage({
           },
           envVars: {
             columns: { id: true, key: true, value: true, isSecret: true, createdAt: true, updatedAt: true },
+          },
+          childApps: {
+            columns: {
+              id: true,
+              name: true,
+              displayName: true,
+              composeService: true,
+              status: true,
+              containerName: true,
+              imageName: true,
+              dependsOn: true,
+              cpuLimit: true,
+              memoryLimit: true,
+              persistentVolumes: true,
+            },
           },
         },
       },

--- a/app/(app)/projects/[...slug]/project-detail.tsx
+++ b/app/(app)/projects/[...slug]/project-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -14,6 +14,7 @@ import {
   Loader2,
   RotateCcw,
   Square,
+  Layers,
 } from "lucide-react";
 import {
   type AppMetrics as AppMetricsType,
@@ -92,6 +93,20 @@ type EnvVar = {
   updatedAt: Date;
 };
 
+type ComposeChildApp = {
+  id: string;
+  name: string;
+  displayName: string;
+  composeService: string | null;
+  status: string;
+  containerName: string | null;
+  imageName: string | null;
+  dependsOn: string[] | null;
+  cpuLimit: number | null;
+  memoryLimit: number | null;
+  persistentVolumes: { name: string; mountPath: string }[] | null;
+};
+
 type ProjectApp = {
   id: string;
   name: string;
@@ -105,9 +120,13 @@ type ProjectApp = {
   deployType: string;
   source: string;
   dependsOn: string[] | null;
+  parentAppId: string | null;
+  composeService: string | null;
+  containerName: string | null;
   domains: { domain: string; isPrimary: boolean | null }[];
   deployments: Deployment[];
   envVars: EnvVar[];
+  childApps?: ComposeChildApp[];
 };
 
 type Project = {
@@ -145,6 +164,7 @@ function AppCard({
   highlight,
   onHoverStart,
   onHoverEnd,
+  childCount = 0,
 }: {
   app: ProjectApp;
   color: string;
@@ -153,6 +173,7 @@ function AppCard({
   highlight: DepHighlight;
   onHoverStart: () => void;
   onHoverEnd: () => void;
+  childCount?: number;
 }) {
   const router = useRouter();
   const lastDeploy = app.deployments[0];
@@ -227,6 +248,14 @@ function AppCard({
             )}
           </div>
           {metrics && <MetricsLine metrics={metrics} onHover={() => {}} />}
+          {childCount > 0 && (
+            <div className="flex items-center gap-1.5 mt-1">
+              <Layers className="size-3 text-muted-foreground/50" />
+              <span className="text-[10px] text-muted-foreground/50">
+                {childCount} service{childCount > 1 ? "s" : ""}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 
@@ -258,6 +287,124 @@ function AppCard({
           <span>depends on this</span>
         </div>
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compose Service Card (child service of a compose app)
+// ---------------------------------------------------------------------------
+
+function ComposeServiceCard({
+  service,
+  parentName,
+}: {
+  service: ComposeChildApp;
+  parentName: string;
+}) {
+  const statusColor =
+    service.status === "active"
+      ? "bg-status-success"
+      : service.status === "error"
+        ? "bg-status-error"
+        : "bg-status-neutral";
+
+  const deps = service.dependsOn ?? [];
+
+  return (
+    <div className="squircle relative flex flex-col rounded-lg border bg-card/60 p-3 transition-all duration-200 hover:bg-accent/50 overflow-hidden">
+      <div className="flex gap-3 w-full">
+        <div className="flex size-8 items-center justify-center rounded-md bg-muted">
+          <Layers className="size-4 text-muted-foreground" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <h3 className="text-sm font-semibold truncate">
+                {service.displayName}
+              </h3>
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-muted-foreground/20">
+                compose
+              </Badge>
+            </div>
+            <span className={`size-2 rounded-full shrink-0 ${statusColor}`} />
+          </div>
+          {service.imageName && (
+            <p className="text-xs text-muted-foreground/60 font-mono truncate mt-0.5">
+              {service.imageName}
+            </p>
+          )}
+          <div className="flex items-center gap-2 mt-1">
+            {service.cpuLimit && (
+              <span className="text-[10px] text-muted-foreground/50">
+                {service.cpuLimit} CPU
+              </span>
+            )}
+            {service.memoryLimit && (
+              <span className="text-[10px] text-muted-foreground/50">
+                {service.memoryLimit}MB
+              </span>
+            )}
+            {service.persistentVolumes && service.persistentVolumes.length > 0 && (
+              <span className="text-[10px] text-muted-foreground/50">
+                {service.persistentVolumes.length} vol{service.persistentVolumes.length > 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {deps.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1 mt-2 pt-2 border-t border-border/50">
+          <span className="text-[10px] text-muted-foreground/60 mr-0.5">depends on</span>
+          {deps.map((dep) => (
+            <span
+              key={dep}
+              className="inline-flex items-center rounded-full bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400"
+            >
+              {dep.replace(`${parentName}-`, "")}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compose Services Section (expandable, nested under parent app card)
+// ---------------------------------------------------------------------------
+
+function ComposeServicesGrid({
+  parentApp,
+}: {
+  parentApp: ProjectApp;
+}) {
+  const children = parentApp.childApps ?? [];
+  if (children.length === 0) return null;
+
+  return (
+    <div className="col-span-full">
+      <div className="squircle rounded-lg border border-dashed border-muted-foreground/20 p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Layers className="size-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">
+            {parentApp.displayName} Services
+          </span>
+          <Badge variant="secondary" className="text-[10px]">
+            {children.length}
+          </Badge>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {children.map((child) => (
+            <ComposeServiceCard
+              key={child.id}
+              service={child}
+              parentName={parentApp.name}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -605,6 +752,12 @@ export function ProjectDetail({
   const [editDescription, setEditDescription] = useState(project.description || "");
   const [editSaving, setEditSaving] = useState(false);
 
+  // Filter out compose child apps — they render nested under their parent
+  const topLevelApps = useMemo(
+    () => project.apps.filter((a) => !a.parentAppId),
+    [project.apps]
+  );
+
   const environments = [
     { name: "production", type: "production" },
     ...project.groupEnvironments.map((e) => ({ name: e.name, type: e.type })),
@@ -613,7 +766,7 @@ export function ProjectDetail({
   // Build reverse dependency map: for each app name, which app names depend on it
   const dependentsMap = useMemo(() => {
     const map = new Map<string, Set<string>>();
-    for (const app of project.apps) {
+    for (const app of topLevelApps) {
       for (const dep of app.dependsOn ?? []) {
         const set = map.get(dep) || new Set();
         set.add(app.name);
@@ -621,14 +774,14 @@ export function ProjectDetail({
       }
     }
     return map;
-  }, [project.apps]);
+  }, [topLevelApps]);
 
   // Compute highlight state for each app based on what's hovered
   const getHighlight = useCallback(
     (appName: string): DepHighlight => {
       if (!hoveredAppName) return "none";
       if (appName === hoveredAppName) return "hovered";
-      const hoveredApp = project.apps.find((a) => a.name === hoveredAppName);
+      const hoveredApp = topLevelApps.find((a) => a.name === hoveredAppName);
       if (!hoveredApp) return "none";
       // Is this app a dependency of the hovered app?
       if ((hoveredApp.dependsOn ?? []).includes(appName)) return "dependency";
@@ -637,7 +790,7 @@ export function ProjectDetail({
       if (hoveredDependents?.has(appName)) return "dependent";
       return "none";
     },
-    [hoveredAppName, project.apps, dependentsMap]
+    [hoveredAppName, topLevelApps, dependentsMap]
   );
 
   const handleTabChange = useCallback((tab: string) => {
@@ -649,8 +802,8 @@ export function ProjectDetail({
   }, [project.name]);
 
   // Count total deployments and env vars for badges
-  const totalDeployments = project.apps.reduce((sum, app) => sum + app.deployments.length, 0);
-  const totalVars = project.apps.reduce((sum, app) => sum + app.envVars.length, 0);
+  const totalDeployments = topLevelApps.reduce((sum, app) => sum + app.deployments.length, 0);
+  const totalVars = topLevelApps.reduce((sum, app) => sum + app.envVars.length, 0);
 
   async function handleDelete() {
     setDeleting(true);
@@ -674,9 +827,9 @@ export function ProjectDetail({
   }
 
   async function handleDeployAll() {
-    if (project.apps.length === 0) return;
+    if (topLevelApps.length === 0) return;
     setDeploying(true);
-    const firstApp = project.apps[0];
+    const firstApp = topLevelApps[0];
     const groupEnvId = selectedEnv !== "production"
       ? project.groupEnvironments.find((e) => e.name === selectedEnv)?.id
       : undefined;
@@ -706,7 +859,7 @@ export function ProjectDetail({
   }
 
   async function handleRestartAll() {
-    for (const app of project.apps) {
+    for (const app of topLevelApps) {
       try {
         await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/restart`, { method: "POST" });
       } catch { /* continue */ }
@@ -716,7 +869,7 @@ export function ProjectDetail({
   }
 
   async function handleStopAll() {
-    for (const app of project.apps) {
+    for (const app of topLevelApps) {
       try {
         await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/stop`, { method: "POST" });
       } catch { /* continue */ }
@@ -789,9 +942,9 @@ export function ProjectDetail({
       <PageToolbar
         actions={
           <div className="flex items-center gap-2">
-            {project.apps.length > 0 && (() => {
-              const allActive = project.apps.every((a) => a.status === "active");
-              const anyNeedsRedeploy = project.apps.some((a) => a.needsRedeploy);
+            {topLevelApps.length > 0 && (() => {
+              const allActive = topLevelApps.every((a) => a.status === "active");
+              const anyNeedsRedeploy = topLevelApps.some((a) => a.needsRedeploy);
 
               if (allActive) {
                 return (
@@ -918,9 +1071,9 @@ export function ProjectDetail({
         <TabsList variant="line">
           <TabsTrigger value="apps">
             Apps
-            {project.apps.length > 0 && (
+            {topLevelApps.length > 0 && (
               <Badge variant="secondary" className="ml-1.5 text-xs">
-                {project.apps.length}
+                {topLevelApps.length}
               </Badge>
             )}
           </TabsTrigger>
@@ -953,7 +1106,7 @@ export function ProjectDetail({
         </TabsList>
 
         <TabsContent value="apps" className="pt-4">
-          {project.apps.length === 0 ? (
+          {topLevelApps.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
               <p className="text-sm text-muted-foreground">
                 No apps yet. Add your first app to this project.
@@ -967,39 +1120,46 @@ export function ProjectDetail({
             </div>
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {project.apps.map((app) => (
-                <AppCard
-                  key={app.id}
-                  app={app}
-                  color={color}
-                  metrics={metrics.get(app.id)}
-                  history={history.get(app.id) || EMPTY_HISTORY}
-                  highlight={getHighlight(app.name)}
-                  onHoverStart={() => setHoveredAppName(app.name)}
-                  onHoverEnd={() => setHoveredAppName(null)}
-                />
-              ))}
+              {project.apps
+                .filter((app) => !app.parentAppId)
+                .map((app) => (
+                  <React.Fragment key={app.id}>
+                    <AppCard
+                      app={app}
+                      color={color}
+                      metrics={metrics.get(app.id)}
+                      history={history.get(app.id) || EMPTY_HISTORY}
+                      highlight={getHighlight(app.name)}
+                      onHoverStart={() => setHoveredAppName(app.name)}
+                      onHoverEnd={() => setHoveredAppName(null)}
+                      childCount={(app.childApps ?? []).length}
+                    />
+                    {(app.childApps ?? []).length > 0 && (
+                      <ComposeServicesGrid parentApp={app} />
+                    )}
+                  </React.Fragment>
+                ))}
             </div>
           )}
         </TabsContent>
 
         <TabsContent value="deployments" className="pt-4">
-          <ProjectDeployments apps={project.apps} color={color} />
+          <ProjectDeployments apps={topLevelApps} color={color} />
         </TabsContent>
 
         <TabsContent value="variables" className="pt-4">
-          <ProjectVariables apps={project.apps} orgId={orgId} />
+          <ProjectVariables apps={topLevelApps} orgId={orgId} />
         </TabsContent>
 
         {featureFlags?.logs !== false && (
           <TabsContent value="logs" className="pt-4">
-            <ProjectLogs apps={project.apps} orgId={orgId} />
+            <ProjectLogs apps={topLevelApps} orgId={orgId} />
           </TabsContent>
         )}
 
         {featureFlags?.metrics !== false && (
           <TabsContent value="metrics" className="pt-4">
-            <ProjectMetricsTab apps={project.apps} orgId={orgId} projectId={project.id} />
+            <ProjectMetricsTab apps={topLevelApps} orgId={orgId} projectId={project.id} />
           </TabsContent>
         )}
       </Tabs>
@@ -1086,8 +1246,8 @@ export function ProjectDetail({
         loading={deleting}
         title="Delete project"
         description={
-          project.apps.length > 0
-            ? `This will remove the project "${project.displayName}" but keep its ${project.apps.length} app(s). They will become unassigned.`
+          topLevelApps.length > 0
+            ? `This will remove the project "${project.displayName}" but keep its ${topLevelApps.length} app(s). They will become unassigned.`
             : `Delete the project "${project.displayName}"?`
         }
       />

--- a/app/(app)/projects/page.tsx
+++ b/app/(app)/projects/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { db } from "@/lib/db";
 import { apps, projects, tags } from "@/lib/db/schema";
 import { getCurrentOrg, getUserOrganizations } from "@/lib/auth/session";
-import { eq, desc, asc, sql } from "drizzle-orm";
+import { eq, desc, asc, sql, isNull, and } from "drizzle-orm";
 import { Plus } from "lucide-react";
 import { PageToolbar } from "@/components/page-toolbar";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,7 @@ export default async function ProjectsPage() {
 
   const [appList, tagList, projectList] = await Promise.all([
     db.query.apps.findMany({
-      where: eq(apps.organizationId, orgId),
+      where: and(eq(apps.organizationId, orgId), isNull(apps.parentAppId)),
       orderBy: [asc(apps.sortOrder), desc(apps.createdAt)],
       with: {
         domains: {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -341,11 +341,16 @@ export const apps = pgTable(
     cpuLimit: real("cpu_limit"), // CPU cores (e.g. 0.5, 1, 2)
     memoryLimit: integer("memory_limit"), // Memory in MB (e.g. 256, 512, 1024)
     envContent: text("env_content"), // Encrypted env file blob (AES-256-GCM)
+    // Compose decomposition: child service records point to parent compose app
+    parentAppId: text("parent_app_id").references(() => apps.id, { onDelete: "cascade" }),
+    composeService: text("compose_service"), // service name from compose YAML
+    containerName: text("container_name"), // computed: {projectName}-{serviceName}-1
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (t) => [
     unique("app_org_name_uniq").on(t.organizationId, t.name),
+    index("app_parent_app_id_idx").on(t.parentAppId),
   ]
 );
 
@@ -929,6 +934,12 @@ export const appsRelations = relations(apps, ({ one, many }) => ({
     fields: [apps.projectId],
     references: [projects.id],
   }),
+  parentApp: one(apps, {
+    fields: [apps.parentAppId],
+    references: [apps.id],
+    relationName: "parentChild",
+  }),
+  childApps: many(apps, { relationName: "parentChild" }),
   deployments: many(deployments),
   envVars: many(envVars),
   domains: many(domains),

--- a/lib/docker/compose-sync.ts
+++ b/lib/docker/compose-sync.ts
@@ -1,0 +1,254 @@
+// ---------------------------------------------------------------------------
+// Compose Decomposition: sync child app records from compose YAML services
+//
+// After a compose-based deploy succeeds, this module parses the compose YAML
+// and creates/updates/cleans up child app records for each service. The compose
+// file stays the single source of truth -- nothing is split. The decomposition
+// is purely presentational so each service gets its own card with metrics,
+// logs, status, and dependency relationships.
+// ---------------------------------------------------------------------------
+
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import type { ComposeFile, ComposeService } from "./compose";
+
+type SyncResult = {
+  created: string[];
+  updated: string[];
+  removed: string[];
+};
+
+/**
+ * Parse resource limits from a compose service's deploy.resources.limits.
+ * Returns { cpuLimit, memoryLimit } in the same units as the apps table.
+ */
+function parseResourceLimits(svc: ComposeService): {
+  cpuLimit: number | null;
+  memoryLimit: number | null;
+} {
+  const limits = svc.deploy?.resources?.limits;
+  if (!limits) return { cpuLimit: null, memoryLimit: null };
+
+  let cpuLimit: number | null = null;
+  if (limits.cpus) {
+    const parsed = parseFloat(limits.cpus);
+    if (!isNaN(parsed)) cpuLimit = parsed;
+  }
+
+  let memoryLimit: number | null = null;
+  if (limits.memory) {
+    const mem = limits.memory.trim().toLowerCase();
+    if (mem.endsWith("g")) {
+      memoryLimit = parseFloat(mem) * 1024;
+    } else if (mem.endsWith("m")) {
+      memoryLimit = parseFloat(mem);
+    } else if (mem.endsWith("k")) {
+      memoryLimit = Math.round(parseFloat(mem) / 1024);
+    } else {
+      // Assume bytes
+      const bytes = parseInt(mem, 10);
+      if (!isNaN(bytes)) memoryLimit = Math.round(bytes / (1024 * 1024));
+    }
+  }
+
+  return { cpuLimit, memoryLimit };
+}
+
+/**
+ * Extract volume declarations from a compose service.
+ * Returns in the same format as apps.persistentVolumes.
+ */
+function parseServiceVolumes(
+  svc: ComposeService,
+  composeVolumes?: Record<string, unknown>
+): { name: string; mountPath: string }[] {
+  if (!svc.volumes) return [];
+
+  const result: { name: string; mountPath: string }[] = [];
+  for (const vol of svc.volumes) {
+    const parts = vol.split(":");
+    if (parts.length >= 2) {
+      const volName = parts[0];
+      const mountPath = parts[1];
+      // Only include named volumes (not bind mounts)
+      if (!volName.startsWith("/") && !volName.startsWith("./") && !volName.startsWith("../")) {
+        result.push({ name: volName, mountPath });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Humanize a docker-compose service name into a display name.
+ * e.g. "redis-cache" -> "Redis Cache", "postgres" -> "Postgres"
+ */
+function humanizeServiceName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Sync child app records from a parsed compose file after a successful deploy.
+ *
+ * For each service in the compose YAML:
+ * - If a child record exists (matched by parentAppId + composeService), update it
+ * - If not, create one with name, status, dependencies, volumes, resource limits
+ * - If a previous child record's service was removed from the YAML, mark it stopped
+ *
+ * @param parentAppId - The parent compose app's ID
+ * @param organizationId - The org scope
+ * @param projectId - The project this app belongs to (nullable)
+ * @param compose - Parsed compose file
+ * @param parentAppName - The parent app's name (used for generating child names/container names)
+ * @param log - Optional logger
+ */
+export async function syncComposeServices(opts: {
+  parentAppId: string;
+  organizationId: string;
+  projectId: string | null;
+  compose: ComposeFile;
+  parentAppName: string;
+  log?: (line: string) => void;
+}): Promise<SyncResult> {
+  const { parentAppId, organizationId, projectId, compose, parentAppName, log } = opts;
+  const result: SyncResult = { created: [], updated: [], removed: [] };
+
+  const serviceNames = Object.keys(compose.services);
+
+  // Skip decomposition for single-service compose files -- there's nothing to decompose
+  if (serviceNames.length <= 1) {
+    // Still clean up any orphaned children from a previous multi-service compose
+    const existingChildren = await db.query.apps.findMany({
+      where: and(
+        eq(apps.parentAppId, parentAppId),
+        eq(apps.organizationId, organizationId),
+      ),
+      columns: { id: true, name: true, composeService: true },
+    });
+
+    if (existingChildren.length > 0) {
+      await db.transaction(async (tx) => {
+        for (const child of existingChildren) {
+          await tx
+            .update(apps)
+            .set({ status: "stopped", updatedAt: new Date() })
+            .where(eq(apps.id, child.id));
+          result.removed.push(child.composeService || child.name);
+        }
+      });
+    }
+
+    return result;
+  }
+
+  // Fetch existing child records for this parent
+  const existingChildren = await db.query.apps.findMany({
+    where: and(
+      eq(apps.parentAppId, parentAppId),
+      eq(apps.organizationId, organizationId),
+    ),
+    columns: {
+      id: true,
+      name: true,
+      composeService: true,
+      status: true,
+    },
+  });
+
+  const childByService = new Map(
+    existingChildren
+      .filter((c) => c.composeService)
+      .map((c) => [c.composeService!, c])
+  );
+
+  // Wrap all create/update/delete operations in a transaction for atomicity
+  await db.transaction(async (tx) => {
+    // Process each service in the compose file
+    for (const [serviceName, svc] of Object.entries(compose.services)) {
+      const childName = `${parentAppName}-${serviceName}`;
+      const containerName = `${parentAppName}-${serviceName}-1`;
+      const displayName = humanizeServiceName(serviceName);
+      const { cpuLimit, memoryLimit } = parseResourceLimits(svc);
+      const volumes = parseServiceVolumes(svc, compose.volumes);
+
+      // Map compose depends_on to child app names (prefixed with parent)
+      const dependsOn = svc.depends_on?.map((dep) => `${parentAppName}-${dep}`) ?? null;
+
+      const existing = childByService.get(serviceName);
+
+      if (existing) {
+        // Update existing child record
+        await tx
+          .update(apps)
+          .set({
+            status: "active",
+            displayName,
+            containerName,
+            imageName: svc.image || null,
+            cpuLimit,
+            memoryLimit,
+            persistentVolumes: volumes.length > 0 ? volumes : null,
+            dependsOn,
+            updatedAt: new Date(),
+          })
+          .where(eq(apps.id, existing.id));
+
+        result.updated.push(serviceName);
+        childByService.delete(serviceName);
+      } else {
+        // Create new child record
+        const id = nanoid();
+        await tx.insert(apps).values({
+          id,
+          organizationId,
+          name: childName,
+          displayName,
+          description: `Compose service: ${serviceName}`,
+          source: "direct",
+          deployType: "compose",
+          imageName: svc.image || null,
+          status: "active",
+          parentAppId,
+          composeService: serviceName,
+          containerName,
+          projectId,
+          cpuLimit,
+          memoryLimit,
+          persistentVolumes: volumes.length > 0 ? volumes : null,
+          dependsOn,
+          sortOrder: 0,
+        });
+
+        result.created.push(serviceName);
+      }
+    }
+
+    // Mark orphaned children (services removed from compose YAML) as stopped
+    for (const [serviceName, child] of childByService) {
+      await tx
+        .update(apps)
+        .set({ status: "stopped", updatedAt: new Date() })
+        .where(eq(apps.id, child.id));
+      result.removed.push(serviceName);
+    }
+  });
+
+  if (log) {
+    if (result.created.length > 0) {
+      log(`[compose-sync] Created child services: ${result.created.join(", ")}`);
+    }
+    if (result.updated.length > 0) {
+      log(`[compose-sync] Updated child services: ${result.updated.join(", ")}`);
+    }
+    if (result.removed.length > 0) {
+      log(`[compose-sync] Orphaned services stopped: ${result.removed.join(", ")}`);
+    }
+  }
+
+  return result;
+}

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -25,6 +25,7 @@ export type ComposeService = {
   volumes?: string[];
   labels?: Record<string, string>;
   networks?: string[];
+  depends_on?: string[];
   deploy?: {
     resources?: {
       limits?: ResourceLimits;
@@ -371,6 +372,14 @@ export function parseCompose(yamlString: string): ComposeFile {
       }
     }
     if (Array.isArray(raw.networks)) svc.networks = raw.networks.map(String);
+    // depends_on: array of strings or object with service keys
+    if (raw.depends_on) {
+      if (Array.isArray(raw.depends_on)) {
+        svc.depends_on = raw.depends_on.map(String);
+      } else if (typeof raw.depends_on === "object") {
+        svc.depends_on = Object.keys(raw.depends_on);
+      }
+    }
     if (
       raw.deploy &&
       typeof raw.deploy === "object" &&

--- a/lib/docker/deploy-group.ts
+++ b/lib/docker/deploy-group.ts
@@ -208,11 +208,12 @@ export async function deployGroup(
 
   if (!project) throw new Error("Project not found");
 
-  // Load all apps in the project
+  // Load all top-level apps in the project (exclude compose child services)
   const projectApps = await db.query.apps.findMany({
     where: and(
       eq(apps.projectId, opts.projectId),
-      eq(apps.organizationId, opts.organizationId)
+      eq(apps.organizationId, opts.organizationId),
+      isNull(apps.parentAppId),
     ),
   });
 

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -26,6 +26,7 @@ import { volumeThreshold } from "@/lib/volumes/threshold";
 import { getInstallationToken } from "@/lib/github/app";
 import { githubAppInstallations, memberships } from "@/lib/db/schema";
 import { detectPreventiveFixes, detectCompatIssues, applyCompatFixes } from "./compat";
+import { syncComposeServices } from "./compose-sync";
 import { recordActivity } from "@/lib/activity";
 import {
   getDecryptedPrivateKey,
@@ -998,6 +999,26 @@ export async function runDeployment(
       log(`[deploy] Warning: cron sync — ${err instanceof Error ? err.message : err}`);
     }
 
+    // Sync compose decomposition: create/update child app records per service
+    if (app.deployType === "compose" && Object.keys(compose.services).length > 0) {
+      try {
+        const syncResult = await syncComposeServices({
+          parentAppId: opts.appId,
+          organizationId: opts.organizationId,
+          projectId: app.projectId,
+          compose,
+          parentAppName: app.name,
+          log,
+        });
+        const totalSync = syncResult.created.length + syncResult.updated.length + syncResult.removed.length;
+        if (totalSync > 0) {
+          log(`[deploy] Compose decomposition: ${syncResult.created.length} created, ${syncResult.updated.length} updated, ${syncResult.removed.length} removed`);
+        }
+      } catch (err) {
+        log(`[deploy] Warning: compose decomposition — ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
     // Mark app as active
     await db
       .update(apps)
@@ -1349,6 +1370,12 @@ export async function stopProject(
       .update(apps)
       .set({ status: "stopped", updatedAt: new Date() })
       .where(eq(apps.id, appId));
+
+    // Cascade stop status to compose child services
+    await db
+      .update(apps)
+      .set({ status: "stopped", updatedAt: new Date() })
+      .where(eq(apps.parentAppId, appId));
 
     return { success: true, log: logs.join("\n") };
   } catch (err) {


### PR DESCRIPTION
## Summary

- Parse compose YAML on deploy, create child app records per service via new `syncComposeServices` engine
- Each service gets its own card with status, image, resource limits, volumes, and dependency badges
- Compose `depends_on` maps to Host's dependency system (both array and object formats)
- Parent app retains deploy/variables/logs -- child cards are presentational only
- Orphaned services cleaned up on redeploy when removed from YAML
- Stop cascades from parent to child service records
- Child apps excluded from group deploy orchestration and apps listing

## Schema changes

- `apps.parentAppId` -- nullable self-FK, child services point to their parent compose app
- `apps.composeService` -- the service name from the compose YAML
- `apps.containerName` -- computed container name for metrics/logs routing (`{project}-{service}-1`)
- Index on `parentAppId` for efficient child lookups

## Test plan

- [ ] Deploy a multi-service compose app (e.g. app + postgres + redis) -- verify child records created
- [ ] Verify child service cards render under parent in project detail view
- [ ] Verify compose badge, image name, resource limits, volumes display correctly
- [ ] Remove a service from compose YAML and redeploy -- verify orphaned child marked stopped
- [ ] Verify Deploy All only triggers parent apps, not children
- [ ] Verify apps listing page excludes compose child apps
- [ ] Deploy a single-service compose app -- verify no child records created
- [ ] Stop parent app -- verify child service statuses cascade to stopped

Closes #20