### PR TITLE
feat(backups): auto-configure backup jobs for apps with volumes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -324,6 +324,49 @@ if [ ! -f "$ENV_FILE" ]; then
     fi
   fi
 
+  # ── Backup storage ──────────────────────────────────────────────────────
+  echo ""
+  BACKUP_STORAGE_TYPE=""
+  BACKUP_STORAGE_BUCKET=""
+  BACKUP_STORAGE_REGION=""
+  BACKUP_STORAGE_ENDPOINT=""
+  BACKUP_STORAGE_ACCESS_KEY=""
+  BACKUP_STORAGE_SECRET_KEY=""
+
+  read -p "  Configure backup storage? (recommended) [Y/n] " ENABLE_BACKUPS
+  if [ "$ENABLE_BACKUPS" != "n" ] && [ "$ENABLE_BACKUPS" != "N" ]; then
+    echo ""
+    echo -e "  ${BOLD}Backup storage type:${RESET}"
+    echo "    1) S3 (AWS S3 or compatible)"
+    echo "    2) R2 (Cloudflare R2)"
+    echo "    3) B2 (Backblaze B2)"
+    read -p "  Choose [1-3]: " BACKUP_TYPE_CHOICE
+    case "$BACKUP_TYPE_CHOICE" in
+      1) BACKUP_STORAGE_TYPE="s3" ;;
+      2) BACKUP_STORAGE_TYPE="r2" ;;
+      3) BACKUP_STORAGE_TYPE="b2" ;;
+      *) BACKUP_STORAGE_TYPE="s3" ;;
+    esac
+
+    read -p "  Bucket name: " BACKUP_STORAGE_BUCKET
+    if [ "$BACKUP_STORAGE_TYPE" = "r2" ]; then
+      read -p "  R2 endpoint (e.g. https://<account-id>.r2.cloudflarestorage.com): " BACKUP_STORAGE_ENDPOINT
+      BACKUP_STORAGE_REGION="auto"
+    elif [ "$BACKUP_STORAGE_TYPE" = "b2" ]; then
+      read -p "  B2 endpoint (e.g. https://s3.us-west-004.backblazeb2.com): " BACKUP_STORAGE_ENDPOINT
+      read -p "  B2 region (e.g. us-west-004): " BACKUP_STORAGE_REGION
+    else
+      read -p "  Region (e.g. us-east-1): " BACKUP_STORAGE_REGION
+      read -p "  Custom endpoint (leave blank for AWS): " BACKUP_STORAGE_ENDPOINT
+    fi
+    read -p "  Access key: " BACKUP_STORAGE_ACCESS_KEY
+    read -sp "  Secret key: " BACKUP_STORAGE_SECRET_KEY
+    echo ""
+    log "Backup storage configured (${BACKUP_STORAGE_TYPE}://${BACKUP_STORAGE_BUCKET})"
+  else
+    warn "You can configure backup storage later in settings"
+  fi
+
   echo ""
 
   # Generate secrets
@@ -353,6 +396,14 @@ COMPOSE_PROFILES=$COMPOSE_PROFILES
 # Feature flags — set to "false" to hide disabled services from the UI
 FEATURE_METRICS=$FEATURE_METRICS
 FEATURE_LOGS=$FEATURE_LOGS
+
+# Backup storage (auto-creates Host-level backup target on startup)
+BACKUP_STORAGE_TYPE=$BACKUP_STORAGE_TYPE
+BACKUP_STORAGE_BUCKET=$BACKUP_STORAGE_BUCKET
+BACKUP_STORAGE_REGION=$BACKUP_STORAGE_REGION
+BACKUP_STORAGE_ENDPOINT=$BACKUP_STORAGE_ENDPOINT
+BACKUP_STORAGE_ACCESS_KEY=$BACKUP_STORAGE_ACCESS_KEY
+BACKUP_STORAGE_SECRET_KEY=$BACKUP_STORAGE_SECRET_KEY
 
 # GitHub App (optional — configure later in Settings)
 GITHUB_APP_ID=

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -28,6 +28,19 @@ export async function register() {
       console.error("[instrumentation] Failed to start cron scheduler:", err);
     }
 
