### PR TITLE
feat(templates): add multi-service compose templates

### DIFF
--- a/templates/ghost.toml
+++ b/templates/ghost.toml
@@ -1,13 +1,35 @@
-version = "1"
+version = "2"
 name = "ghost"
-displayName = "Ghost"
-description = "Professional publishing platform"
+displayName = "Ghost + MySQL"
+description = "Professional publishing platform with a dedicated MySQL 8 database"
 icon = "https://cdn.simpleicons.org/ghost"
 category = "web"
 source = "direct"
-deployType = "image"
-imageName = "ghost:5-alpine"
+deployType = "compose"
 defaultPort = 2368
+
+composeContent = """
+services:
+  ghost:
+    image: ghost:latest
+    depends_on:
+      - mysql
+    env_file:
+      - .env
+    volumes:
+      - ghost-content:/var/lib/ghost/content
+
+  mysql:
+    image: mysql:8
+    env_file:
+      - .env
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  ghost-content: {}
+  mysql-data: {}
+"""
 
 [[envVars]]
 key = "url"
@@ -19,9 +41,66 @@ defaultValue = "${project.url}"
 key = "database__client"
 description = "Database client"
 required = false
-defaultValue = "sqlite3"
+defaultValue = "mysql"
+
+[[envVars]]
+key = "database__connection__host"
+description = "Database hostname (compose service name)"
+required = true
+defaultValue = "mysql"
+
+[[envVars]]
+key = "database__connection__port"
+description = "Database port"
+required = false
+defaultValue = "3306"
+
+[[envVars]]
+key = "database__connection__user"
+description = "Database username"
+required = true
+defaultValue = "ghost"
+
+[[envVars]]
+key = "database__connection__password"
+description = "Database password"
+required = true
+
+[[envVars]]
+key = "database__connection__database"
+description = "Database name"
+required = true
+defaultValue = "ghost"
+
+[[envVars]]
+key = "MYSQL_ROOT_PASSWORD"
+description = "MySQL root password"
+required = true
+
+[[envVars]]
+key = "MYSQL_DATABASE"
+description = "MySQL database to create on startup"
+required = false
+defaultValue = "ghost"
+
+[[envVars]]
+key = "MYSQL_USER"
+description = "MySQL user to create on startup"
+required = false
+defaultValue = "ghost"
+
+[[envVars]]
+key = "MYSQL_PASSWORD"
+description = "MySQL user password (should match database__connection__password)"
+required = false
+defaultValue = "${database__connection__password}"
 
 [[volumes]]
-name = "content"
+name = "ghost-content"
 mountPath = "/var/lib/ghost/content"
-description = "Ghost content and images"
+description = "Ghost content, themes, and images"
+
+[[volumes]]
+name = "mysql-data"
+mountPath = "/var/lib/mysql"
+description = "MySQL data files"

--- a/templates/n8n-postgres.toml
+++ b/templates/n8n-postgres.toml
@@ -1,0 +1,105 @@
+version = "1"
+name = "n8n-postgres"
+displayName = "n8n + Postgres"
+description = "Workflow automation tool with a dedicated PostgreSQL 17 database"
+icon = "https://cdn.simpleicons.org/n8n"
+category = "tool"
+source = "direct"
+deployType = "compose"
+defaultPort = 5678
+
+composeContent = """
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    depends_on:
+      - postgres
+    env_file:
+      - .env
+    volumes:
+      - n8n-data:/home/node/.n8n
+
+  postgres:
+    image: postgres:17
+    env_file:
+      - .env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  n8n-data: {}
+  postgres-data: {}
+"""
+
+[[envVars]]
+key = "DB_TYPE"
+description = "n8n database type"
+required = true
+defaultValue = "postgresdb"
+
+[[envVars]]
+key = "DB_POSTGRESDB_HOST"
+description = "Database hostname (compose service name)"
+required = true
+defaultValue = "postgres"
+
+[[envVars]]
+key = "DB_POSTGRESDB_PORT"
+description = "Database port"
+required = false
+defaultValue = "5432"
+
+[[envVars]]
+key = "DB_POSTGRESDB_DATABASE"
+description = "Database name"
+required = true
+defaultValue = "n8n"
+
+[[envVars]]
+key = "DB_POSTGRESDB_USER"
+description = "Database username"
+required = true
+defaultValue = "n8n"
+
+[[envVars]]
+key = "DB_POSTGRESDB_PASSWORD"
+description = "Database password"
+required = true
+
+[[envVars]]
+key = "N8N_BASIC_AUTH_USER"
+description = "Basic auth username for the n8n UI"
+required = false
+
+[[envVars]]
+key = "N8N_BASIC_AUTH_PASSWORD"
+description = "Basic auth password for the n8n UI"
+required = false
+
+[[envVars]]
+key = "POSTGRES_DB"
+description = "PostgreSQL database to create on startup"
+required = false
+defaultValue = "n8n"
+
+[[envVars]]
+key = "POSTGRES_USER"
+description = "PostgreSQL superuser name"
+required = false
+defaultValue = "n8n"
+
+[[envVars]]
+key = "POSTGRES_PASSWORD"
+description = "PostgreSQL superuser password (should match DB_POSTGRESDB_PASSWORD)"
+required = false
+defaultValue = "${DB_POSTGRESDB_PASSWORD}"
+
+[[volumes]]
+name = "n8n-data"
+mountPath = "/home/node/.n8n"
+description = "n8n workflows, credentials, and execution data"
+
+[[volumes]]
+name = "postgres-data"
+mountPath = "/var/lib/postgresql/data"
+description = "PostgreSQL data files"

