### PR TITLE
fix(ux): implement consistent error states across the app

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -211,7 +211,7 @@ function StatusBadge({ status }: { status: string }) {
     case "error":
       return (
         <Badge className="border-transparent bg-status-error-muted text-status-error">
-          Error
+          Crashed
         </Badge>
       );
     default:
@@ -973,7 +973,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
         if (data.success) {
           toast.success(`Deployed in ${data.durationMs ? Math.round(data.durationMs / 1000) + "s" : "---"}`);
         } else {
-          toast.error("Deployment failed");
+          toast.error(data.error || "Deployment failed");
         }
         if (data.deploymentId) {
           setViewingLogId(data.deploymentId);
@@ -1017,7 +1017,17 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
               if (dep.status === "success") {
                 toast.success(`Deployed in ${dep.durationMs ? Math.round(dep.durationMs / 1000) + "s" : "---"}`);
               } else {
-                toast.error("Deployment failed");
+                // Extract last error line from deploy log for the toast
+                const errorLine = dep.log
+                  ?.split("\n")
+                  .reverse()
+                  .find((l: string) => l.includes("ERROR") || l.includes("FATAL") || l.includes("failed"));
+                const cleaned = errorLine
+                  ?.replace(/^\[.*?\]\s*/, "")
+                  .replace(/x-access-token:[^\s@]+/g, "***")
+                  .replace(/ghs_[A-Za-z0-9]+/g, "***")
+                  .trim();
+                toast.error(cleaned || "Deployment failed");
               }
               setViewingLogId(dep.id);
               stopped = true;
@@ -1299,11 +1309,11 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
               stageQueue.push({ stage, status });
               processStageQueue();
             } else if (eventType === "done") {
-              const result = data as { deploymentId: string; success: boolean; durationMs: number };
+              const result = data as { deploymentId: string; success: boolean; durationMs: number; error?: string };
               if (result.success) {
                 toast.success(`Deployed in ${result.durationMs}ms`);
               } else {
-                toast.error("Deployment failed");
+                toast.error(result.error || "Deployment failed");
               }
               if (result.deploymentId) {
                 setViewingLogId(result.deploymentId);
@@ -1320,7 +1330,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
       if (err instanceof Error && err.name === "AbortError") {
         toast.info("Deployment aborted");
       } else {
-        toast.error("Deployment failed");
+        toast.error(err instanceof Error ? err.message : "Deployment failed");
       }
     } finally {
       setDeploying(false);
@@ -1473,9 +1483,13 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={async () => {
-                      const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/restart`, { method: "POST" });
-                      const data = await res.json();
-                      data.success ? toast.success("Restarted") : toast.error("Restart failed");
+                      try {
+                        const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/restart`, { method: "POST" });
+                        const data = await res.json();
+                        data.success ? toast.success("Restarted") : toast.error(data.error || "Restart failed");
+                      } catch (err) {
+                        toast.error(err instanceof Error ? err.message : "Restart failed");
+                      }
                       router.refresh();
                     }}
                   >
@@ -1485,9 +1499,13 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
                     onClick={async () => {
-                      const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/stop`, { method: "POST" });
-                      const data = await res.json();
-                      data.success ? toast.success("Stopped") : toast.error("Stop failed");
+                      try {
+                        const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/stop`, { method: "POST" });
+                        const data = await res.json();
+                        data.success ? toast.success("Stopped") : toast.error(data.error || "Stop failed");
+                      } catch (err) {
+                        toast.error(err instanceof Error ? err.message : "Stop failed");
+                      }
                       router.refresh();
                     }}
                   >
@@ -1661,15 +1679,25 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
           <div className="flex items-center gap-2 rounded-lg bg-status-error-muted px-4 py-2.5 text-sm text-status-error">
             <X className="size-4 shrink-0" />
             <span className="truncate">{cleaned || "App crashed — check the deploy log for details"}</span>
