### PR TITLE
fix(charts): visual polish — gradients, colors, axis formatting, network rates

### DIFF
--- a/app/(app)/apps/[...slug]/app-metrics.tsx
+++ b/app/(app)/apps/[...slug]/app-metrics.tsx
@@ -5,9 +5,9 @@ import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
 import { Activity, AlertTriangle, Container, Cpu, MemoryStick, Network, Loader2, RefreshCw } from "lucide-react";
 import { ChartCard } from "@/components/app-status";
-import { formatBytes, formatMemLimit, formatBytesRate, formatTime } from "@/lib/metrics/format";
+import { formatBytes, formatBytesShort, formatBytesRateShort, formatMemLimit, formatBytesRate, formatTime } from "@/lib/metrics/format";
 import { CHART_COLORS, TIME_RANGES, type TimeRange } from "@/lib/metrics/constants";
-import { TREMOR_METRIC_COLORS, MetricsTooltip } from "@/components/metrics-chart";
+import { TREMOR_METRIC_COLORS, CHART_DEFAULTS, MetricsTooltip } from "@/components/metrics-chart";
 import type { ContainerPoint } from "@/lib/metrics/types";
 import { useMetricsStream } from "@/lib/hooks/use-metrics-stream";
 
@@ -242,17 +242,13 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
       {/* CPU Chart */}
       <ChartCard title="CPU Usage" icon={Cpu}>
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartData}
           index="time"
           categories={["cpu"]}
           colors={[TREMOR_METRIC_COLORS.cpu]}
-          valueFormatter={(v) => `${v.toFixed(2)}%`}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          valueFormatter={(v) => `${v.toFixed(1)}%`}
           customTooltip={CpuTooltip}
         />
       </ChartCard>
@@ -265,18 +261,13 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
           </p>
         )}
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartData}
           index="time"
           categories={["memory"]}
           colors={[TREMOR_METRIC_COLORS.memory]}
-          valueFormatter={(v) => formatBytes(v)}
-          yAxisWidth={65}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          valueFormatter={(v) => formatBytesShort(v)}
           maxValue={latestMemoryLimit > 0 ? latestMemoryLimit * 1.1 : undefined}
           customTooltip={MemTooltip}
         />
@@ -285,18 +276,13 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
       {/* Network I/O Chart */}
       <ChartCard title="Network I/O" icon={Network}>
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartData}
           index="time"
           categories={["networkRxRate", "networkTxRate"]}
           colors={[TREMOR_METRIC_COLORS.networkRxRate, TREMOR_METRIC_COLORS.networkTxRate]}
-          valueFormatter={(v) => formatBytesRate(v)}
-          yAxisWidth={75}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          valueFormatter={(v) => formatBytesRateShort(v)}
           customTooltip={NetTooltip}
         />
       </ChartCard>

--- a/app/(app)/metrics/org-metrics.tsx
+++ b/app/(app)/metrics/org-metrics.tsx
@@ -6,11 +6,11 @@ import { Activity, Box, Cpu, HardDrive, MemoryStick, Network, Loader2, RefreshCw
 import { Button } from "@/components/ui/button";
 import { AreaChart } from "@tremor/react";
 import type { CustomTooltipProps } from "@tremor/react";
-import { formatBytes, formatMemLimit, formatTime } from "@/lib/metrics/format";
+import { formatBytes, formatBytesShort, formatBytesRate, formatBytesRateShort, formatMemLimit, formatTime } from "@/lib/metrics/format";
 import { CHART_COLORS, type TimeRange } from "@/lib/metrics/constants";
 import { useMetricsStream } from "@/lib/hooks/use-metrics-stream";
 import { Sparkline } from "@/components/app-metrics-card";
-import { TREMOR_METRIC_COLORS, MetricsTooltip } from "@/components/metrics-chart";
+import { TREMOR_METRIC_COLORS, CHART_DEFAULTS, MetricsTooltip } from "@/components/metrics-chart";
 import type { SystemInfo, DiskUsage } from "@/lib/docker/client";
 
 type AppSummary = {
@@ -62,8 +62,8 @@ function NetTooltip(props: CustomTooltipProps) {
   return (
     <MetricsTooltip
       {...props}
-      valueFormatter={(v: number) => formatBytes(v)}
-      categoryLabels={{ networkRx: "\u2193 Received", networkTx: "\u2191 Sent" }}
+      valueFormatter={(v: number) => formatBytesRate(v)}
+      categoryLabels={{ networkRxRate: "\u2193 Received", networkTxRate: "\u2191 Sent" }}
     />
   );
 }
@@ -157,9 +157,24 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
     return counts;
   }, [displayApps]);
 