--- a/templates/strapi.toml
+++ b/templates/strapi.toml
@@ -1,0 +1,115 @@
+version = "1"
+name = "strapi"
+displayName = "Strapi + Postgres"
+description = "Headless CMS with a dedicated PostgreSQL 17 database"
+icon = "https://cdn.simpleicons.org/strapi/4945FF"
+category = "web"
+source = "direct"
+deployType = "compose"
+defaultPort = 1337
+
+composeContent = """
+services:
+  strapi:
+    image: strapi/strapi:latest
+    depends_on:
+      - postgres
+    env_file:
+      - .env
+    volumes:
+      - strapi-uploads:/opt/app/public/uploads
+
+  postgres:
+    image: postgres:17
+    env_file:
+      - .env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  strapi-uploads: {}
+  postgres-data: {}
+"""
+
+[[envVars]]
+key = "DATABASE_CLIENT"
+description = "Database client type"
+required = true
+defaultValue = "postgres"
+
+[[envVars]]
+key = "DATABASE_HOST"
+description = "Database hostname (compose service name)"
+required = true
+defaultValue = "postgres"
+
+[[envVars]]
+key = "DATABASE_PORT"
+description = "Database port"
+required = false
+defaultValue = "5432"
+
+[[envVars]]
+key = "DATABASE_NAME"
+description = "Database name"
+required = true
+defaultValue = "strapi"
+
+[[envVars]]
+key = "DATABASE_USERNAME"
+description = "Database username"
+required = true
+defaultValue = "strapi"
+
+[[envVars]]
+key = "DATABASE_PASSWORD"
+description = "Database password"
+required = true
+
+[[envVars]]
+key = "APP_KEYS"
+description = "Strapi application keys (comma-separated)"
+required = true
+
+[[envVars]]
+key = "API_TOKEN_SALT"
+description = "Salt for API token generation"
+required = true
+
+[[envVars]]
+key = "ADMIN_JWT_SECRET"
+description = "Secret for admin JWT tokens"
+required = true
+
+[[envVars]]
+key = "JWT_SECRET"
+description = "Secret for user JWT tokens"
+required = true
+
+[[envVars]]
+key = "POSTGRES_DB"
+description = "PostgreSQL database to create on startup"
+required = false
+defaultValue = "strapi"
+
+[[envVars]]
+key = "POSTGRES_USER"
+description = "PostgreSQL superuser name"
+required = false
+defaultValue = "strapi"
+
+[[envVars]]
+key = "POSTGRES_PASSWORD"
+description = "PostgreSQL superuser password (should match DATABASE_PASSWORD)"
+required = false
+defaultValue = "${DATABASE_PASSWORD}"
+
+[[volumes]]
+name = "strapi-uploads"
+mountPath = "/opt/app/public/uploads"
+description = "Strapi media uploads"
+
+[[volumes]]
+name = "postgres-data"
+mountPath = "/var/lib/postgresql/data"
+description = "PostgreSQL data files"