-            {failedDeploy && (
+            <div className="flex items-center gap-2 shrink-0">
+              {failedDeploy && (
+                <button
+                  type="button"
+                  onClick={() => { setActiveTab("deployments"); setViewingLogId(failedDeploy.id); }}
+                  className="text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
+                >
+                  View log
+                </button>
+              )}
               <button
                 type="button"
-                onClick={() => { setActiveTab("deployments"); setViewingLogId(failedDeploy.id); }}
-                className="shrink-0 text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
+                disabled={deploying}
+                onClick={handleDeploy}
+                className="text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
               >
-                View log
+                Retry
               </button>
-            )}
+            </div>
           </div>
         );
       })()}

--- a/app/(app)/apps/[...slug]/app-metrics.tsx
+++ b/app/(app)/apps/[...slug]/app-metrics.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
-import { Activity, Container, Cpu, MemoryStick, Network, Loader2 } from "lucide-react";
+import { Activity, AlertTriangle, Container, Cpu, MemoryStick, Network, Loader2, RefreshCw } from "lucide-react";
 import { ChartCard } from "@/components/app-status";
 import { formatBytes, formatMemLimit, formatBytesRate, formatTime } from "@/lib/metrics/format";
 import { CHART_COLORS, TIME_RANGES, type TimeRange } from "@/lib/metrics/constants";
@@ -104,7 +104,7 @@ function ContainerTable({ containers }: { containers: ContainerPoint[] }) {
 export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
   const [timeRange, setTimeRange] = useState<TimeRange>("1h");
 
-  const { points, containers, connected, loading } = useMetricsStream({
+  const { points, containers, connected, loading, reconnecting, error } = useMetricsStream({
     historyUrl: `/api/v1/organizations/${orgId}/apps/${appId}/stats/history`,
     streamUrl: `/api/v1/organizations/${orgId}/apps/${appId}/stats/stream${environmentName ? "?environment=" + environmentName : ""}`,
     timeRange,
@@ -140,6 +140,19 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
       };
     });
   }, [points]);
+
+  // Error state -- metrics service unreachable
+  if (error && !connected && !loading && points.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
+        <AlertTriangle className="size-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Metrics unavailable</p>
+        <p className="text-xs text-muted-foreground max-w-xs text-center">
+          Could not connect to the metrics service. This may be a temporary issue.
+        </p>
+      </div>
+    );
+  }
 
   // Loading state -- show if still loading history and not connected
   if (loading && !connected) {
@@ -187,9 +200,13 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
           ))}
         </div>
         <div className="flex items-center gap-2">
-          <span className={`size-2 rounded-full ${connected ? "bg-status-success" : "bg-status-neutral"}`} />
+          {reconnecting ? (
+            <RefreshCw className="size-3 text-status-warning animate-spin" />
+          ) : (
+            <span className={`size-2 rounded-full ${connected ? "bg-status-success" : "bg-status-neutral"}`} />
+          )}
           <span className="text-xs text-muted-foreground">
-            {connected ? "Live" : "Historical"}
+            {reconnecting ? "Reconnecting..." : connected ? "Live" : "Historical"}
           </span>
         </div>
       </div>

--- a/app/(app)/apps/new/new-app-flow.tsx
+++ b/app/(app)/apps/new/new-app-flow.tsx
@@ -476,7 +476,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
       } else {
         router.push(`/apps/${app.name}`);
       }
-    } catch { toast.error("Failed to create app"); }
+    } catch (err) { toast.error(err instanceof Error ? err.message : "Failed to create app"); }
     finally { setCreating(false); }
   }
 