-  // Memoized chart data
+  // Memoized chart data with computed network rates (delta bytes / delta seconds)
   const chartPoints = useMemo(
-    () => points.map((p) => ({ ...p, time: formatTime(p.timestamp) })),
+    () =>
+      points.map((p, i) => {
+        let networkRxRate = 0;
+        let networkTxRate = 0;
+        if (i > 0) {
+          const prev = points[i - 1];
+          const dtSec = (p.timestamp - prev.timestamp) / 1000;
+          if (dtSec > 0) {
+            const rxDelta = p.networkRx - prev.networkRx;
+            const txDelta = p.networkTx - prev.networkTx;
+            networkRxRate = Math.max(0, rxDelta / dtSec);
+            networkTxRate = Math.max(0, txDelta / dtSec);
+          }
+        }
+        return { ...p, time: formatTime(p.timestamp), networkRxRate, networkTxRate };
+      }),
     [points],
   );
 
@@ -319,15 +334,13 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </div>
             <div className="p-4">
               <AreaChart
+                {...CHART_DEFAULTS}
                 className="h-[180px]"
                 data={chartPoints}
                 index="time"
                 categories={["cpu"]}
                 colors={[TREMOR_METRIC_COLORS.cpu]}
                 valueFormatter={(v) => `${v.toFixed(1)}%`}
-                showLegend={false}
-                showAnimation={false}
-                curveType="monotone"
                 customTooltip={CpuTooltip}
               />
             </div>
@@ -339,16 +352,13 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </div>
             <div className="p-4">
               <AreaChart
+                {...CHART_DEFAULTS}
                 className="h-[180px]"
                 data={chartPoints}
                 index="time"
                 categories={["memory"]}
                 colors={[TREMOR_METRIC_COLORS.memory]}
-                valueFormatter={(v) => formatBytes(v)}
-                yAxisWidth={65}
-                showLegend={false}
-                showAnimation={false}
-                curveType="monotone"
+                valueFormatter={(v) => formatBytesShort(v)}
                 customTooltip={MemTooltip}
               />
             </div>
@@ -360,16 +370,13 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </div>
             <div className="p-4">
               <AreaChart
+                {...CHART_DEFAULTS}
                 className="h-[180px]"
                 data={chartPoints}
                 index="time"
-                categories={["networkRx", "networkTx"]}
-                colors={[TREMOR_METRIC_COLORS.networkRx, TREMOR_METRIC_COLORS.networkTx]}
-                valueFormatter={(v) => formatBytes(v)}
-                yAxisWidth={65}
-                showLegend={false}
-                showAnimation={false}
-                curveType="monotone"
+                categories={["networkRxRate", "networkTxRate"]}
+                colors={[TREMOR_METRIC_COLORS.networkRxRate, TREMOR_METRIC_COLORS.networkTxRate]}
+                valueFormatter={(v) => formatBytesRateShort(v)}
                 customTooltip={NetTooltip}
               />
             </div>
@@ -381,16 +388,13 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </div>
             <div className="p-4">
               <AreaChart
+                {...CHART_DEFAULTS}
                 className="h-[180px]"
                 data={chartPoints}
                 index="time"
                 categories={["diskTotal"]}
                 colors={[TREMOR_METRIC_COLORS.diskTotal]}