--- a/templates/wordpress.toml
+++ b/templates/wordpress.toml
@@ -1,0 +1,88 @@
+version = "1"
+name = "wordpress"
+displayName = "WordPress + MySQL"
+description = "WordPress CMS with a dedicated MySQL 8 database"
+icon = "https://cdn.simpleicons.org/wordpress/21759B"
+category = "web"
+source = "direct"
+deployType = "compose"
+defaultPort = 80
+
+composeContent = """
+services:
+  wordpress:
+    image: wordpress:latest
+    depends_on:
+      - mysql
+    env_file:
+      - .env
+    volumes:
+      - wp-content:/var/www/html/wp-content
+
+  mysql:
+    image: mysql:8
+    env_file:
+      - .env
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  wp-content: {}
+  mysql-data: {}
+"""
+
+[[envVars]]
+key = "WORDPRESS_DB_HOST"
+description = "Database hostname (compose service name)"
+required = true
+defaultValue = "mysql"
+
+[[envVars]]
+key = "WORDPRESS_DB_USER"
+description = "Database username"
+required = true
+defaultValue = "wordpress"
+
+[[envVars]]
+key = "WORDPRESS_DB_PASSWORD"
+description = "Database password"
+required = true
+
+[[envVars]]
+key = "WORDPRESS_DB_NAME"
+description = "Database name"
+required = true
+defaultValue = "wordpress"
+
+[[envVars]]
+key = "MYSQL_ROOT_PASSWORD"
+description = "MySQL root password"
+required = true
+
+[[envVars]]
+key = "MYSQL_DATABASE"
+description = "MySQL database to create on startup"
+required = false
+defaultValue = "wordpress"
+
+[[envVars]]
+key = "MYSQL_USER"
+description = "MySQL user to create on startup"
+required = false
+defaultValue = "wordpress"
+
+[[envVars]]
+key = "MYSQL_PASSWORD"
+description = "MySQL user password (should match WORDPRESS_DB_PASSWORD)"
+required = false
+defaultValue = "${WORDPRESS_DB_PASSWORD}"
+
+[[volumes]]
+name = "wp-content"
+mountPath = "/var/www/html/wp-content"
+description = "WordPress themes, plugins, and uploads"
+
+[[volumes]]
+name = "mysql-data"
+mountPath = "/var/lib/mysql"
+description = "MySQL data files"


### PR DESCRIPTION
## Summary

- **WordPress + MySQL** (`templates/wordpress.toml`) -- WordPress latest with MySQL 8, cross-service DB env vars, wp-content and mysql-data volumes
- **Ghost + MySQL** (`templates/ghost.toml`) -- Upgrades existing Ghost template from single-service SQLite to multi-service MySQL stack with `database__connection__*` env vars
- **Strapi + Postgres** (`templates/strapi.toml`) -- Strapi CMS with PostgreSQL 17, includes all required Strapi secrets (APP_KEYS, JWT secrets, token salts)
- **n8n + Postgres** (`templates/n8n-postgres.toml`) -- n8n workflow automation with PostgreSQL 17, `DB_POSTGRESDB_*` env vars

Each template defines a full docker-compose stack with:
- `depends_on` relationships between app and database services
- Cross-service env vars (app DB vars reference the compose service name)
- Shared `.env` file via `env_file` directive on both services
- Named volumes per service declared at compose top level
- Postgres/MySQL init vars (`POSTGRES_DB`, `MYSQL_DATABASE`, etc.) that mirror the app-side credentials

No loader or schema changes required -- the existing template system already supports `composeContent` + `deployType: compose`. On deploy, the compose decomposition engine (`compose-sync.ts`) creates individual child app records per service.

## Test plan

- [ ] Deploy WordPress template -- verify both wordpress and mysql containers start, WordPress connects to MySQL
- [ ] Deploy Ghost template -- verify Ghost starts with MySQL backend, admin panel accessible
- [ ] Deploy Strapi template -- verify Strapi starts with Postgres backend, admin panel accessible
- [ ] Deploy n8n template -- verify n8n starts with Postgres backend, workflow editor accessible
- [ ] Verify compose decomposition creates child app cards for each service
- [ ] Verify volumes are created in the volumes table for each declared volume
- [ ] Confirm existing single-service n8n template still works alongside the new n8n-postgres template