--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60dvh] items-center justify-center p-4">
+      <div className="text-center space-y-4 max-w-sm">
+        <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-status-error-muted">
+          <AlertTriangle className="size-5 text-status-error" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="text-sm text-muted-foreground">
+            {error.message && error.message !== "An error occurred in the Server Components render."
+              ? error.message
+              : "An unexpected error occurred. Please try again or contact support if the problem persists."}
+          </p>
+        </div>
+        {error.digest && (
+          <p className="text-xs text-muted-foreground font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <Button onClick={reset} variant="outline" size="sm">
+          <RotateCcw className="mr-1.5 size-3.5" />
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/metrics/org-metrics.tsx
+++ b/app/(app)/metrics/org-metrics.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import { Activity, Box, Cpu, HardDrive, MemoryStick, Network, Loader2 } from "lucide-react";
+import { Activity, Box, Cpu, HardDrive, MemoryStick, Network, Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
@@ -88,7 +88,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
     ? `/api/v1/admin/stats/stream`
     : `/api/v1/organizations/${orgId}/stats/stream`;
 
-  const { points, meta, connected, loading } = useMetricsStream({
+  const { points, meta, connected, loading, reconnecting } = useMetricsStream({
     historyUrl,
     streamUrl,
     timeRange,
@@ -190,8 +190,14 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
           ))}
         </div>
         <div className="flex items-center gap-2">
-          <span className={`size-2 rounded-full ${loading ? "bg-status-neutral animate-pulse" : connected ? "bg-status-success" : "bg-status-neutral"}`} />
-          <span className="text-xs text-muted-foreground">Live</span>
+          {reconnecting ? (
+            <RefreshCw className="size-3 text-status-warning animate-spin" />
+          ) : (
+            <span className={`size-2 rounded-full ${loading ? "bg-status-neutral animate-pulse" : connected ? "bg-status-success" : "bg-status-neutral"}`} />
+          )}
+          <span className="text-xs text-muted-foreground">
+            {reconnecting ? "Reconnecting..." : connected ? "Live" : loading ? "Loading..." : "Disconnected"}
+          </span>
         </div>
       </div>
 

--- a/app/(app)/projects/[...slug]/project-detail.tsx
+++ b/app/(app)/projects/[...slug]/project-detail.tsx
@@ -872,8 +872,8 @@ export function ProjectDetail({
         const data = await res.json().catch(() => ({}));
         toast.error(data.error || "Deploy failed");
       }
-    } catch {
-      toast.error("Deploy failed");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Deploy failed");
     } finally {
       setDeploying(false);
     }

--- a/app/(app)/projects/[...slug]/project-metrics.tsx
+++ b/app/(app)/projects/[...slug]/project-metrics.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
-import { Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { Cpu, MemoryStick, Network } from "lucide-react";
 import { ChartCard } from "@/components/app-status";
 import { formatBytes, formatTime } from "@/lib/metrics/format";
@@ -56,7 +56,7 @@ function NetTooltip(props: CustomTooltipProps) {
 export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) {
   const [timeRange, setTimeRange] = useState<TimeRange>("1h");
 
-  const { points, loading } = useMetricsStream({
+  const { points, loading, error, connected } = useMetricsStream({
     historyUrl: `/api/v1/organizations/${orgId}/projects/${projectId}/stats/history`,
     streamUrl: `/api/v1/organizations/${orgId}/projects/${projectId}/stats/stream`,
     timeRange,
@@ -66,6 +66,18 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
     () => points.map((p) => ({ ...p, time: formatTime(p.timestamp) })),
     [points],
   );
+
+  if (error && !connected && !loading && points.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-12">
+        <AlertTriangle className="size-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Metrics unavailable</p>
+        <p className="text-xs text-muted-foreground max-w-xs text-center">
+          Could not connect to the metrics service. This may be a temporary issue.
+        </p>
+      </div>
+    );
+  }
 
   if (loading && points.length === 0) {
     return (

--- a/app/(app)/settings/notification-channels.tsx
+++ b/app/(app)/settings/notification-channels.tsx
@@ -41,15 +41,15 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
       const res = await fetch(`/api/v1/organizations/${orgId}/notifications`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, type, config, enabled: true }) });
       if (!res.ok) { const d = await res.json(); toast.error(d.error || "Failed"); return; }
       toast.success("Channel created"); reset(); load();
-    } catch { toast.error("Failed"); } finally { setSaving(false); }
+    } catch (err) { toast.error(err instanceof Error ? err.message : "Failed to save channel"); } finally { setSaving(false); }
   };
 
   const handleToggle = async (id: string, enabled: boolean) => {
-    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }); if (res.ok) setChannels(prev => prev.map(c => c.id === id ? { ...c, enabled } : c)); } catch { toast.error("Failed"); }
+    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }); if (res.ok) setChannels(prev => prev.map(c => c.id === id ? { ...c, enabled } : c)); } catch { toast.error("Failed to toggle channel"); }
   };
 
   const handleDelete = async (id: string) => {
-    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "DELETE" }); if (res.ok) { setChannels(prev => prev.filter(c => c.id !== id)); toast.success("Deleted"); } } catch { toast.error("Failed"); }
+    try { const res = await fetch(`/api/v1/organizations/${orgId}/notifications/${id}`, { method: "DELETE" }); if (res.ok) { setChannels(prev => prev.filter(c => c.id !== id)); toast.success("Deleted"); } } catch { toast.error("Failed to delete channel"); }
   };
 
   if (loading) return <div className="flex items-center gap-2 text-muted-foreground py-8"><Loader2 className="h-4 w-4 animate-spin" />Loading...</div>;

