### PR TITLE
feat(onboarding): auto-create org and simplify to single step

### DIFF
--- a/app/(app)/apps/new/new-app-flow.tsx
+++ b/app/(app)/apps/new/new-app-flow.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import Link from "next/link";
 import {
   ArrowLeft,
   Loader2,
@@ -180,6 +179,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
   const [selectedInstallation, setSelectedInstallation] = useState("");
   const [repos, setRepos] = useState<Repo[]>([]);
   const [reposLoading, setReposLoading] = useState(false);
+  const [connectingGithub, setConnectingGithub] = useState(false);
   const [selectedRepo, setSelectedRepo] = useState("");
   const [branches, setBranches] = useState<string[]>([]);
 
@@ -592,11 +592,42 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
                     <Loader2 className="size-5 animate-spin text-muted-foreground" />
                   </div>
                 ) : installations.length === 0 ? (
-                  <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed p-8 text-center">
-                    <Github className="size-6 text-muted-foreground" />
-                    <p className="text-sm text-muted-foreground">No GitHub account connected.</p>
-                    <Button size="sm" variant="outline" asChild>
-                      <Link href="/profile"><Github className="mr-1.5 size-4" />Connect in Profile</Link>
+                  <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed p-8 text-center">
+                    <Github className="size-8 text-muted-foreground" />
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium">Connect GitHub to continue</p>
+                      <p className="text-xs text-muted-foreground">
+                        Install the GitHub App to import repositories and enable auto-deploy.
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      disabled={connectingGithub}
+                      onClick={async () => {
+                        setConnectingGithub(true);
+                        try {
+                          const res = await fetch("/api/v1/github/connect");
+                          if (res.ok) {
+                            const data = await res.json();
+                            if (data.url) {
+                              window.location.href = data.url;
+                              return;
+                            }
+                          }
+                          toast.error("Failed to start GitHub connection");
+                        } catch {
+                          toast.error("Failed to connect GitHub");
+                        } finally {
+                          setConnectingGithub(false);
+                        }
+                      }}
+                    >
+                      {connectingGithub ? (
+                        <Loader2 className="mr-1.5 size-4 animate-spin" />
+                      ) : (
+                        <Github className="mr-1.5 size-4" />
+                      )}
+                      Connect GitHub
                     </Button>
                   </div>
                 ) : (

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -26,7 +26,7 @@ export default async function AppLayout({
   const orgData = await getCurrentOrg();
 
   if (!orgData) {
-    redirect("/onboarding");
+    redirect("/create-org");
   }
 
   const { organization } = orgData;

--- a/app/(public)/create-org/page.tsx
+++ b/app/(public)/create-org/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "@/lib/auth/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+export default function CreateOrgPage() {
+  const router = useRouter();
+  const { data: session, isPending } = useSession();
+  const [orgName, setOrgName] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!isPending && !session) {
+      router.replace("/login");
+    }
+  }, [session, isPending, router]);
+
+  async function handleCreateOrg(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const slug = orgName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+
+      const res = await fetch("/api/v1/organizations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: orgName, slug }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        toast.error(data.error || "Failed to create organization");
+        return;
+      }
+
+      toast.success("Organization created");
+      router.push("/projects");
+    } catch {
+      toast.error("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (isPending || !session) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center p-4">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Create an organization
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Organizations group your apps and team together.
+          </p>
+        </div>
+
+        <form onSubmit={handleCreateOrg} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="orgName">Organization name</Label>
+            <Input
+              id="orgName"
+              placeholder="e.g. My Team"
+              value={orgName}
+              onChange={(e) => setOrgName(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? <Loader2 className="size-4 animate-spin" /> : "Continue"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(public)/onboarding/page.tsx
+++ b/app/(public)/onboarding/page.tsx
@@ -2,19 +2,16 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { signUp, signIn, useSession } from "@/lib/auth/client";
+import { signUp, useSession } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Github, ArrowRight, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
-
-type Step = "account" | "github" | "org";
 
 export default function OnboardingPage() {
   const router = useRouter();
   const { data: session, isPending } = useSession();
-  const [step, setStep] = useState<Step>("account");
   const [loading, setLoading] = useState(false);
 
   // Account form
@@ -22,38 +19,12 @@ export default function OnboardingPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  // GitHub state
-  const [githubConnected, setGithubConnected] = useState(false);
-  const [checkingGithub, setCheckingGithub] = useState(false);
-
-  // Org form
-  const [orgName, setOrgName] = useState("");
-
-  // Skip account creation if already signed in (e.g. via OAuth)
+  // If already signed in, go straight to dashboard
   useEffect(() => {
-    if (session && step === "account") {
-      setStep("github");
+    if (session) {
+      router.replace("/projects");
     }
-  }, [session, step]);
-
-  // Check if GitHub is already connected when we reach that step
-  useEffect(() => {
-    if (step !== "github") return;
-    let cancelled = false;
-    async function check() {
-      setCheckingGithub(true);
-      try {
-        const res = await fetch("/api/v1/github/installations");
-        if (res.ok && !cancelled) {
-          const data = await res.json();
-          setGithubConnected((data.installations || []).length > 0);
-        }
-      } catch { /* skip */ }
-      finally { if (!cancelled) setCheckingGithub(false); }
-    }
-    check();
-    return () => { cancelled = true; };
-  }, [step]);
+  }, [session, router]);
 
   async function handleCreateAccount(e: React.FormEvent) {
     e.preventDefault();
@@ -65,55 +36,6 @@ export default function OnboardingPage() {
         return;
       }
       toast.success("Account created");
-      setStep("github");
-    } catch {
-      toast.error("Something went wrong");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleConnectGithub() {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/v1/github/connect");
-      if (res.ok) {
-        const data = await res.json();
-        if (data.url) {
-          window.location.href = data.url;
-          return;
-        }
-      }
-      toast.error("Failed to start GitHub connection");
-    } catch {
-      toast.error("Failed to connect GitHub");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleCreateOrg(e: React.FormEvent) {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      const slug = orgName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-|-$/g, "");
-
-      const res = await fetch("/api/v1/organizations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: orgName, slug }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        toast.error(data.error || "Failed to create organization");
-        return;
-      }
-
-      toast.success("Organization created");
       router.push("/projects");
     } catch {
       toast.error("Something went wrong");
@@ -130,133 +52,53 @@ export default function OnboardingPage() {
     );
   }
 
-  const stepIndex = step === "account" ? 0 : step === "github" ? 1 : 2;
-  const totalSteps = session ? 2 : 3; // Skip account step count if already signed in
-
   return (
     <div className="flex min-h-dvh items-center justify-center p-4">
       <div className="w-full max-w-sm space-y-6">
-        {/* Step indicator */}
-        <div className="flex items-center justify-center gap-1.5">
-          {Array.from({ length: totalSteps }).map((_, i) => (
-            <div
-              key={i}
-              className={`h-1 rounded-full transition-all ${
-                i <= (session ? stepIndex - 1 : stepIndex)
-                  ? "w-8 bg-primary"
-                  : "w-4 bg-muted"
-              }`}
-            />
-          ))}
-        </div>
-
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">
-            {step === "account"
-              ? "Create your account"
-              : step === "github"
-              ? "Connect GitHub"
-              : "Create an organization"}
+            Create your account
           </h1>
           <p className="text-sm text-muted-foreground">
-            {step === "account"
-              ? "Set up your admin account."
-              : step === "github"
-              ? "Deploy directly from your repositories."
-              : "Organizations group your apps and team together."}
+            Set up your admin account to get started.
           </p>
         </div>
 
-        {step === "account" && (
-          <form onSubmit={handleCreateAccount} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                minLength={8}
-                required
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? <Loader2 className="size-4 animate-spin" /> : "Continue"}
-            </Button>
-          </form>
-        )}
-
-        {step === "github" && (
-          <div className="space-y-4">
-            {checkingGithub ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="size-5 animate-spin text-muted-foreground" />
-              </div>
-            ) : githubConnected ? (
-              <div className="rounded-lg border bg-status-success-muted p-4 text-center">
-                <p className="text-sm text-status-success font-medium">GitHub connected</p>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                className="w-full h-12"
-                onClick={handleConnectGithub}
-                disabled={loading}
-              >
-                {loading ? (
-                  <Loader2 className="size-4 animate-spin mr-2" />
-                ) : (
-                  <Github className="size-5 mr-2" />
-                )}
-                Connect GitHub
-              </Button>
-            )}
-            <Button
-              className="w-full"
-              onClick={() => setStep("org")}
-            >
-              {githubConnected ? "Continue" : "Skip for now"}
-              <ArrowRight className="size-4 ml-2" />
-            </Button>
+        <form onSubmit={handleCreateAccount} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
           </div>
-        )}
-
-        {step === "org" && (
-          <form onSubmit={handleCreateOrg} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="orgName">Organization name</Label>
-              <Input
-                id="orgName"
-                placeholder="e.g. Joey Yax, LLC"
-                value={orgName}
-                onChange={(e) => setOrgName(e.target.value)}
-                required
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? <Loader2 className="size-4 animate-spin" /> : "Get started"}
-            </Button>
-          </form>
-        )}
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              minLength={8}
+              required
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? <Loader2 className="size-4 animate-spin" /> : "Get started"}
+          </Button>
+        </form>
       </div>
     </div>
   );

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -82,21 +82,53 @@ export const auth = betterAuth({
     },
   },
 
-  // Auto-promote first user to app admin
+  // Auto-promote first user to app admin + auto-create default organization
   databaseHooks: {
     user: {
       create: {
         after: async (user) => {
-          const [{ count }] = await db
-            .select({ count: sql<number>`count(*)` })
-            .from(schema.user);
-          if (Number(count) === 1) {
-            const { eq } = await import("drizzle-orm");
-            await db
-              .update(schema.user)
-              .set({ isAppAdmin: true })
-              .where(eq(schema.user.id, user.id));
-          }
+          const { eq } = await import("drizzle-orm");
+          const { nanoid } = await import("nanoid");
+
+          await db.transaction(async (tx) => {
+            const [{ count }] = await tx
+              .select({ count: sql<number>`count(*)` })
+              .from(schema.user);
+            if (Number(count) === 1) {
+              await tx
+                .update(schema.user)
+                .set({ isAppAdmin: true })
+                .where(eq(schema.user.id, user.id));
+            }
+
+            // Auto-create a default organization for the new user
+            const rawName = user.name || user.email.split("@")[0];
+            // Strip +suffix from email local parts, replace dots/underscores
+            // with spaces, and capitalize the first letter
+            const cleanedName = rawName
+              .replace(/\+.*$/, "")
+              .replace(/[._]/g, " ")
+              .replace(/^\w/, (c: string) => c.toUpperCase());
+            const baseSlug = cleanedName
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, "-")
+              .replace(/^-|-$/g, "");
+            const slug = `${baseSlug}-${nanoid(8)}`;
+
+            const orgId = nanoid();
+            await tx.insert(schema.organizations).values({
+              id: orgId,
+              name: cleanedName,
+              slug,
+            });
+
+            await tx.insert(schema.memberships).values({
+              id: nanoid(),
+              userId: user.id,
+              organizationId: orgId,
+              role: "owner",
+            });
+          });
         },
       },
     },


### PR DESCRIPTION
## Summary
- Auto-create default organization on first user signup via Better Auth `databaseHooks.user.create.after` (named after the user's name or email prefix, with owner membership)
- Simplify onboarding to single-step account creation: name, email, password, then redirect straight to `/projects`
- Remove GitHub connection step from onboarding wizard entirely
- Add `/create-org` safety-net page for the edge case where a signed-in user has no organization
- GitHub connection is now prompted contextually in the new app flow when the user selects "GitHub" as a source

## Test plan
- [ ] Fresh signup creates account + default org, lands on `/projects`
- [ ] Existing users with orgs see no change in behavior
- [ ] User with no org (edge case) is redirected to `/create-org`, not the old wizard
- [ ] New app flow > GitHub source shows inline "Connect GitHub" button when not connected
- [ ] After connecting GitHub from new app flow, user returns and can select repos

Closes #34