### PR TITLE
feat(deploy): auto-rollback on container crash after deploy

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -83,7 +83,7 @@ import type { FeatureFlags } from "@/lib/config/features";
 
 type Deployment = {
   id: string;
-  status: "queued" | "running" | "success" | "failed" | "cancelled";
+  status: "queued" | "running" | "success" | "failed" | "cancelled" | "rolled_back";
   trigger: "manual" | "webhook" | "api" | "rollback";
   gitSha: string | null;
   gitMessage: string | null;
@@ -146,6 +146,8 @@ type App = {
   exposedPorts: { internal: number; external?: number; description?: string }[] | null;
   cpuLimit: number | null;
   memoryLimit: number | null;
+  autoRollback: boolean | null;
+  rollbackGracePeriod: number | null;
   projectId: string | null;
   cloneStrategy: string | null;
   dependsOn: string[] | null;
@@ -245,6 +247,12 @@ function DeploymentStatusBadge({ status }: { status: Deployment["status"] }) {
       );
     case "cancelled":
       return <Badge variant="secondary">Cancelled</Badge>;
+    case "rolled_back":
+      return (
+        <Badge className="border-transparent bg-status-warning-muted text-status-warning">
+          Rolled Back
+        </Badge>
+      );
     default:
       return <Badge variant="secondary">Queued</Badge>;
   }
@@ -747,6 +755,8 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
   const [editParentId, setEditParentId] = useState<string | null>(app.projectId ?? null);
   const [cpuLimit, setCpuLimit] = useState(app.cpuLimit?.toString() || "");
   const [memoryLimit, setMemoryLimit] = useState(app.memoryLimit?.toString() || "");
+  const [autoRollback, setAutoRollback] = useState(app.autoRollback ?? false);
+  const [rollbackGracePeriod, setRollbackGracePeriod] = useState(app.rollbackGracePeriod?.toString() || "60");
 
   // New environment form state
   const [newEnvOpen, setNewEnvOpen] = useState(false);
@@ -1146,6 +1156,8 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
       body.restartPolicy = restartPolicy;
       body.cpuLimit = cpuLimit ? parseFloat(cpuLimit) : null;
       body.memoryLimit = memoryLimit ? parseInt(memoryLimit, 10) : null;
+      body.autoRollback = autoRollback;
+      body.rollbackGracePeriod = rollbackGracePeriod ? parseInt(rollbackGracePeriod, 10) : 60;
       if (editParentId) {
         body.projectId = editParentId;
       } else {
@@ -2684,6 +2696,31 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                   />
                   <Label htmlFor="edit-auto-deploy">Auto Deploy</Label>
                 </div>
+                <div className="flex items-center gap-3">
+                  <Switch
+                    id="edit-auto-rollback"
+                    checked={autoRollback}
+                    onCheckedChange={setAutoRollback}
+                  />
+                  <Label htmlFor="edit-auto-rollback">Auto Rollback</Label>
+                </div>
+                {autoRollback && (
+                  <div className="grid gap-2 pl-10">
+                    <Label htmlFor="edit-rollback-grace">Grace Period (seconds)</Label>
+                    <Input
+                      id="edit-rollback-grace"
+                      type="number"
+                      step="10"
+                      min="10"
+                      max="600"
+                      value={rollbackGracePeriod}
+                      onChange={(e) => setRollbackGracePeriod(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Monitor for container crashes for this duration after deploy. If a crash is detected, automatically roll back to the previous version.
+                    </p>
+                  </div>
+                )}
               </div>
 
               {/* Project */}

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
@@ -33,6 +33,8 @@ const updateAppSchema = z.object({
   })).nullable().optional(),
   cpuLimit: z.number().positive().max(64).nullable().optional(),
   memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
+  autoRollback: z.boolean().optional(),
+  rollbackGracePeriod: z.number().int().min(10).max(600).optional(),
   projectId: z.string().nullable().optional(),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
   cloneStrategy: z.enum(["clone", "clone_data", "empty", "skip"]).optional(),

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -40,6 +40,7 @@ export const deploymentStatusEnum = pgEnum("deployment_status", [
   "success",
   "failed",
   "cancelled",
+  "rolled_back",
 ]);
 
 export const deploymentTriggerEnum = pgEnum("deployment_trigger", [
@@ -340,6 +341,8 @@ export const apps = pgTable(
     needsRedeploy: boolean("needs_redeploy").default(false),
     cpuLimit: real("cpu_limit"), // CPU cores (e.g. 0.5, 1, 2)
     memoryLimit: integer("memory_limit"), // Memory in MB (e.g. 256, 512, 1024)
+    autoRollback: boolean("auto_rollback").default(false), // Rollback on crash after deploy
+    rollbackGracePeriod: integer("rollback_grace_period").default(60), // Seconds to monitor after deploy
     envContent: text("env_content"), // Encrypted env file blob (AES-256-GCM)
     // Compose decomposition: child service records point to parent compose app
     parentAppId: text("parent_app_id").references(() => apps.id, { onDelete: "cascade" }),

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1065,6 +1065,27 @@ export async function runDeployment(
     // Send success notification (non-blocking)
     sendDeployNotification(app, deploymentId, true, durationMs).catch(() => {});
 
+    // Start auto-rollback monitor if enabled
+    if (app.autoRollback && activeSlot) {
+      const gracePeriod = app.rollbackGracePeriod ?? 60;
+      log(`[deploy] Auto-rollback enabled — monitoring for ${gracePeriod}s`);
+      try {
+        const { startRollbackMonitor } = await import("./rollback-monitor");
+        startRollbackMonitor({
+          appId: opts.appId,
+          appName: app.name,
+          organizationId: opts.organizationId,
+          deploymentId,
+          gracePeriodSeconds: gracePeriod,
+          currentSlot: newSlot,
+          previousSlot: activeSlot,
+          envName,
+        });
+      } catch (err) {
+        log(`[deploy] Warning: rollback monitor — ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
     return { deploymentId, success: true, log: logLines.join("\n"), durationMs };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/lib/docker/rollback-monitor.ts
+++ b/lib/docker/rollback-monitor.ts
@@ -1,0 +1,284 @@
+import { db } from "@/lib/db";
+import { deployments, apps } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { join, resolve } from "path";
+import { readFile } from "fs/promises";
+import { listContainers, inspectContainer } from "./client";
+import { publishEvent, appChannel } from "@/lib/events";
+import { recordActivity } from "@/lib/activity";
+
+const execAsync = promisify(exec);
+const PROJECTS_DIR = resolve(process.env.HOST_PROJECTS_DIR || "./.host/projects");
+const POLL_INTERVAL_MS = 5000;
+
+/** In-memory set of app IDs currently being monitored. Prevents concurrent monitors. */
+const activeMonitors = new Set<string>();
+
+type RollbackMonitorOpts = {
+  appId: string;
+  appName: string;
+  organizationId: string;
+  deploymentId: string;
+  gracePeriodSeconds: number;
+  /** The slot that was just deployed (blue or green) */
+  currentSlot: "blue" | "green";
+  /** The slot that was active before this deploy (null if first deploy) */
+  previousSlot: "blue" | "green" | null;
+  /** Environment name for directory resolution */
+  envName: string;
+};
+
+/**
+ * Start a background monitor that watches a freshly deployed container
+ * for crashes within the grace period. If a crash is detected, the
+ * monitor swaps back to the previous blue-green slot and marks the
+ * deployment as rolled_back.
+ *
+ * This function returns immediately -- monitoring runs in the background.
+ * It never throws to the caller.
+ */
+export function startRollbackMonitor(opts: RollbackMonitorOpts): void {
+  // No previous slot means first deploy -- nothing to roll back to
+  if (!opts.previousSlot) return;
+
+  // Guard: skip if this app is already being monitored (e.g. rapid re-deploy)
+  if (activeMonitors.has(opts.appId)) {
+    console.log(
+      `[rollback-monitor] Monitor already active for ${opts.appName}, skipping`
+    );
+    return;
+  }
+
+  const {
+    appId,
+    appName,
+    organizationId,
+    deploymentId,
+    gracePeriodSeconds,
+    currentSlot,
+    previousSlot,
+    envName,
+  } = opts;
+
+  activeMonitors.add(appId);
+  const deadline = Date.now() + gracePeriodSeconds * 1000;
+
+  // The compose project name that Docker labels containers with
+  const slotProjectName = `${appName}-${envName}-${currentSlot}`;
+
+  // Fire-and-forget async loop
+  (async () => {
+    try {
+      while (Date.now() < deadline) {
+        await sleep(POLL_INTERVAL_MS);
+
+        // Check if containers for the current slot are still running
+        const crashed = await isContainerCrashed(appName, envName, slotProjectName);
+
+        if (crashed) {
+          console.log(
+            `[rollback-monitor] Container crashed within grace period for ${appName}, rolling back`
+          );
+
+          await performRollback({
+            appId,
+            appName,
+            organizationId,
+            deploymentId,
+            currentSlot,
+            previousSlot,
+            envName,
+          });
+          return; // Done -- rollback performed
+        }
+      }
+
+      // Grace period passed without crash -- deploy is stable
+      console.log(
+        `[rollback-monitor] Grace period passed for ${appName} -- deploy is stable`
+      );
+    } catch (err) {
+      // Monitor itself failed -- log but never crash the process
+      console.error(
+        `[rollback-monitor] Monitor error for ${appName}:`,
+        err instanceof Error ? err.message : err
+      );
+    } finally {
+      activeMonitors.delete(appId);
+    }
+  })();
+}
+
+/**
+ * Check whether any container for the current deploy slot has exited or is restarting.
+ * Filters by the compose project name to only check containers belonging to the
+ * deployed slot (blue or green), not the previous slot's containers.
+ */
+async function isContainerCrashed(
+  appName: string,
+  _envName: string,
+  slotProjectName: string,
+): Promise<boolean> {
+  try {
+    const containers = await listContainers(appName);
+
+    // Filter to only containers belonging to the current slot's compose project
+    const slotContainers = containers.filter(
+      (c) => c.labels["com.docker.compose.project"] === slotProjectName
+    );
+
+    if (slotContainers.length === 0) {
+      // No containers found for this slot -- treat as crashed
+      return true;
+    }
+
+    for (const c of slotContainers) {
+      const info = await inspectContainer(c.id);
+      const status = info.state.status.toLowerCase();
+      if (status === "exited" || status === "dead" || status === "restarting") {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    // If we can't reach Docker, don't trigger a rollback -- that would be
+    // dangerous on a transient Docker socket error.
+    return false;
+  }
+}
+
+type PerformRollbackOpts = {
+  appId: string;
+  appName: string;
+  organizationId: string;
+  deploymentId: string;
+  currentSlot: "blue" | "green";
+  previousSlot: "blue" | "green";
+  envName: string;
+};
+
+async function performRollback(opts: PerformRollbackOpts): Promise<void> {
+  const {
+    appId,
+    appName,
+    organizationId,
+    deploymentId,
+    currentSlot,
+    previousSlot,
+    envName,
+  } = opts;
+
+  const appDir = join(PROJECTS_DIR, appName, envName);
+
+  // Step 1: Tear down the crashing slot
+  const crashedSlotDir = join(appDir, currentSlot);
+  const crashedProjectName = `${appName}-${envName}-${currentSlot}`;
+  const crashedComposePath = join(crashedSlotDir, "docker-compose.yml");
+
+  try {
+    await execAsync(
+      `docker compose -f "${crashedComposePath}" -p "${crashedProjectName}" down --remove-orphans`,
+      { cwd: crashedSlotDir, timeout: 30000 }
+    );
+  } catch (err) {
+    console.error(
+      `[rollback-monitor] Failed to tear down crashing slot:`,
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  // Step 2: Bring the previous slot back up
+  const prevSlotDir = join(appDir, previousSlot);
+  const prevProjectName = `${appName}-${envName}-${previousSlot}`;
+  const prevComposePath = join(prevSlotDir, "docker-compose.yml");
+
+  try {
+    await execAsync(
+      `docker compose -f "${prevComposePath}" -p "${prevProjectName}" up -d`,
+      { cwd: prevSlotDir, timeout: 60000 }
+    );
+  } catch (err) {
+    // Previous slot also failed -- just alert, don't recurse
+    console.error(
+      `[rollback-monitor] Failed to restore previous slot -- manual intervention required:`,
+      err instanceof Error ? err.message : err
+    );
+
+    await sendRollbackNotification(organizationId, appId, appName, false);
+    return;
+  }
+
+  // Step 3: Swap active slot marker back
+  const { writeFile } = await import("fs/promises");
+  await writeFile(join(appDir, ".active-slot"), previousSlot, "utf-8");
+
+  // Step 4: Update deployment status to rolled_back
+  await db
+    .update(deployments)
+    .set({ status: "rolled_back", finishedAt: new Date() })
+    .where(eq(deployments.id, deploymentId));
+
+  // Step 5: Set app status back to active (previous slot is running)
+  await db
+    .update(apps)
+    .set({ status: "active", updatedAt: new Date() })
+    .where(eq(apps.id, appId));
+
+  // Step 6: Publish event for real-time UI
+  publishEvent(appChannel(appId), {
+    event: "deploy:rolled_back",
+    appId,
+    deploymentId,
+    message: "Container crashed within grace period, rolled back to previous version",
+  }).catch(() => {});
+
+  // Step 7: Record activity
+  recordActivity({
+    organizationId,
+    action: "deployment.rolled_back",
+    appId,
+    metadata: {
+      deploymentId,
+      reason: "Container crashed within grace period",
+      rolledBackTo: previousSlot,
+    },
+  }).catch(() => {});
+
+  // Step 8: Notify
+  await sendRollbackNotification(organizationId, appId, appName, true);
+}
+
+async function sendRollbackNotification(
+  organizationId: string,
+  appId: string,
+  appName: string,
+  success: boolean
+): Promise<void> {
+  try {
+    const { notify } = await import("@/lib/notifications/dispatch");
+    if (success) {
+      notify(organizationId, {
+        type: "deploy-failed",
+        title: `Auto-rollback: ${appName}`,
+        message: `Container crashed after deploy. Rolled back to previous version.`,
+        metadata: { projectName: appName, appId },
+      });
+    } else {
+      notify(organizationId, {
+        type: "deploy-failed",
+        title: `Auto-rollback failed: ${appName}`,
+        message: `Container crashed after deploy and rollback to previous version also failed. Manual intervention required.`,
+        metadata: { projectName: appName, appId },
+      });
+    }
+  } catch (err) {
+    console.error("[rollback-monitor] Notification error:", err);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Adds per-app auto-rollback config (opt-in, default off) with configurable grace period (10-600s, default 60s)
- After successful deploy, background monitor polls container health every 5s for the grace period
- If container crashes/exits/restarts during grace period: tears down new slot, restores previous blue-green slot, marks deployment as `rolled_back`, sends notification
- First deploy is skipped (nothing to roll back to); only rolls back once per deploy (if previous slot also fails, alerts without recursing)
- New `rolled_back` deployment status enum value with UI badge
- UI: auto-rollback toggle and grace period input in app settings (next to Auto Deploy)

## Changes
- `lib/db/schema.ts` -- `autoRollback`, `rollbackGracePeriod` columns on apps table; `rolled_back` added to deployment_status enum
- `lib/docker/rollback-monitor.ts` -- new background health monitor with rollback logic
- `lib/docker/deploy.ts` -- starts rollback monitor after successful deploy when enabled
- `app/api/v1/.../route.ts` -- accepts new fields in PATCH schema
- `app/(app)/apps/[...slug]/app-detail.tsx` -- settings UI and rolled_back status badge

## Safety
- Monitor never blocks deploy response (fire-and-forget async loop)
- Docker API errors during monitoring do NOT trigger rollback (avoids false positives on transient socket issues)
- Single rollback attempt only -- if previous slot also crashes, notifies but does not recurse
- Grace period is bounded (10-600s) to prevent indefinite monitoring

## Test plan
- [ ] Enable auto-rollback on a test app, deploy a healthy image -- verify grace period passes with "deploy is stable" log
- [ ] Enable auto-rollback, deploy a crashing image (e.g. `exit 1` entrypoint) -- verify rollback triggers, previous version restored, deployment marked `rolled_back`
- [ ] First deploy with auto-rollback enabled -- verify monitoring is skipped (no previous slot)
- [ ] Verify `rolled_back` badge renders correctly in deployment history
- [ ] Verify notification dispatched on rollback
- [ ] Toggle auto-rollback on/off in settings, adjust grace period, verify persistence

Closes #32