-                valueFormatter={(v) => formatBytes(v)}
-                yAxisWidth={65}
-                showLegend={false}
-                showAnimation={false}
-                curveType="monotone"
+                valueFormatter={(v) => formatBytesShort(v)}
                 customTooltip={DiskTooltip}
               />
             </div>

--- a/app/(app)/projects/[...slug]/project-metrics.tsx
+++ b/app/(app)/projects/[...slug]/project-metrics.tsx
@@ -6,9 +6,9 @@ import type { CustomTooltipProps } from "@tremor/react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { Cpu, MemoryStick, Network } from "lucide-react";
 import { ChartCard } from "@/components/app-status";
-import { formatBytes, formatTime } from "@/lib/metrics/format";
+import { formatBytes, formatBytesShort, formatBytesRate, formatBytesRateShort, formatTime } from "@/lib/metrics/format";
 import { TIME_RANGES, type TimeRange } from "@/lib/metrics/constants";
-import { TREMOR_METRIC_COLORS, MetricsTooltip } from "@/components/metrics-chart";
+import { TREMOR_METRIC_COLORS, CHART_DEFAULTS, MetricsTooltip } from "@/components/metrics-chart";
 import { useMetricsStream } from "@/lib/hooks/use-metrics-stream";
 
 type AppInfo = {
@@ -27,7 +27,7 @@ function CpuTooltip(props: CustomTooltipProps) {
   return (
     <MetricsTooltip
       {...props}
-      valueFormatter={(v) => `${v.toFixed(2)}%`}
+      valueFormatter={(v) => `${v.toFixed(1)}%`}
       categoryLabels={{ cpu: "CPU" }}
     />
   );
@@ -47,8 +47,8 @@ function NetTooltip(props: CustomTooltipProps) {
   return (
     <MetricsTooltip
       {...props}
-      valueFormatter={(v) => formatBytes(v)}
-      categoryLabels={{ networkRx: "Received", networkTx: "Sent" }}
+      valueFormatter={(v) => formatBytesRate(v)}
+      categoryLabels={{ networkRxRate: "Received", networkTxRate: "Sent" }}
     />
   );
 }
@@ -62,8 +62,24 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
     timeRange,
   });
 
+  // Compute network rates from cumulative counters (delta bytes / delta seconds)
   const chartPoints = useMemo(
-    () => points.map((p) => ({ ...p, time: formatTime(p.timestamp) })),
+    () =>
+      points.map((p, i) => {
+        let networkRxRate = 0;
+        let networkTxRate = 0;
+        if (i > 0) {
+          const prev = points[i - 1];
+          const dtSec = (p.timestamp - prev.timestamp) / 1000;
+          if (dtSec > 0) {
+            const rxDelta = p.networkRx - prev.networkRx;
+            const txDelta = p.networkTx - prev.networkTx;
+            networkRxRate = Math.max(0, rxDelta / dtSec);
+            networkTxRate = Math.max(0, txDelta / dtSec);
+          }
+        }
+        return { ...p, time: formatTime(p.timestamp), networkRxRate, networkTxRate };
+      }),
     [points],
   );
 
@@ -109,53 +125,39 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
 
       <ChartCard title="CPU" icon={Cpu}>
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartPoints}
           index="time"
           categories={["cpu"]}
           colors={[TREMOR_METRIC_COLORS.cpu]}
-          valueFormatter={(v) => `${v.toFixed(2)}%`}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          valueFormatter={(v) => `${v.toFixed(1)}%`}
           customTooltip={CpuTooltip}
         />
       </ChartCard>
 
       <ChartCard title="Memory" icon={MemoryStick}>
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartPoints}
           index="time"
           categories={["memory"]}
           colors={[TREMOR_METRIC_COLORS.memory]}
-          valueFormatter={(v) => formatBytes(v)}
-          yAxisWidth={65}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          valueFormatter={(v) => formatBytesShort(v)}
           customTooltip={MemTooltip}
         />
       </ChartCard>
 
       <ChartCard title="Network" icon={Network}>
         <AreaChart
+          {...CHART_DEFAULTS}
           className="h-[200px]"
           data={chartPoints}
           index="time"