+    console.log("[instrumentation] Ensuring Host-level backup target...");
+    try {
+      const { ensureHostBackupTarget } = await import("./lib/backup/auto-backup");
+      const target = await ensureHostBackupTarget();
+      if (target) {
+        console.log(`[instrumentation] Host backup target ready: ${target.name} (${target.type})`);
+      } else {
+        console.log("[instrumentation] No backup storage configured (set BACKUP_STORAGE_* env vars or configure in settings)");
+      }
+    } catch (err) {
+      console.error("[instrumentation] Failed to ensure backup target:", err);
+    }
+
     console.log("[instrumentation] Starting backup scheduler...");
     try {
       const { startBackupScheduler } = await import("./lib/backup/scheduler");

--- a/lib/backup/auto-backup.ts
+++ b/lib/backup/auto-backup.ts
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// Auto-Backup Configuration
+//
+// Provides two capabilities:
+// 1. ensureHostBackupTarget() — on app startup, auto-creates a Host-level
+//    backup target from BACKUP_STORAGE_* env vars if none exists.
+// 2. ensureAutoBackupJob() — after deploy detects persistent volumes,
+//    auto-creates a daily backup job linked to the app.
+// ---------------------------------------------------------------------------
+
+import { db } from "@/lib/db";
+import { backupTargets, backupJobs, backupJobApps, volumes } from "@/lib/db/schema";
+import { eq, and, isNull } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+// ---------------------------------------------------------------------------
+// 1. Host-level backup target from env vars
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a Host-level backup target exists. If not, but BACKUP_STORAGE_*
+ * env vars are configured, auto-create one. This is the global safety-net
+ * target that any org can fall back to.
+ *
+ * Returns the Host-level target if one exists (or was created), null otherwise.
+ */
+export async function ensureHostBackupTarget() {
+  // Check if a Host-level target already exists (organizationId IS NULL)
+  const existing = await db.query.backupTargets.findFirst({
+    where: isNull(backupTargets.organizationId),
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  // Check env vars
+  const storageType = process.env.BACKUP_STORAGE_TYPE;
+  const bucket = process.env.BACKUP_STORAGE_BUCKET;
+  const region = process.env.BACKUP_STORAGE_REGION;
+  const endpoint = process.env.BACKUP_STORAGE_ENDPOINT;
+  const accessKey = process.env.BACKUP_STORAGE_ACCESS_KEY;
+  const secretKey = process.env.BACKUP_STORAGE_SECRET_KEY;
+
+  if (!storageType || !bucket || !accessKey || !secretKey) {
+    // Not enough config to create a target
+    return null;
+  }
+
+  // Validate storage type
+  const validTypes = ["s3", "r2", "b2"] as const;
+  const type = storageType.toLowerCase() as (typeof validTypes)[number];
+  if (!validTypes.includes(type)) {
+    console.warn(
+      `[auto-backup] Invalid BACKUP_STORAGE_TYPE: ${storageType}. Must be one of: ${validTypes.join(", ")}`
+    );
+    return null;
+  }
+
+  // Build the S3-compatible config
+  const config = {
+    bucket,
+    region: region || "auto",
+    accessKeyId: accessKey,
+    secretAccessKey: secretKey,
+    ...(endpoint ? { endpoint } : {}),
+  } satisfies {
+    bucket: string;
+    region: string;
+    endpoint?: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+
+  console.log(`[auto-backup] Creating Host-level backup target (${type}://${bucket})`);
+
+  const [target] = await db
+    .insert(backupTargets)
+    .values({
+      id: nanoid(),
+      organizationId: null, // Host-level
+      name: "Host Auto-Configured",
+      type,
+      config,
+      isDefault: true,
+    })
+    .returning();
+
+  return target;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Auto-create backup job on deploy
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the best backup target for an organization:
+ * 1. Org-level default target (takes precedence)
+ * 2. Host-level target (fallback safety net)
+ * Returns null if no target is configured anywhere.
+ */
+export async function resolveBackupTarget(organizationId: string) {
+  // Check for org-level default target first
+  const orgTarget = await db.query.backupTargets.findFirst({
+    where: and(
+      eq(backupTargets.organizationId, organizationId),
+      eq(backupTargets.isDefault, true),
+    ),
+  });
+
+  if (orgTarget) return orgTarget;
+
+  // Fall back to any org-level target
+  const anyOrgTarget = await db.query.backupTargets.findFirst({
+    where: eq(backupTargets.organizationId, organizationId),
+  });
+
+  if (anyOrgTarget) return anyOrgTarget;
+
+  // Fall back to Host-level target
+  const hostTarget = await db.query.backupTargets.findFirst({
+    where: isNull(backupTargets.organizationId),
+  });
+
+  return hostTarget ?? null;
+}
+
+/**
+ * After a deploy detects persistent volumes, check if the app already has a
+ * backup job. If not and a backup target exists (org-level or Host-level),
+ * auto-create a daily backup job.
+ *
+ * Returns the created job ID, or null if skipped.
+ */
+export async function ensureAutoBackupJob(opts: {
+  appId: string;
+  appName: string;
+  organizationId: string;
+}): Promise<string | null> {
+  const { appId, appName, organizationId } = opts;
+
+  // Check if the app has persistent volumes
+  const appVolumes = await db.query.volumes.findMany({
+    where: eq(volumes.appId, appId),
+  });
+  const hasPersistentVolumes = appVolumes.some((v) => v.persistent);
+
+  if (!hasPersistentVolumes) {
+    return null;
+  }
+
+  // Check if the app already has a backup job
+  const existingLink = await db.query.backupJobApps.findFirst({
+    where: eq(backupJobApps.appId, appId),
+  });
+
+  if (existingLink) {
+    return null; // Already covered
+  }
+
+  // Resolve the best backup target
+  const target = await resolveBackupTarget(organizationId);
+
+  if (!target) {
+    // No backup target configured anywhere -- skip silently
+    return null;
+  }
+
+  // Create a daily backup job at 2 AM
+  const jobId = nanoid();
+  await db.insert(backupJobs).values({
+    id: jobId,
+    organizationId,
+    targetId: target.id,
+    name: `Auto: ${appName}`,
+    schedule: "0 2 * * *",
+    enabled: true,
+    keepDaily: 7,
+    notifyOnFailure: true,
+  });
+
+  // Link the app to the job
+  await db.insert(backupJobApps).values({
+    backupJobId: jobId,
+    appId,
+  });
+
+  return jobId;
+}

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -891,6 +891,21 @@ export async function runDeployment(
       // Volume detection is best-effort
     }
 
+    // Auto-create backup job for apps with persistent volumes
+    try {
+      const { ensureAutoBackupJob } = await import("@/lib/backup/auto-backup");
+      const backupJobId = await ensureAutoBackupJob({
+        appId: opts.appId,
+        appName: app.name,
+        organizationId: opts.organizationId,
+      });
+      if (backupJobId) {
+        log(`[deploy] Auto-configured daily backup job for persistent volumes`);
+      }
+    } catch {
+      // Auto-backup is best-effort — don't fail the deploy
+    }
+
     // Check volume size limits (reads limits directly from volume records)
     try {
       const limitedVolumes = await db.query.volumes.findMany({


### PR DESCRIPTION
## Summary
- `install.sh` now prompts for backup storage config (S3/R2/B2) during initial setup, writing `BACKUP_STORAGE_*` env vars to `.env.prod`
- On app startup (`instrumentation.ts`), auto-creates a Host-level backup target from env vars if none exists
- After deploy detects persistent volumes, auto-creates a daily 2AM backup job (7-day retention) linked to the app
- Org-level backup targets take precedence over the Host-level fallback
- No backup target configured = no auto-backup, no errors -- clear messaging in startup logs

## Architecture

**Target resolution priority:**
1. Org-level default target
2. Any org-level target
3. Host-level target (from env vars)
4. None -- skip silently

**New file:** `lib/backup/auto-backup.ts` -- contains `ensureHostBackupTarget()` (startup) and `ensureAutoBackupJob()` (post-deploy)

## Test plan
- [ ] Fresh install: verify `install.sh` prompts for backup storage and writes env vars
- [ ] App startup with `BACKUP_STORAGE_*` set: verify Host-level target auto-created in `backup_target` table
- [ ] App startup without env vars: verify no target created, clean log message
- [ ] Deploy app with volumes + Host target exists: verify backup job auto-created in `backup_job` + `backup_job_app`
- [ ] Deploy app with volumes + org target exists: verify org target used instead of Host
- [ ] Deploy app without volumes: verify no backup job created
- [ ] Re-deploy app that already has backup job: verify no duplicate job created
- [ ] `pnpm typecheck` passes (no new errors)
- [ ] `bash -n install.sh` passes

Closes #35