### PR TITLE
feat(volumes): git vs disk diff view with selective sync

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/diff/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/diff/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { apps, volumes } from "@/lib/db/schema";
+import { verifyAppAccess } from "@/lib/api/verify-access";
+import { eq, and } from "drizzle-orm";
+import { computeVolumeDiff } from "@/lib/volumes/diff";
+import { listContainers, inspectContainer } from "@/lib/docker/client";
+
+type RouteParams = {
+  params: Promise<{ orgId: string; appId: string; volumeName: string }>;
+};
+
+/**
+ * GET — Compare image contents vs volume contents at the mount path.
+ *
+ * Runs a temp container from the app's current image, generates file lists
+ * with checksums from both image and volume, and returns a categorised diff.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, appId, volumeName } = await params;
+    const appRecord = await verifyAppAccess(orgId, appId);
+    if (!appRecord) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Load the volume record
+    const volume = await db.query.volumes.findFirst({
+      where: and(eq(volumes.appId, appId), eq(volumes.name, volumeName)),
+    });
+    if (!volume) {
+      return NextResponse.json({ error: "Volume not found" }, { status: 404 });
+    }
+
+    // Get the app's image name
+    const app = await db.query.apps.findFirst({
+      where: and(eq(apps.id, appId), eq(apps.organizationId, orgId)),
+      columns: { id: true, name: true, imageName: true },
+    });
+    if (!app) {
+      return NextResponse.json({ error: "App not found" }, { status: 404 });
+    }
+
+    // Determine the image to diff against
+    let imageName = app.imageName;
+    if (!imageName) {
+      // For built images, try to detect from running container
+      try {
+        const containers = await listContainers(app.name);
+        if (containers.length > 0) {
+          imageName = containers[0].image;
+        }
+      } catch { /* no containers running */ }
+    }
+
+    if (!imageName) {
+      return NextResponse.json(
+        { error: "No image available for diff. Deploy the app first." },
+        { status: 400 },
+      );
+    }
+
+    // Find the Docker volume name from running containers
+    let dockerVolumeName: string | null = null;
+    try {
+      const containers = await listContainers(app.name);
+      for (const container of containers) {
+        const info = await inspectContainer(container.id);
+        for (const mount of info.mounts) {
+          if (mount.destination === volume.mountPath && mount.type === "volume") {
+            dockerVolumeName = mount.source.split("/").pop() || mount.source;
+            break;
+          }
+        }
+        if (dockerVolumeName) break;
+      }
+    } catch { /* Docker not available */ }
+
+    if (!dockerVolumeName) {
+      return NextResponse.json(
+        { error: "Volume is not currently mounted. Deploy the app first." },
+        { status: 400 },
+      );
+    }
+
+    const diff = await computeVolumeDiff(
+      imageName,
+      dockerVolumeName,
+      volume.mountPath,
+      volume.ignorePatterns ?? [],
+    );
+
+    return NextResponse.json({
+      volume: volumeName,
+      mountPath: volume.mountPath,
+      imageName,
+      diff,
+      summary: {
+        modified: diff.modified.length,
+        addedOnDisk: diff.addedOnDisk.length,
+        missingFromDisk: diff.missingFromDisk.length,
+        ignored: diff.ignored.length,
+        totalDrift: diff.modified.length + diff.addedOnDisk.length + diff.missingFromDisk.length,
+      },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error computing volume diff");
+  }
+}

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { volumes } from "@/lib/db/schema";
+import { verifyAppAccess } from "@/lib/api/verify-access";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+
+type RouteParams = {
+  params: Promise<{ orgId: string; appId: string; volumeName: string }>;
+};
+
+const patchSchema = z.object({
+  ignorePatterns: z.array(z.string().min(1).max(200)).max(100).optional(),
+  description: z.string().max(500).optional(),
+});
+
+/**
+ * PATCH — Update volume metadata (ignore patterns, description).
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, appId, volumeName } = await params;
+    const appRecord = await verifyAppAccess(orgId, appId);
+    if (!appRecord) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = patchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 },
+      );
+    }
+
+    const volume = await db.query.volumes.findFirst({
+      where: and(eq(volumes.appId, appId), eq(volumes.name, volumeName)),
+    });
+    if (!volume) {
+      return NextResponse.json({ error: "Volume not found" }, { status: 404 });
+    }
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (parsed.data.ignorePatterns !== undefined) {
+      updates.ignorePatterns = parsed.data.ignorePatterns;
+    }
+    if (parsed.data.description !== undefined) {
+      updates.description = parsed.data.description;
+    }
+
+    await db.update(volumes).set(updates).where(eq(volumes.id, volume.id));
+
+    const updated = await db.query.volumes.findFirst({
+      where: eq(volumes.id, volume.id),
+    });
+
+    return NextResponse.json({ volume: updated });
+  } catch (error) {
+    return handleRouteError(error, "Error updating volume");
+  }
+}

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/sync/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/[volumeName]/sync/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { apps, volumes } from "@/lib/db/schema";
+import { verifyAppAccess } from "@/lib/api/verify-access";
+import { eq, and } from "drizzle-orm";
+import { syncFilesFromImage } from "@/lib/volumes/diff";
+import { listContainers, inspectContainer } from "@/lib/docker/client";
+import { z } from "zod";
+import { recordActivity } from "@/lib/activity";
+
+type RouteParams = {
+  params: Promise<{ orgId: string; appId: string; volumeName: string }>;
+};
+
+const DESTRUCTIVE_THRESHOLD = 10;
+
+const syncSchema = z.object({
+  paths: z.array(z.string().min(1)).min(1).max(1000),
+  confirm: z.boolean().optional(),
+});
+
+/**
+ * POST — Sync specific files from the image into the volume.
+ *
+ * Runs a temp container, copies the specified files from the image's
+ * filesystem into the named volume. Destructive syncs (deleting many files)
+ * require `{ confirm: true }` in the body.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId, appId, volumeName } = await params;
+    const appRecord = await verifyAppAccess(orgId, appId);
+    if (!appRecord) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = syncSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 },
+      );
+    }
+
+    const { paths, confirm } = parsed.data;
+
+    // Require confirmation for destructive operations
+    if (paths.length >= DESTRUCTIVE_THRESHOLD && !confirm) {
+      return NextResponse.json(
+        {
+          error: `Syncing ${paths.length} files is a destructive operation. Send { confirm: true } to proceed.`,
+          requiresConfirmation: true,
+          fileCount: paths.length,
+        },
+        { status: 409 },
+      );
+    }
+
+    // Load the volume record
+    const volume = await db.query.volumes.findFirst({
+      where: and(eq(volumes.appId, appId), eq(volumes.name, volumeName)),
+    });
+    if (!volume) {
+      return NextResponse.json({ error: "Volume not found" }, { status: 404 });
+    }
+
+    // Get the app's image name
+    const app = await db.query.apps.findFirst({
+      where: and(eq(apps.id, appId), eq(apps.organizationId, orgId)),
+      columns: { id: true, name: true, imageName: true, organizationId: true },
+    });
+    if (!app) {
+      return NextResponse.json({ error: "App not found" }, { status: 404 });
+    }
+
+    let imageName = app.imageName;
+    if (!imageName) {
+      try {
+        const containers = await listContainers(app.name);
+        if (containers.length > 0) {
+          imageName = containers[0].image;
+        }
+      } catch { /* no containers */ }
+    }
+
+    if (!imageName) {
+      return NextResponse.json(
+        { error: "No image available for sync." },
+        { status: 400 },
+      );
+    }
+
+    // Find Docker volume name
+    let dockerVolumeName: string | null = null;
+    try {
+      const containers = await listContainers(app.name);
+      for (const container of containers) {
+        const info = await inspectContainer(container.id);
+        for (const mount of info.mounts) {
+          if (mount.destination === volume.mountPath && mount.type === "volume") {
+            dockerVolumeName = mount.source.split("/").pop() || mount.source;
+            break;
+          }
+        }
+        if (dockerVolumeName) break;
+      }
+    } catch { /* Docker not available */ }
+
+    if (!dockerVolumeName) {
+      return NextResponse.json(
+        { error: "Volume is not currently mounted." },
+        { status: 400 },
+      );
+    }
+
+    const result = await syncFilesFromImage(
+      imageName,
+      dockerVolumeName,
+      volume.mountPath,
+      paths,
+    );
+
+    // Record activity
+    recordActivity({
+      organizationId: app.organizationId,
+      action: "volume.sync",
+      appId,
+      metadata: {
+        volumeName,
+        syncedCount: result.synced.length,
+        failedCount: result.failed.length,
+      },
+    }).catch(() => {});
+
+    return NextResponse.json({
+      synced: result.synced,
+      failed: result.failed,
+      summary: {
+        requested: paths.length,
+        synced: result.synced.length,
+        failed: result.failed.length,
+      },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error syncing files from image");
+  }
+}

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/volumes/route.ts
@@ -37,6 +37,8 @@ type VolumeInfo = {
   description: string | null;
   maxSizeBytes: number | null;
   warnAtPercent: number | null;
+  ignorePatterns: string[] | null;
+  driftCount: number;
   source: string;
   sizeBytes: number | null;
 };