-          categories={["networkRx", "networkTx"]}
-          colors={[TREMOR_METRIC_COLORS.networkRx, TREMOR_METRIC_COLORS.networkTx]}
-          valueFormatter={(v) => formatBytes(v)}
-          yAxisWidth={65}
-          showLegend={false}
-          showAnimation={false}
-          curveType="monotone"
-          autoMinValue={false}
-          minValue={0}
+          categories={["networkRxRate", "networkTxRate"]}
+          colors={[TREMOR_METRIC_COLORS.networkRxRate, TREMOR_METRIC_COLORS.networkTxRate]}
+          valueFormatter={(v) => formatBytesRateShort(v)}
           customTooltip={NetTooltip}
         />
       </ChartCard>

--- a/app/globals.css
+++ b/app/globals.css
@@ -263,6 +263,46 @@ html[data-bottom-sheet-open] [data-main-content] {
   height: 0;
 }
 
+/* ── Tremor chart color overrides ──
+ * Tremor v3 generates arbitrary-value Tailwind classes like
+ * stroke-[var(--metric-cpu)] and fill-[var(--metric-cpu)].
+ * In Tailwind v4, these are only generated if they appear in source.
+ * We add explicit CSS to ensure strokes, fills, and gradient stops
+ * resolve our oklch metric colors correctly. */
+
+/* Stroke colors for area chart lines */
+.stroke-\[var\(--metric-cpu\)\] { stroke: var(--metric-cpu); }
+.stroke-\[var\(--metric-memory\)\] { stroke: var(--metric-memory); }
+.stroke-\[var\(--metric-network-rx\)\] { stroke: var(--metric-network-rx); }
+.stroke-\[var\(--metric-network-tx\)\] { stroke: var(--metric-network-tx); }
+.stroke-\[var\(--metric-memory-limit\)\] { stroke: var(--metric-memory-limit); }
+.stroke-\[var\(--metric-disk\)\] { stroke: var(--metric-disk); }
+
+/* Fill colors for area fills */
+.fill-\[var\(--metric-cpu\)\] { fill: var(--metric-cpu); }
+.fill-\[var\(--metric-memory\)\] { fill: var(--metric-memory); }
+.fill-\[var\(--metric-network-rx\)\] { fill: var(--metric-network-rx); }
+.fill-\[var\(--metric-network-tx\)\] { fill: var(--metric-network-tx); }
+.fill-\[var\(--metric-memory-limit\)\] { fill: var(--metric-memory-limit); }
+.fill-\[var\(--metric-disk\)\] { fill: var(--metric-disk); }
+
+/* Text/currentColor for gradient <stop> elements (Tremor uses stopColor: currentColor) */
+.text-\[var\(--metric-cpu\)\] { color: var(--metric-cpu); }
+.text-\[var\(--metric-memory\)\] { color: var(--metric-memory); }
+.text-\[var\(--metric-network-rx\)\] { color: var(--metric-network-rx); }
+.text-\[var\(--metric-network-tx\)\] { color: var(--metric-network-tx); }
+.text-\[var\(--metric-memory-limit\)\] { color: var(--metric-memory-limit); }
+.text-\[var\(--metric-disk\)\] { color: var(--metric-disk); }
+
+/* Tremor Y-axis and grid styling */
+.tremor-AreaChart-root .recharts-cartesian-axis-tick text {
+  fill: var(--muted-foreground) !important;
+  font-size: 11px;
+}
+.tremor-AreaChart-root .recharts-cartesian-grid line {
+  stroke: oklch(0.30 0.006 285.75 / 40%);
+}
+
 /* Squircle progressive enhancement */
 @supports (corner-shape: squircle) {
   .squircle {

--- a/components/metrics-chart.tsx
+++ b/components/metrics-chart.tsx
@@ -36,6 +36,22 @@ const SWATCH_COLORS: Record<string, string> = {
 };
 
 /**
+ * Common props shared by all Tremor AreaCharts across metric views.
+ * Apply these as defaults and override per-chart as needed.
+ */
+export const CHART_DEFAULTS = {
+  showLegend: false,
+  showAnimation: false,
+  showGradient: true,
+  showGridLines: true,
+  connectNulls: true,
+  curveType: "monotone" as const,
+  autoMinValue: false,
+  minValue: 0,
+  yAxisWidth: 80,
+} as const;
+
+/**
  * Custom dark-themed tooltip for metric area charts.
  * Replaces Tremor's default light tooltip with one that matches
  * the existing dark card style (oklch-based background, border, text).

--- a/lib/metrics/format.ts
+++ b/lib/metrics/format.ts
@@ -6,6 +6,16 @@ export function formatBytes(bytes: number, decimals = 1): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
 }
 
+/** Shorter format for Y-axis tick labels — 0 decimals for MB+, 1 for KB */
+export function formatBytesShort(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB", "PB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  const d = i >= 2 ? 0 : 1; // 0 decimals for MB and above
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(d))} ${sizes[i]}`;
+}
+
 // Memory limit > 1TB is effectively "unlimited" (Docker reports host RAM or sentinel)
 export function formatMemLimit(bytes: number): string {
   if (bytes === 0 || bytes > 1099511627776) return "No limit";
@@ -14,6 +24,11 @@ export function formatMemLimit(bytes: number): string {
 
 export function formatBytesRate(bytes: number): string {
   return `${formatBytes(bytes)}/s`;
+}
+
+/** Shorter rate format for Y-axis tick labels */
+export function formatBytesRateShort(bytes: number): string {
+  return `${formatBytesShort(bytes)}/s`;
 }
 
 export function formatTime(timestamp: number): string {


### PR DESCRIPTION
## Summary

- **Y-axis width**: increased to 80px with shorter format strings (`954 MB` instead of `953.7 MB`) to prevent label wrapping
- **Area gradient fills**: enabled `showGradient` via shared `CHART_DEFAULTS` and added explicit CSS overrides for Tremor's arbitrary-value classes (`stroke-[var(--metric-cpu)]`, `fill-[var(--metric-cpu)]`, `text-[var(--metric-cpu)]`) so oklch colors resolve correctly in Tailwind v4
- **Colors**: CSS overrides ensure vibrant oklch metric colors actually apply to SVG strokes, fills, and gradient `<stop>` elements
- **Network rates**: org-metrics and project-metrics now compute delta bytes/s instead of charting raw cumulative `networkRx`/`networkTx` counters (matching the existing app-metrics behavior)
- **Disk smoothing**: `connectNulls` + `curveType="monotone"` applied consistently via `CHART_DEFAULTS`
- **General polish**: `showGridLines`, consistent `minValue={0}` baselines, `showAnimation={false}` to avoid janky data-update animations, shared `CHART_DEFAULTS` object reduces per-chart prop boilerplate

## Files changed

- `lib/metrics/format.ts` -- added `formatBytesShort` and `formatBytesRateShort` for compact axis labels
- `components/metrics-chart.tsx` -- added `CHART_DEFAULTS` shared config object
- `app/globals.css` -- CSS overrides for Tremor arbitrary-value color classes + grid/axis styling
- `app/(app)/metrics/org-metrics.tsx` -- network rate computation, CHART_DEFAULTS, short formatters
- `app/(app)/projects/[...slug]/project-metrics.tsx` -- network rate computation, CHART_DEFAULTS
- `app/(app)/apps/[...slug]/app-metrics.tsx` -- CHART_DEFAULTS, short formatters

## Test plan

- [ ] Visit `/metrics` (org-level) -- verify CPU/Memory/Network/Disk charts show colored gradient fills, readable Y-axis labels, network in bytes/s
- [ ] Visit `/admin/metrics` -- same checks (uses `adminMode` prop on OrgMetrics)
- [ ] Visit any app detail metrics tab -- verify charts match, network still shows rates
- [ ] Visit any project detail metrics tab -- verify network shows rates not cumulative
- [ ] Check dark mode specifically -- gradient fills should fade from colored line to transparent