### PR TITLE
fix(ux): implement inviting empty states across all pages

### DIFF
--- a/app/(app)/activity/activity-feed.tsx
+++ b/app/(app)/activity/activity-feed.tsx
@@ -199,10 +199,13 @@ export function ActivityFeed({ activities: initialActivities, orgId }: ActivityF
 
   if (activities.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <p className="text-sm text-muted-foreground">
-          No activity recorded yet.
-        </p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">No activity yet</p>
+          <p className="text-sm text-muted-foreground">
+            Deployments, configuration changes, and team actions will appear here as they happen.
+          </p>
+        </div>
       </div>
     );
   }

--- a/app/(app)/admin/admin-organizations.tsx
+++ b/app/(app)/admin/admin-organizations.tsx
@@ -40,9 +40,14 @@ export function AdminOrganizations() {
 
   if (orgs.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <Building2 className="size-8 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">No organizations yet.</p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <Building2 className="size-8 text-muted-foreground/50" />
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">No organizations yet</p>
+          <p className="text-sm text-muted-foreground">
+            Organizations are created when users sign up. Once someone creates an account, their organization will appear here.
+          </p>
+        </div>
       </div>
     );
   }

--- a/app/(app)/apps/[...slug]/app-cron.tsx
+++ b/app/(app)/apps/[...slug]/app-cron.tsx
@@ -242,11 +242,18 @@ export function CronManager({ appId, orgId }: Props) {
         </div>
 
         {jobs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-            <Clock className="size-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
-              No cron jobs configured. Add one to run commands or hit URLs on a schedule.
-            </p>
+          <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+            <Clock className="size-8 text-muted-foreground/50" />
+            <div className="text-center space-y-1">
+              <p className="text-sm font-medium">No scheduled jobs</p>
+              <p className="text-sm text-muted-foreground">
+                Add a cron job to run commands or hit URLs on a recurring schedule.
+              </p>
+            </div>
+            <Button size="sm" onClick={openCreate}>
+              <Plus className="mr-1.5 size-4" />
+              Add Job
+            </Button>
           </div>
         ) : (
           <div className="space-y-2">

--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -359,7 +359,8 @@ function PortsManager({
       {ports.length === 0 && !adding ? (
         <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8">
           <p className="text-sm text-muted-foreground">
-            No ports exposed. Container ports are only accessible within the Docker network.
+            No ports exposed to the host. Container ports are accessible within the Docker network by default.
+            Expose a port to access this service directly.
           </p>
         </div>
       ) : ports.length > 0 && (
@@ -1877,10 +1878,16 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
 
         <TabsContent value="deployments" className="pt-4 space-y-4">
           {filteredDeployments.length === 0 && !deploying && !serverRunningDeploy ? (
-            <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-              <p className="text-sm text-muted-foreground">
-                No deployments yet.
-              </p>
+            <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+              <Rocket className="size-8 text-muted-foreground/50" />
+              <div className="text-center space-y-1">
+                <p className="text-sm font-medium">Ready for your first deploy</p>
+                <p className="text-sm text-muted-foreground">
+                  {app.source === "git" && app.autoDeploy
+                    ? "Push to your connected repo to trigger an automatic deploy, or deploy manually."
+                    : "Hit the Deploy button above to get started."}
+                </p>
+              </div>
             </div>
           ) : (
             <div className="space-y-2">
@@ -2218,9 +2225,12 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
 
             {app.domains.length === 0 && !domainOpen ? (
               <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8">
-                <p className="text-sm text-muted-foreground">
-                  No domains configured.
-                </p>
+                <Globe2 className="size-6 text-muted-foreground/50" />
+                <div className="text-center space-y-1">
+                  <p className="text-sm text-muted-foreground">
+                    Add a domain to make this app accessible over the web.
+                  </p>
+                </div>
               </div>
             ) : app.domains.length > 0 && (
               <div className="space-y-2">

--- a/app/(app)/backups/backup-manager.tsx
+++ b/app/(app)/backups/backup-manager.tsx
@@ -710,12 +710,14 @@ export function BackupManager({ orgId, apps }: Props) {
         </div>
 
         {targets.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8">
-            <Cloud className="size-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
-              No storage targets configured. Add a target to start creating
-              backup jobs.
-            </p>
+          <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-8">
+            <Cloud className="size-8 text-muted-foreground/50" />
+            <div className="text-center space-y-1">
+              <p className="text-sm font-medium">Add a storage target to get started</p>
+              <p className="text-sm text-muted-foreground">
+                Connect an S3 bucket, Cloudflare R2, Backblaze B2, or SSH server to store your backups.
+              </p>
+            </div>
             <Button
               size="sm"
               onClick={() => {
@@ -791,13 +793,33 @@ export function BackupManager({ orgId, apps }: Props) {
         </div>
 
         {jobs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8">
-            <Archive className="size-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
-              {targets.length === 0
-                ? "Add a storage target first, then create backup jobs."
-                : "No backup jobs configured. Create one to start protecting your data."}
-            </p>
+          <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-8">
+            <Archive className="size-8 text-muted-foreground/50" />
+            <div className="text-center space-y-1">
+              <p className="text-sm font-medium">
+                {targets.length === 0 ? "Set up a storage target first" : "Protect your data"}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {targets.length === 0
+                  ? "Add a storage target above, then create backup jobs to schedule automatic backups."
+                  : "Create a backup job to automatically back up your app data on a schedule."}
+              </p>
+            </div>
+            {targets.length > 0 && (
+              <Button
+                size="sm"
+                onClick={() => {
+                  resetJobForm();
+                  if (targets.length > 0) {
+                    setNewJobTargetId(targets[0].id);
+                  }
+                  setJobSheetOpen(true);
+                }}
+              >
+                <Plus className="mr-1.5 size-4" />
+                New Job
+              </Button>
+            )}
           </div>
         ) : (
           <div className="space-y-2">

--- a/app/(app)/metrics/org-metrics.tsx
+++ b/app/(app)/metrics/org-metrics.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { Activity, Box, Cpu, HardDrive, MemoryStick, Network, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
 import { formatBytes, formatMemLimit, formatTime } from "@/lib/metrics/format";
@@ -518,9 +519,20 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
 
       {/* Project list with stats */}
       {displayApps.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-          <Activity className="size-8 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">No apps yet.</p>
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+          <Activity className="size-8 text-muted-foreground/50" />
+          <div className="text-center space-y-1">
+            <p className="text-sm font-medium">Metrics will appear here</p>
+            <p className="text-sm text-muted-foreground">
+              Deploy your first app to see CPU, memory, network, and disk usage across your infrastructure.
+            </p>
+          </div>
+          <Button size="sm" asChild>
+            <Link href="/projects">
+              <Box className="mr-1.5 size-4" />
+              Go to Projects
+            </Link>
+          </Button>
         </div>
       ) : (
         <div className="squircle rounded-lg border bg-card overflow-x-auto">

--- a/app/(app)/projects/[...slug]/project-detail.tsx
+++ b/app/(app)/projects/[...slug]/project-detail.tsx
@@ -15,6 +15,9 @@ import {
   RotateCcw,
   Square,
   Layers,
+  Variable,
+  FileText,
+  Activity,
 } from "lucide-react";
 import {
   type AppMetrics as AppMetricsType,
@@ -424,10 +427,16 @@ function ProjectDeployments({ apps, color }: { apps: ProjectApp[]; color: string
 
   if (allDeployments.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <p className="text-sm text-muted-foreground">
-          No deployments yet.
-        </p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <Rocket className="size-8 text-muted-foreground/50" />
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">
+            Ready for your first deploy
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Deploy an app from the Apps tab, or push to a connected repo to trigger an automatic deploy.
+          </p>
+        </div>
       </div>
     );
   }
@@ -577,8 +586,12 @@ function ProjectVariables({ apps, orgId }: { apps: ProjectApp[]; orgId: string }
 
   if (apps.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <p className="text-sm text-muted-foreground">No apps in this project.</p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <Variable className="size-8 text-muted-foreground/50" />
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">No variables to show</p>
+          <p className="text-sm text-muted-foreground">Add an app to this project to manage its environment variables.</p>
+        </div>
       </div>
     );
   }
@@ -626,8 +639,12 @@ function ProjectLogs({ apps, orgId }: { apps: ProjectApp[]; orgId: string }) {
 
   if (apps.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <p className="text-sm text-muted-foreground">No apps in this project.</p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <FileText className="size-8 text-muted-foreground/50" />
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">No logs to show</p>
+          <p className="text-sm text-muted-foreground">Logs appear here once an app is running in this project.</p>
+        </div>
       </div>
     );
   }
@@ -671,8 +688,12 @@ function ProjectMetricsTab({ apps, orgId, projectId }: { apps: ProjectApp[]; org
 
   if (apps.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-        <p className="text-sm text-muted-foreground">No apps in this project.</p>
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+        <Activity className="size-8 text-muted-foreground/50" />
+        <div className="text-center space-y-1">
+          <p className="text-sm font-medium">No metrics to show</p>
+          <p className="text-sm text-muted-foreground">Metrics appear here once an app is running in this project.</p>
+        </div>
       </div>
     );
   }
@@ -1107,10 +1128,15 @@ export function ProjectDetail({
 
         <TabsContent value="apps" className="pt-4">
           {topLevelApps.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-              <p className="text-sm text-muted-foreground">
-                No apps yet. Add your first app to this project.
-              </p>
+            <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+              <div className="text-center space-y-1">
+                <p className="text-sm font-medium">
+                  Add your first app
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Connect a Git repo, Docker image, or Compose file to start deploying.
+                </p>
+              </div>
               <Button size="sm" asChild>
                 <Link href={`/apps/new?project=${project.id}`}>
                   <Plus className="mr-1.5 size-4" />

--- a/app/(app)/projects/page.tsx
+++ b/app/(app)/projects/page.tsx
@@ -86,11 +86,16 @@ export default async function ProjectsPage() {
       </PageToolbar>
 
       {appList.length === 0 && emptyProjects.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
-          <p className="text-sm text-muted-foreground">
-            No projects yet. Create your first project to get started.
-          </p>
-          <Button size="sm" asChild>
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-12">
+          <div className="text-center space-y-1">
+            <p className="text-sm font-medium">
+              Deploy your first app
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Create a project and add apps from a Git repo, Docker image, or Compose file.
+            </p>
+          </div>
+          <Button asChild>
             <Link href="/projects/new">
               <Plus className="mr-1.5 size-4" />
               New Project

--- a/app/(app)/settings/notification-channels.tsx
+++ b/app/(app)/settings/notification-channels.tsx
@@ -73,7 +73,14 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
         </div>
       )}
       {channels.length === 0 && !showForm ? (
-        <div className="border border-dashed border-border rounded-lg p-8 text-center text-muted-foreground"><Bell className="h-8 w-8 mx-auto mb-2 opacity-50" /><p className="text-sm">No notification channels configured.</p><p className="text-xs mt-1">Add an email, webhook, or Slack channel to receive alerts.</p></div>
+        <div className="flex flex-col items-center justify-center gap-4 border border-dashed border-border rounded-lg p-12">
+          <Bell className="size-8 text-muted-foreground/50" />
+          <div className="text-center space-y-1">
+            <p className="text-sm font-medium">Stay in the loop</p>
+            <p className="text-sm text-muted-foreground">Add a notification channel to get alerted on deploy failures, backup issues, and cron errors.</p>
+          </div>
+          <Button size="sm" onClick={() => setShowForm(true)} className="squircle"><Plus className="h-4 w-4 mr-1" />Add channel</Button>
+        </div>
       ) : (
         <div className="space-y-2">{channels.map(ch => (
           <div key={ch.id} className="flex items-center justify-between border border-border rounded-lg p-3 bg-card">


### PR DESCRIPTION
## Summary

- Audited all pages for empty states and replaced generic "No X yet" messages with clear, inviting copy and actionable CTAs
- Every empty state now tells users what will appear and how to get there -- invitations, not dead ends
- Added contextual icons, descriptive subtitles, and inline action buttons where appropriate

### Pages updated (9 files)

| Page | Before | After |
|------|--------|-------|
| Projects list | "No projects yet" | "Deploy your first app" + description of Git/Docker/Compose options |
| Project > Apps tab | "No apps yet" | "Add your first app" + connect sources description |
| Project > Deployments | "No deployments yet" | "Ready for your first deploy" + push-to-deploy hint |
| Project > Variables | "No apps in this project" | Icon + "Add an app to manage variables" |
| Project > Logs | "No apps in this project" | Icon + "Logs appear once an app is running" |
| Project > Metrics | "No apps in this project" | Icon + "Metrics appear once an app is running" |
| App > Deployments | "No deployments yet" | Contextual: auto-deploy hint for Git apps, "Hit Deploy" for others |
| App > Domains | "No domains configured" | "Add a domain to make this app accessible" |
| App > Cron | "No cron jobs configured" | "No scheduled jobs" + inline Add Job CTA |
| Backups > Targets | Generic message | "Connect an S3 bucket, R2, B2, or SSH server" |
| Backups > Jobs | Generic message | "Protect your data" + inline New Job CTA (only when targets exist) |
| Notifications | "No notification channels" | "Stay in the loop" + Add channel CTA |
| Org Metrics | "No apps yet" | "Deploy your first app to see metrics" + link to Projects |
| Activity Feed | "No activity recorded" | "Deployments, changes, and team actions will appear here" |
| Admin > Organizations | "No organizations yet" | Explains how orgs are created via signup |

## Test plan

- [ ] Visit each page listed above with no data present and verify the empty state copy and CTA
- [ ] Confirm CTA buttons link to the correct destinations
- [ ] Verify no visual regressions on pages that already have data

Closes #36