### PR TITLE
fix(charts): widen Y-axis for readable byte labels

### DIFF
--- a/app/(app)/apps/[...slug]/app-metrics.tsx
+++ b/app/(app)/apps/[...slug]/app-metrics.tsx
@@ -254,6 +254,7 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
           categories={["memory"]}
           colors={[TREMOR_METRIC_COLORS.memory]}
           valueFormatter={(v) => formatBytes(v)}
+          yAxisWidth={65}
           showLegend={false}
           showAnimation={false}
           curveType="monotone"
@@ -273,6 +274,7 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
           categories={["networkRxRate", "networkTxRate"]}
           colors={[TREMOR_METRIC_COLORS.networkRxRate, TREMOR_METRIC_COLORS.networkTxRate]}
           valueFormatter={(v) => formatBytesRate(v)}
+          yAxisWidth={75}
           showLegend={false}
           showAnimation={false}
           curveType="monotone"

--- a/app/(app)/metrics/org-metrics.tsx
+++ b/app/(app)/metrics/org-metrics.tsx
@@ -338,6 +338,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                 categories={["memory"]}
                 colors={[TREMOR_METRIC_COLORS.memory]}
                 valueFormatter={(v) => formatBytes(v)}
+                yAxisWidth={65}
                 showLegend={false}
                 showAnimation={false}
                 curveType="monotone"
@@ -358,6 +359,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                 categories={["networkRx", "networkTx"]}
                 colors={[TREMOR_METRIC_COLORS.networkRx, TREMOR_METRIC_COLORS.networkTx]}
                 valueFormatter={(v) => formatBytes(v)}
+                yAxisWidth={65}
                 showLegend={false}
                 showAnimation={false}
                 curveType="monotone"
@@ -378,6 +380,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                 categories={["diskTotal"]}
                 colors={[TREMOR_METRIC_COLORS.diskTotal]}
                 valueFormatter={(v) => formatBytes(v)}
+                yAxisWidth={65}
                 showLegend={false}
                 showAnimation={false}
                 curveType="monotone"

--- a/app/(app)/projects/[...slug]/project-metrics.tsx
+++ b/app/(app)/projects/[...slug]/project-metrics.tsx
@@ -120,6 +120,7 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
           categories={["memory"]}
           colors={[TREMOR_METRIC_COLORS.memory]}
           valueFormatter={(v) => formatBytes(v)}
+          yAxisWidth={65}
           showLegend={false}
           showAnimation={false}
           curveType="monotone"
@@ -137,6 +138,7 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
           categories={["networkRx", "networkTx"]}
           colors={[TREMOR_METRIC_COLORS.networkRx, TREMOR_METRIC_COLORS.networkTx]}
           valueFormatter={(v) => formatBytes(v)}
+          yAxisWidth={65}
           showLegend={false}
           showAnimation={false}
           curveType="monotone"


### PR DESCRIPTION
## Summary

- Y-axis labels on memory, network, and disk charts were garbled after the Recharts to Tremor migration
- Root cause: Tremor's default `yAxisWidth` (56px) is too narrow for formatted byte strings like "248.3 MB"
- Added `yAxisWidth={65}` to all byte-formatted charts and `yAxisWidth={75}` to network rate charts (which append "/s")
- The `valueFormatter` prop was already correctly wired — only the axis width needed fixing

## Files changed

- `app/(app)/metrics/org-metrics.tsx` — org-level memory, network, disk charts
- `app/(app)/apps/[...slug]/app-metrics.tsx` — app-level memory and network rate charts
- `app/(app)/projects/[...slug]/project-metrics.tsx` — project-level memory and network charts

## Test plan

- [ ] Verify memory chart Y-axis shows clean labels like "128 MB", "256 MB"
- [ ] Verify disk chart Y-axis shows clean labels like "1.2 GB"
- [ ] Verify network chart Y-axis shows clean labels, including "/s" suffix on app-level rate charts
- [ ] Confirm CPU charts are unaffected (they use short "0.0%" labels, no width change needed)