--- a/app/(public)/onboarding/page.tsx
+++ b/app/(public)/onboarding/page.tsx
@@ -37,8 +37,8 @@ export default function OnboardingPage() {
       }
       toast.success("Account created");
       router.push("/projects");
-    } catch {
-      toast.error("Something went wrong");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create account");
     } finally {
       setLoading(false);
     }

--- a/components/app-status.tsx
+++ b/components/app-status.tsx
@@ -64,7 +64,12 @@ export function StatusIndicator({
       </span>
     );
   }
-  if (status === "error") return <span className="text-sm text-status-error shrink-0">Error</span>;
+  if (status === "error") return (
+    <span className="flex items-center gap-1.5 text-sm text-status-error shrink-0">
+      <span className="size-2 rounded-full bg-status-error" />
+      Crashed
+    </span>
+  );
   if (status === "deploying") return <span className="text-sm text-status-info animate-pulse shrink-0">Deploying</span>;
   return <span className="text-sm text-status-neutral shrink-0">Stopped</span>;
 }

--- a/components/log-viewer.tsx
+++ b/components/log-viewer.tsx
@@ -454,7 +454,7 @@ export function LogViewer({ streamUrl, historyUrl, maxLines = 1000 }: LogViewerP
         <div className="flex items-center gap-2">
           <span className={`size-2 rounded-full ${connected ? "bg-status-success" : timedOut ? "bg-status-warning" : "bg-status-error"}`} />
           <span className="text-xs text-muted-foreground">
-            {connected ? "Streaming" : timedOut ? "Paused" : "Disconnected"}
+            {connected ? "Streaming" : timedOut ? "Paused" : lines.length > 0 ? "Reconnecting..." : "Disconnected"}
           </span>
           {logSource && (
             <span className="inline-flex items-center gap-1 text-xs text-muted-foreground border border-zinc-800 rounded px-1.5 py-0.5">

--- a/lib/hooks/use-metrics-stream.ts
+++ b/lib/hooks/use-metrics-stream.ts
@@ -39,6 +39,10 @@ type UseMetricsStreamReturn = {
   connected: boolean;
   /** Whether historical data is still loading */
   loading: boolean;
+  /** Whether the stream is reconnecting after a disconnect */
+  reconnecting: boolean;
+  /** Error message when historical fetch or stream fails */
+  error: string | null;
 };
 
 export function useMetricsStream(
@@ -51,6 +55,9 @@ export function useMetricsStream(
   const [meta, setMeta] = useState<MetricsMeta | null>(null);
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wasConnectedRef = useRef(false);
 
   const visKey = useVisibilityKey();
 
@@ -79,8 +86,11 @@ export function useMetricsStream(
           setPoints(data.points ?? []);
         }
       })
-      .catch(() => {
-        if (!cancelled) setPoints([]);
+      .catch((err) => {
+        if (!cancelled) {
+          setPoints([]);
+          setError(err instanceof Error ? err.message : "Failed to load metrics history");
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -99,7 +109,12 @@ export function useMetricsStream(
 
     const es = new EventSource(streamUrl);
 
-    es.onopen = () => setConnected(true);
+    es.onopen = () => {
+      setConnected(true);
+      setReconnecting(false);
+      setError(null);
+      wasConnectedRef.current = true;
+    };
 
     function handlePoint(event: MessageEvent) {
       try {
@@ -154,12 +169,18 @@ export function useMetricsStream(
       es.close();
     });
 
-    es.onerror = () => setConnected(false);
+    es.onerror = () => {
+      setConnected(false);
+      // If we were previously connected, the browser will auto-retry -- show reconnecting
+      if (wasConnectedRef.current) {
+        setReconnecting(true);
+      }
+    };
 
     return () => {
       es.close();
     };
   }, [streamUrl, visKey, maxPoints]);
 
-  return { points, containers, meta, connected, loading };
+  return { points, containers, meta, connected, loading, reconnecting, error };
 }


### PR DESCRIPTION
## Summary
- Audited error handling patterns across the entire app (toast.error, catch blocks, SSE reconnection, error boundaries)
- API errors now surface actual messages from the response, not generic text like "Failed" or "Something went wrong"
- Metrics pages show graceful "Metrics unavailable" fallback when cAdvisor/Redis is down, instead of a hanging spinner
- SSE streams show "Reconnecting..." during reconnection instead of silently dropping indicators
- Deploy failure toasts include the actual error from the stream/log
- Error banner on crashed apps includes an inline "Retry" button
- StatusIndicator shows "Crashed" with a red dot for error state (was just "Error" text)
- Added `app/(app)/error.tsx` as a catch-all error boundary for authenticated routes with actionable UI

## Changes
| File | What changed |
|------|-------------|
| `app/(app)/error.tsx` | **New** -- scoped error boundary with AlertTriangle icon, error message, digest ID, and "Try again" button |
| `lib/hooks/use-metrics-stream.ts` | Expose `reconnecting` and `error` state from the SSE hook |
| `app/(app)/apps/[...slug]/app-metrics.tsx` | Show "Metrics unavailable" fallback + "Reconnecting..." indicator |
| `app/(app)/metrics/org-metrics.tsx` | Show "Reconnecting..." / "Disconnected" instead of always "Live" |
| `app/(app)/projects/[...slug]/project-metrics.tsx` | Show "Metrics unavailable" fallback on error |
| `app/(app)/apps/[...slug]/app-detail.tsx` | Deploy failure toasts with actual error; Retry button in error banner; "Crashed" badge; try/catch on restart/stop actions |
| `components/app-status.tsx` | StatusIndicator shows "Crashed" with red dot for error state |
| `components/log-viewer.tsx` | Show "Reconnecting..." when stream disconnects mid-session |
| `app/(public)/onboarding/page.tsx` | Replace "Something went wrong" with actual error messages |
| `app/(app)/apps/new/new-app-flow.tsx` | Surface actual error from catch block |
| `app/(app)/settings/notification-channels.tsx` | Replace bare "Failed" toasts with context |
| `app/(app)/projects/[...slug]/project-detail.tsx` | Surface actual deploy error message |

## Test plan
- [ ] Trigger a deploy failure (e.g., bad Dockerfile) and verify the toast shows the actual error, not just "Deployment failed"
- [ ] Stop the cAdvisor/metrics service and verify the metrics tab shows "Metrics unavailable" instead of an infinite spinner
- [ ] Disconnect network briefly while on metrics page and verify "Reconnecting..." appears, then recovers
- [ ] Navigate to an app with `status: error` and verify the error banner shows "Crashed" badge, error message, and both "View log" and "Retry" buttons
- [ ] Throw an error in a server component to verify the `app/(app)/error.tsx` boundary renders with the error message and "Try again" button
- [ ] Test the log viewer: disconnect and verify it shows "Reconnecting..." instead of "Disconnected" when there are existing log lines

Closes #37