@@ -85,6 +87,8 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
               description: saved?.description ?? null,
               maxSizeBytes: saved?.maxSizeBytes ?? null,
               warnAtPercent: saved?.warnAtPercent ?? null,
+              ignorePatterns: saved?.ignorePatterns ?? null,
+              driftCount: saved?.driftCount ?? 0,
               source: mount.source,
               sizeBytes: null,
             });
@@ -147,6 +151,8 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
           description: saved.description,
           maxSizeBytes: saved.maxSizeBytes,
           warnAtPercent: saved.warnAtPercent,
+          ignorePatterns: saved.ignorePatterns,
+          driftCount: saved.driftCount ?? 0,
           source: saved.name,
           sizeBytes: null,
         });

--- a/components/volumes-panel.tsx
+++ b/components/volumes-panel.tsx
@@ -12,6 +12,15 @@ import {
   Pencil,
   Trash2,
   AlertTriangle,
+  GitCompareArrows,
+  ChevronDown,
+  ChevronRight,
+  FileWarning,
+  FilePlus,
+  FileMinus,
+  RefreshCw,
+  EyeOff,
+  Check,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -50,6 +59,22 @@ type Volume = {
   warnAtPercent: number | null;
   source: string;
   sizeBytes: number | null;
+  driftCount?: number;
+  ignorePatterns?: string[];
+};
+
+type DiffEntry = {
+  path: string;
+  imageHash?: string;
+  volumeHash?: string;
+  sizeBytes: number;
+};
+
+type DiffResult = {
+  modified: DiffEntry[];
+  addedOnDisk: DiffEntry[];
+  missingFromDisk: DiffEntry[];
+  ignored: DiffEntry[];
 };
 
 type VolumeLimit = {
@@ -97,6 +122,303 @@ function thresholdProgressClass(level: ThresholdLevel): string {
   if (level === "critical") return "h-1.5 [&>[data-slot=progress-indicator]]:bg-destructive";
   if (level === "warning") return "h-1.5 [&>[data-slot=progress-indicator]]:bg-amber-500";
   return "h-1.5";
+}
+
+function VolumeDiffSection({
+  appId,
+  orgId,
+  volume,
+  onIgnoreAdded,
+}: {
+  appId: string;
+  orgId: string;
+  volume: Volume;
+  onIgnoreAdded: (pattern: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [diff, setDiff] = useState<DiffResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState<Set<string>>(new Set());
+  const [synced, setSynced] = useState<Set<string>>(new Set());
+
+  async function loadDiff() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/v1/organizations/${orgId}/apps/${appId}/volumes/${encodeURIComponent(volume.name)}/diff`
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to load diff");
+        return;
+      }
+      const data = await res.json();
+      setDiff(data.diff);
+    } catch {
+      setError("Failed to load diff");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleToggle() {
+    if (!expanded && !diff && !loading) {
+      loadDiff();
+    }
+    setExpanded(!expanded);
+  }
+
+  async function syncFile(path: string) {
+    setSyncing((prev) => new Set(prev).add(path));
+    try {
+      const res = await fetch(
+        `/api/v1/organizations/${orgId}/apps/${appId}/volumes/${encodeURIComponent(volume.name)}/sync`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ paths: [path] }),
+        }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        if (data.synced?.includes(path)) {
+          setSynced((prev) => new Set(prev).add(path));
+          toast.success(`Synced ${path}`);
+        } else {
+          toast.error(`Failed to sync ${path}`);
+        }
+      } else {
+        toast.error("Sync failed");
+      }
+    } catch {
+      toast.error("Sync failed");
+    } finally {
+      setSyncing((prev) => {
+        const next = new Set(prev);
+        next.delete(path);
+        return next;
+      });
+    }
+  }
+
+  async function ignorePattern(path: string) {
+    // Add the exact file path as the ignore pattern.
+    // Users can manually add directory globs (e.g. "uploads/**") if they want broader ignores.
+    const pattern = path;
+
+    const currentPatterns = volume.ignorePatterns ?? [];
+    if (currentPatterns.includes(pattern)) {
+      toast.success("Pattern already ignored");
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/v1/organizations/${orgId}/apps/${appId}/volumes/${encodeURIComponent(volume.name)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ignorePatterns: [...currentPatterns, pattern],
+          }),
+        }
+      );
+      if (res.ok) {
+        toast.success(`Added ignore pattern: ${pattern}`);
+        onIgnoreAdded(pattern);
+        // Reload diff
+        loadDiff();
+      } else {
+        toast.error("Failed to add ignore pattern");
+      }
+    } catch {
+      toast.error("Failed to add ignore pattern");
+    }
+  }
+
+  const totalChanges = diff
+    ? diff.modified.length + diff.addedOnDisk.length + diff.missingFromDisk.length
+    : volume.driftCount ?? 0;
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={handleToggle}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
+        )}
+        <GitCompareArrows className="size-3" />
+        <span>Changes</span>
+        {totalChanges > 0 && (
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 h-4 bg-amber-500/10 text-amber-600 border-amber-500/20"
+          >
+            {totalChanges}
+          </Badge>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-2 rounded-md border bg-muted/30 p-3 space-y-2">
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              Computing diff...
+            </div>
+          )}
+
+          {error && (
+            <p className="text-xs text-destructive">{error}</p>
+          )}
+
+          {diff && totalChanges === 0 && (
+            <p className="text-xs text-muted-foreground">
+              No drift detected. Volume matches image contents.
+            </p>
+          )}
+
+          {diff && diff.modified.length > 0 && (
+            <DiffFileGroup
+              label="Modified"
+              icon={<FileWarning className="size-3 text-amber-500" />}
+              entries={diff.modified}
+              syncing={syncing}
+              synced={synced}
+              onSync={syncFile}
+              onIgnore={ignorePattern}
+            />
+          )}
+
+          {diff && diff.addedOnDisk.length > 0 && (
+            <DiffFileGroup
+              label="Added on disk"
+              icon={<FilePlus className="size-3 text-blue-500" />}
+              entries={diff.addedOnDisk}
+              syncing={syncing}
+              synced={synced}
+              onIgnore={ignorePattern}
+            />
+          )}
+
+          {diff && diff.missingFromDisk.length > 0 && (
+            <DiffFileGroup
+              label="Missing from disk"
+              icon={<FileMinus className="size-3 text-red-500" />}
+              entries={diff.missingFromDisk}
+              syncing={syncing}
+              synced={synced}
+              onSync={syncFile}
+              onIgnore={ignorePattern}
+            />
+          )}
+
+          {diff && diff.ignored.length > 0 && (
+            <details className="text-xs">
+              <summary className="text-muted-foreground cursor-pointer hover:text-foreground">
+                {diff.ignored.length} ignored file(s)
+              </summary>
+              <ul className="mt-1 space-y-0.5 pl-4">
+                {diff.ignored.map((entry) => (
+                  <li
+                    key={entry.path}
+                    className="font-mono text-muted-foreground truncate"
+                  >
+                    {entry.path}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {diff && (
+            <button
+              onClick={loadDiff}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              disabled={loading}
+            >
+              <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} />
+              Refresh
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffFileGroup({
+  label,
+  icon,
+  entries,
+  syncing,
+  synced,
+  onSync,
+  onIgnore,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  entries: DiffEntry[];
+  syncing: Set<string>;
+  synced: Set<string>;
+  onSync?: (path: string) => void;
+  onIgnore: (path: string) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs font-medium mb-1">
+        {icon}
+        {label} ({entries.length})
+      </div>
+      <ul className="space-y-0.5">
+        {entries.map((entry) => (
+          <li
+            key={entry.path}
+            className="flex items-center justify-between gap-2 text-xs group"
+          >
+            <span className="font-mono text-muted-foreground truncate min-w-0 flex-1">
+              {entry.path}
+            </span>
+            <span className="text-muted-foreground shrink-0 text-[10px]">
+              {formatBytes(entry.sizeBytes)}
+            </span>
+            <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+              {onSync && !synced.has(entry.path) && (
+                <button
+                  onClick={() => onSync(entry.path)}
+                  disabled={syncing.has(entry.path)}
+                  className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50"
+                  title="Sync from image"
+                >
+                  {syncing.has(entry.path) ? (
+                    <Loader2 className="size-2.5 animate-spin" />
+                  ) : (
+                    "Sync"
+                  )}
+                </button>
+              )}
+              {synced.has(entry.path) && (
+                <Check className="size-3 text-green-500" />
+              )}
+              <button
+                onClick={() => onIgnore(entry.path)}
+                className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80"
+                title="Add ignore pattern"
+              >
+                <EyeOff className="size-2.5" />
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export function VolumesPanel({ appId, orgId }: Props) {
@@ -388,71 +710,105 @@ export function VolumesPanel({ appId, orgId }: Props) {
             {volumes.map((vol) => (
               <div
                 key={`${vol.name}-${vol.mountPath}`}
-                className="squircle flex items-center justify-between gap-4 rounded-lg border bg-card p-4"
+                className="squircle rounded-lg border bg-card p-4"
               >
-                <div className="flex items-center gap-4 min-w-0 flex-1">
-                  <HardDrive className="size-4 text-muted-foreground shrink-0" />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-medium font-mono truncate">
-                        {vol.name}
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-4 min-w-0 flex-1">
+                    <HardDrive className="size-4 text-muted-foreground shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium font-mono truncate">
+                          {vol.name}
+                        </p>
+                        <Badge variant="secondary" className="text-xs shrink-0">
+                          {vol.type}
+                        </Badge>
+                        {vol.persistent ? (
+                          <Badge className="text-xs shrink-0 border-transparent bg-status-success-muted text-status-success">
+                            <ShieldCheck className="mr-1 size-3" />
+                            Persistent
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline" className="text-xs shrink-0">
+                            <Clock className="mr-1 size-3" />
+                            Ephemeral
+                          </Badge>
+                        )}
+                        {(vol.driftCount ?? 0) > 0 && (
+                          <Badge
+                            variant="secondary"
+                            className="text-xs shrink-0 bg-amber-500/10 text-amber-600 border-amber-500/20"
+                          >
+                            <GitCompareArrows className="mr-1 size-3" />
+                            {vol.driftCount} change{vol.driftCount !== 1 ? "s" : ""}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground font-mono mt-0.5 truncate">
+                        {vol.mountPath}
                       </p>
-                      <Badge variant="secondary" className="text-xs shrink-0">
-                        {vol.type}
-                      </Badge>
-                      {vol.persistent ? (
-                        <Badge className="text-xs shrink-0 border-transparent bg-status-success-muted text-status-success">
-                          <ShieldCheck className="mr-1 size-3" />
-                          Persistent
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="text-xs shrink-0">
-                          <Clock className="mr-1 size-3" />
-                          Ephemeral
-                        </Badge>
-                      )}
-                    </div>
-                    <p className="text-xs text-muted-foreground font-mono mt-0.5 truncate">
-                      {vol.mountPath}
-                    </p>
-                    {/* Per-volume usage vs limit */}
-                    {vol.sizeBytes != null && vol.sizeBytes > 0 && limit && (() => {
-                      const level = volumeThreshold(vol.sizeBytes!, limit.maxSizeBytes, limit.warnAtPercent ?? 80);
-                      const percent = Math.round((vol.sizeBytes! / limit.maxSizeBytes) * 100);
-                      return (
-                        <div className="mt-2 space-y-1">
-                          <div className="flex items-center justify-between text-xs">
-                            <span className="text-muted-foreground">
-                              {formatBytes(vol.sizeBytes!)} / {formatBytes(limit.maxSizeBytes)}
-                            </span>
-                            <span className={thresholdTextClass(level)}>
-                              {percent}%
-                            </span>
+                      {/* Per-volume usage vs limit */}
+                      {vol.sizeBytes != null && vol.sizeBytes > 0 && limit && (() => {
+                        const level = volumeThreshold(vol.sizeBytes!, limit.maxSizeBytes, limit.warnAtPercent ?? 80);
+                        const percent = Math.round((vol.sizeBytes! / limit.maxSizeBytes) * 100);
+                        return (
+                          <div className="mt-2 space-y-1">
+                            <div className="flex items-center justify-between text-xs">
+                              <span className="text-muted-foreground">
+                                {formatBytes(vol.sizeBytes!)} / {formatBytes(limit.maxSizeBytes)}
+                              </span>
+                              <span className={thresholdTextClass(level)}>
+                                {percent}%
+                              </span>
+                            </div>
+                            <Progress
+                              value={Math.min(percent, 100)}
+                              className={thresholdProgressClass(level)}
+                            />
                           </div>
-                          <Progress
-                            value={Math.min(percent, 100)}
-                            className={thresholdProgressClass(level)}
-                          />
-                        </div>
-                      );
-                    })()}
+                        );
+                      })()}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <Switch
+                      checked={vol.persistent}
+                      onCheckedChange={() => togglePersistent(vol.name)}
+                      disabled={saving}
+                    />
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => removeVolume(vol.name)}
+                    >
+                      <X className="size-3.5" />
+                    </Button>
                   </div>
                 </div>
-                <div className="flex items-center gap-3 shrink-0">
-                  <Switch
-                    checked={vol.persistent}
-                    onCheckedChange={() => togglePersistent(vol.name)}
-                    disabled={saving}
+                {/* Volume diff / changes section */}
+                {vol.persistent && (
+                  <VolumeDiffSection
+                    appId={appId}
+                    orgId={orgId}
+                    volume={vol}
+                    onIgnoreAdded={(pattern) => {
+                      setVolumes((prev) =>
+                        prev.map((v) =>
+                          v.name === vol.name
+                            ? {
+                                ...v,
+                                ignorePatterns: [
+                                  ...(v.ignorePatterns ?? []),
+                                  pattern,
+                                ],
+                              }
+                            : v
+                        )
+                      );
+                    }}
                   />
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => removeVolume(vol.name)}
-                  >
-                    <X className="size-3.5" />
-                  </Button>
-                </div>
+                )}
               </div>
             ))}
           </div>

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -690,6 +690,8 @@ export const volumes = pgTable(
     description: text("description"),
     maxSizeBytes: bigint("max_size_bytes", { mode: "number" }), // nullable = no limit
     warnAtPercent: integer("warn_at_percent").default(80),
+    ignorePatterns: jsonb("ignore_patterns").$type<string[]>(), // glob patterns to ignore in diff (e.g. "uploads/**")
+    driftCount: integer("drift_count").default(0), // unignored file drift after last deploy
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1117,6 +1117,20 @@ export async function runDeployment(
       }
     }
 
+    // Post-deploy drift check (non-blocking, purely informational).
+    // Wait 10s for containers to settle before scanning volumes.
+    setTimeout(() => {
+      import("@/lib/volumes/drift-check")
+        .then(({ runPostDeployDriftCheck }) =>
+          runPostDeployDriftCheck({
+            appId: opts.appId,
+            organizationId: opts.organizationId,
+            appName: app.name,
+            log,
+          }),
+        )
+        .catch(() => {});
+    }, 10000);
     return { deploymentId, success: true, log: logLines.join("\n"), durationMs };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -1,3 +1,3 @@
-export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed";
+export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed" | "volume-drift";
 export type NotificationEvent = { type: NotificationEventType; title: string; message: string; metadata: Record<string, string> };
 export interface NotificationChannel { send(event: NotificationEvent): Promise<void>; }

--- a/lib/volumes/diff.ts
+++ b/lib/volumes/diff.ts
@@ -1,0 +1,280 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { assertSafeName } from "@/lib/docker/validate";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Validate that an image reference contains only safe characters.
+ * Image refs can include alphanumerics, dots, dashes, underscores,
+ * slashes, colons, and @ (for digests).
+ */
+function assertSafeImageRef(ref: string): void {
+  if (!/^[a-zA-Z0-9._\-/:@]+$/.test(ref)) {
+    throw new Error(`Invalid image reference: ${ref}`);
+  }
+}
+
+/**
+ * Simple glob pattern matcher supporting * and ** wildcards.
+ * Converts a glob pattern to a regex for matching file paths.
+ */
+function matchesAnyPattern(filePath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    const regex = globToRegex(pattern);
+    if (regex.test(filePath)) return true;
+  }
+  return false;
+}
+
+function globToRegex(glob: string): RegExp {
+  let result = "^";
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        // ** matches any path segment(s)
+        if (glob[i + 2] === "/") {
+          result += "(?:.+/)?";
+          i += 3;
+        } else {
+          result += ".*";
+          i += 2;
+        }
+      } else {
+        // * matches anything except /
+        result += "[^/]*";
+        i++;
+      }
+    } else if (c === "?") {
+      result += "[^/]";
+      i++;
+    } else if (c === "." || c === "(" || c === ")" || c === "+" || c === "^" || c === "$" || c === "{" || c === "}" || c === "|" || c === "\\") {
+      result += "\\" + c;
+      i++;
+    } else {
+      result += c;
+      i++;
+    }
+  }
+  result += "$";
+  return new RegExp(result);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DiffEntry = {
+  path: string;
+  imageHash?: string;
+  volumeHash?: string;
+  sizeBytes: number;
+};
+
+export type VolumeDiffResult = {
+  modified: DiffEntry[];
+  addedOnDisk: DiffEntry[];
+  missingFromDisk: DiffEntry[];
+  ignored: DiffEntry[];
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type FileEntry = { path: string; hash: string; size: number };
+
+/**
+ * Run a temp container from the given image and generate a file manifest
+ * (path \t md5 \t size) for everything under `mountPath`.
+ */
+async function getImageManifest(
+  imageName: string,
+  mountPath: string,
+): Promise<FileEntry[]> {
+  assertSafeImageRef(imageName);
+  // Use find + md5sum to enumerate all regular files under the mount path.
+  const script = `find "${mountPath}" -type f -exec sh -c 'for f; do s=$(stat -c %s "$f" 2>/dev/null || stat -f %z "$f" 2>/dev/null); h=$(md5sum "$f" 2>/dev/null | cut -d" " -f1); echo "$f\\t$h\\t$s"; done' _ {} +`;
+
+  try {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["run", "--rm", "--entrypoint", "sh", imageName, "-c", script],
+      { timeout: 60000, maxBuffer: 10 * 1024 * 1024 },
+    );
+    return parseManifest(stdout, mountPath);
+  } catch {
+    // Image might not have the path at all — that's fine
+    return [];
+  }
+}
+
+/**
+ * Run a temp container that mounts the named Docker volume and generates
+ * the same manifest format.
+ */
+async function getVolumeManifest(
+  volumeDockerName: string,
+  mountPath: string,
+): Promise<FileEntry[]> {
+  assertSafeName(volumeDockerName);
+  const script = `find /vol -type f -exec sh -c 'for f; do s=$(stat -c %s "$f" 2>/dev/null || stat -f %z "$f" 2>/dev/null); h=$(md5sum "$f" 2>/dev/null | cut -d" " -f1); echo "$f\\t$h\\t$s"; done' _ {} +`;
+
+  try {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["run", "--rm", "-v", `${volumeDockerName}:/vol`, "alpine", "sh", "-c", script],
+      { timeout: 60000, maxBuffer: 10 * 1024 * 1024 },
+    );
+    return parseManifest(stdout, "/vol");
+  } catch {
+    return [];
+  }
+}
+
+function parseManifest(raw: string, prefix: string): FileEntry[] {
+  const entries: FileEntry[] = [];
+  for (const line of raw.trim().split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    if (parts.length < 3) continue;
+    const fullPath = parts[0];
+    const hash = parts[1];
+    const size = parseInt(parts[2]) || 0;
+    // Normalise path to be relative
+    const rel = fullPath.startsWith(prefix)
+      ? fullPath.slice(prefix.length).replace(/^\//, "")
+      : fullPath;
+    if (rel) entries.push({ path: rel, hash, size });
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare the contents of a Docker image at `mountPath` against the
+ * contents of a named Docker volume, returning a categorised diff.
+ *
+ * @param imageName    Full image reference (e.g. "postgres:16")
+ * @param volumeDockerName  Docker volume name (e.g. "myapp-production-blue_data")
+ * @param mountPath    Container mount path (e.g. "/var/lib/postgresql/data")
+ * @param ignorePatterns  Glob patterns to filter out (e.g. ["uploads/**", "cache/**"])
+ */
+export async function computeVolumeDiff(
+  imageName: string,
+  volumeDockerName: string,
+  mountPath: string,
+  ignorePatterns: string[] = [],
+): Promise<VolumeDiffResult> {
+  const [imageFiles, volumeFiles] = await Promise.all([
+    getImageManifest(imageName, mountPath),
+    getVolumeManifest(volumeDockerName, mountPath),
+  ]);
+
+  const imageMap = new Map(imageFiles.map((f) => [f.path, f]));
+  const volumeMap = new Map(volumeFiles.map((f) => [f.path, f]));
+
+  const isIgnored = ignorePatterns.length > 0
+    ? (path: string) => matchesAnyPattern(path, ignorePatterns)
+    : () => false;
+
+  const modified: DiffEntry[] = [];
+  const addedOnDisk: DiffEntry[] = [];
+  const missingFromDisk: DiffEntry[] = [];
+  const ignored: DiffEntry[] = [];
+
+  // Files in the volume that differ from or don't exist in the image
+  for (const [path, volFile] of volumeMap) {
+    const entry: DiffEntry = {
+      path,
+      volumeHash: volFile.hash,
+      sizeBytes: volFile.size,
+    };
+
+    const imgFile = imageMap.get(path);
+    if (imgFile) {
+      entry.imageHash = imgFile.hash;
+      if (imgFile.hash !== volFile.hash) {
+        if (isIgnored(path)) {
+          ignored.push(entry);
+        } else {
+          modified.push(entry);
+        }
+      }
+    } else {
+      // File exists on disk but not in image
+      if (isIgnored(path)) {
+        ignored.push(entry);
+      } else {
+        addedOnDisk.push(entry);
+      }
+    }
+  }
+
+  // Files in the image that are missing from the volume
+  for (const [path, imgFile] of imageMap) {
+    if (!volumeMap.has(path)) {
+      const entry: DiffEntry = {
+        path,
+        imageHash: imgFile.hash,
+        sizeBytes: imgFile.size,
+      };
+      if (isIgnored(path)) {
+        ignored.push(entry);
+      } else {
+        missingFromDisk.push(entry);
+      }
+    }
+  }
+
+  return { modified, addedOnDisk, missingFromDisk, ignored };
+}
+
+/**
+ * Copy specific files from an image into a named Docker volume.
+ * Runs a temp container with the volume mounted, then copies files from the
+ * image's filesystem into the volume mount.
+ */
+export async function syncFilesFromImage(
+  imageName: string,
+  volumeDockerName: string,
+  mountPath: string,
+  paths: string[],
+): Promise<{ synced: string[]; failed: string[] }> {
+  if (paths.length === 0) return { synced: [], failed: [] };
+
+  assertSafeName(volumeDockerName);
+
+  // Build a script that copies each file from the image path to the volume
+  const copyCommands = paths.map((p) => {
+    const src = `${mountPath}/${p}`;
+    const dst = `/vol/${p}`;
+    // Ensure parent directory exists, then copy
+    return `mkdir -p "$(dirname "${dst}")" && cp -f "${src}" "${dst}" && echo "OK:${p}" || echo "FAIL:${p}"`;
+  });
+
+  const script = copyCommands.join(" ; ");
+
+  try {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["run", "--rm", "-v", `${volumeDockerName}:/vol`, imageName, "sh", "-c", script],
+      { timeout: 60000 },
+    );
+
+    const synced: string[] = [];
+    const failed: string[] = [];
+    for (const line of stdout.trim().split("\n")) {
+      if (line.startsWith("OK:")) synced.push(line.slice(3));
+      else if (line.startsWith("FAIL:")) failed.push(line.slice(5));
+    }
+    return { synced, failed };
+  } catch {
+    return { synced: [], failed: paths };
+  }
+}

--- a/lib/volumes/drift-check.ts
+++ b/lib/volumes/drift-check.ts
@@ -1,0 +1,143 @@
+import { db } from "@/lib/db";
+import { volumes, apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { computeVolumeDiff } from "./diff";
+import { listContainers, inspectContainer } from "@/lib/docker/client";
+import { recordActivity } from "@/lib/activity";
+
+const DRIFT_NOTIFICATION_THRESHOLD = 10;
+
+type DriftCheckOpts = {
+  appId: string;
+  organizationId: string;
+  appName: string;
+  imageName?: string;
+  log?: (line: string) => void;
+};
+
+/**
+ * Run a post-deploy drift check on all volumes for an app.
+ * Updates driftCount on each volume record. Fires a notification
+ * if unignored drift exceeds the threshold.
+ *
+ * This is designed to run in the background after deploy completes
+ * and should never throw — all errors are caught internally.
+ */
+export async function runPostDeployDriftCheck(opts: DriftCheckOpts): Promise<void> {
+  const { appId, organizationId, appName, log } = opts;
+
+  try {
+    // Load all volumes for this app
+    const appVolumes = await db.query.volumes.findMany({
+      where: eq(volumes.appId, appId),
+    });
+
+    if (appVolumes.length === 0) return;
+
+    // Determine image name
+    let imageName = opts.imageName;
+    if (!imageName) {
+      const app = await db.query.apps.findFirst({
+        where: and(eq(apps.id, appId), eq(apps.organizationId, organizationId)),
+        columns: { imageName: true, name: true },
+      });
+      imageName = app?.imageName ?? undefined;
+
+      if (!imageName) {
+        try {
+          const containers = await listContainers(appName);
+          if (containers.length > 0) {
+            imageName = containers[0].image;
+          }
+        } catch { /* no containers */ }
+      }
+    }
+
+    if (!imageName) {
+      log?.("[drift] No image available for drift check");
+      return;
+    }
+
+    // Find Docker volume names from running containers
+    const dockerVolumes = new Map<string, string>(); // mountPath -> dockerVolumeName
+    try {
+      const containers = await listContainers(appName);
+      for (const container of containers) {
+        const info = await inspectContainer(container.id);
+        for (const mount of info.mounts) {
+          if (mount.type === "volume" && !dockerVolumes.has(mount.destination)) {
+            const volName = mount.source.split("/").pop() || mount.source;
+            dockerVolumes.set(mount.destination, volName);
+          }
+        }
+      }
+    } catch {
+      log?.("[drift] Could not list containers for drift check");
+      return;
+    }
+
+    let totalDrift = 0;
+
+    for (const vol of appVolumes) {
+      const dockerVolumeName = dockerVolumes.get(vol.mountPath);
+      if (!dockerVolumeName) continue;
+
+      try {
+        const diff = await computeVolumeDiff(
+          imageName,
+          dockerVolumeName,
+          vol.mountPath,
+          vol.ignorePatterns ?? [],
+        );
+
+        const driftCount =
+          diff.modified.length + diff.addedOnDisk.length + diff.missingFromDisk.length;
+
+        // Update drift count on the volume record
+        await db
+          .update(volumes)
+          .set({ driftCount, updatedAt: new Date() })
+          .where(eq(volumes.id, vol.id));
+
+        totalDrift += driftCount;
+
+        if (driftCount > 0) {
+          log?.(
+            `[drift] Volume '${vol.name}': ${driftCount} unignored change(s) (${diff.modified.length} modified, ${diff.addedOnDisk.length} added, ${diff.missingFromDisk.length} missing)`,
+          );
+        }
+      } catch (err) {
+        log?.(
+          `[drift] Error checking volume '${vol.name}': ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    // Fire notification if drift exceeds threshold
+    if (totalDrift >= DRIFT_NOTIFICATION_THRESHOLD) {
+      try {
+        const { notify } = await import("@/lib/notifications/dispatch");
+        await notify(organizationId, {
+          type: "volume-drift",
+          title: `Volume drift detected: ${appName}`,
+          message: `${totalDrift} unignored file change(s) detected across volumes after deploy. Review in the Volumes panel.`,
+          metadata: { appId, appName, totalDrift: String(totalDrift) },
+        });
+      } catch {
+        // Notification module may not exist yet — non-fatal
+      }
+
+      recordActivity({
+        organizationId,
+        action: "volume.drift_detected",
+        appId,
+        metadata: { totalDrift },
+      }).catch(() => {});
+    }
+  } catch (err) {
+    // Entire drift check is best-effort
+    log?.(
+      `[drift] Drift check failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **Diff API** compares Docker image contents vs volume contents at mount path, returning categorised results (modified, added on disk, missing from disk, ignored)
- **Collapsible "Changes" section** per volume card with drift badge showing unignored change count
- **Selective sync** from image — per-file or bulk, with confirmation required for destructive syncs (10+ files)
- **Ignore patterns** per volume (glob syntax: `uploads/**`, `cache/**`) stored as JSONB, filters diff results
- **Post-deploy drift check** runs in background after successful deploy, updates `driftCount` on volume records, fires notification when threshold exceeded
- **Never blocks deploys** — drift check is purely informational and best-effort

### Schema changes
- `volumes.ignore_patterns` (jsonb, string array) — glob patterns to exclude from diff
- `volumes.drift_count` (integer, default 0) — cached unignored file drift after last deploy

### New API endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `.../volumes/[volumeName]/diff` | Compute image vs volume diff |
| POST | `.../volumes/[volumeName]/sync` | Sync specific files from image |
| PATCH | `.../volumes/[volumeName]` | Update ignore patterns / metadata |

### New notification type
- `volume-drift` — fired when unignored drift exceeds 10 files after deploy

Closes #28

## Test plan
- [ ] Deploy an image-based app with persistent volumes, verify diff API returns expected results
- [ ] Modify a file inside a volume, re-run diff, confirm it appears as "modified"
- [ ] Add an ignore pattern via PATCH, verify diff filters it to "ignored" category
- [ ] Use sync endpoint to restore a file from image, verify it succeeds
- [ ] Trigger a deploy, verify post-deploy drift check updates `driftCount` without blocking
- [ ] Verify destructive sync (10+ files) returns 409 without `confirm: true`
- [ ] Verify UI shows drift badge on volume cards and collapsible Changes section works