### PR TITLE
feat(monitoring): disk write alerts per container

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -149,6 +149,7 @@ type App = {
   exposedPorts: { internal: number; external?: number; description?: string }[] | null;
   cpuLimit: number | null;
   memoryLimit: number | null;
+  diskWriteAlertThreshold: number | null;
   autoRollback: boolean | null;
   rollbackGracePeriod: number | null;
   projectId: string | null;
@@ -773,6 +774,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
   const [editParentId, setEditParentId] = useState<string | null>(app.projectId ?? null);
   const [cpuLimit, setCpuLimit] = useState(app.cpuLimit?.toString() || "");
   const [memoryLimit, setMemoryLimit] = useState(app.memoryLimit?.toString() || "");
+  const [diskWriteAlertThreshold, setDiskWriteAlertThreshold] = useState(app.diskWriteAlertThreshold ? (app.diskWriteAlertThreshold / 1_073_741_824).toString() : "");
   const [autoRollback, setAutoRollback] = useState(app.autoRollback ?? false);
   const [rollbackGracePeriod, setRollbackGracePeriod] = useState(app.rollbackGracePeriod?.toString() || "60");
 
@@ -1174,6 +1176,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
       body.restartPolicy = restartPolicy;
       body.cpuLimit = cpuLimit ? parseFloat(cpuLimit) : null;
       body.memoryLimit = memoryLimit ? parseInt(memoryLimit, 10) : null;
+      body.diskWriteAlertThreshold = diskWriteAlertThreshold ? Math.round(parseFloat(diskWriteAlertThreshold) * 1_073_741_824) : null;
       body.autoRollback = autoRollback;
       body.rollbackGracePeriod = rollbackGracePeriod ? parseInt(rollbackGracePeriod, 10) : 60;
       if (editParentId) {
@@ -2835,7 +2838,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
               </div>
 
               {/* Resource Limits */}
-              <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-4 sm:grid-cols-3">
                 <div className="grid gap-2">
                   <Label htmlFor="edit-cpu-limit">CPU Limit (cores)</Label>
                   <Input id="edit-cpu-limit" type="number" step="0.1" min="0.1" placeholder="No limit" value={cpuLimit} onChange={(e) => setCpuLimit(e.target.value)} />
@@ -2845,6 +2848,11 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                   <Label htmlFor="edit-memory-limit">Memory Limit (MB)</Label>
                   <Input id="edit-memory-limit" type="number" step="64" min="64" placeholder="No limit" value={memoryLimit} onChange={(e) => setMemoryLimit(e.target.value)} />
                   <p className="text-xs text-muted-foreground">{memoryLimit ? memoryLimit + " MB" : "No limit"}</p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-disk-write-threshold">Disk Write Alert (GB/hr)</Label>
+                  <Input id="edit-disk-write-threshold" type="number" step="0.5" min="0.1" placeholder="Default: 1 GB" value={diskWriteAlertThreshold} onChange={(e) => setDiskWriteAlertThreshold(e.target.value)} />
+                  <p className="text-xs text-muted-foreground">{diskWriteAlertThreshold ? diskWriteAlertThreshold + " GB/hr" : "Default: 1 GB/hr"}</p>
                 </div>
               </div>
 

--- a/app/(app)/apps/new/new-app-flow.tsx
+++ b/app/(app)/apps/new/new-app-flow.tsx
@@ -63,6 +63,7 @@ type Template = {
     | null;
   defaultCpuLimit: number | null;
   defaultMemoryLimit: number | null;
+  defaultDiskWriteAlertThreshold: number | null;
 };
 
 type Installation = {
@@ -164,6 +165,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
   const [createRepo, setCreateRepo] = useState(false);
   const [cpuLimit, setCpuLimit] = useState("");
   const [memoryLimit, setMemoryLimit] = useState("");
+  const [diskWriteAlertThreshold, setDiskWriteAlertThreshold] = useState("");
 
   // Domain
   const [generateDomain, setGenerateDomain] = useState(true);
@@ -294,6 +296,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
     setTemplateConnectionInfo(template.defaultConnectionInfo || []);
     setCpuLimit(template.defaultCpuLimit?.toString() || "");
     setMemoryLimit(template.defaultMemoryLimit?.toString() || "");
+    setDiskWriteAlertThreshold(template.defaultDiskWriteAlertThreshold ? (template.defaultDiskWriteAlertThreshold / 1_073_741_824).toString() : "");
     if (template.defaultEnvVars?.length) {
       const slug = slugify(template.name);
       const lines: string[] = [`# ${template.displayName} configuration`];
@@ -396,6 +399,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
       if (containerPort) body.containerPort = parseInt(containerPort, 10);
       if (cpuLimit) body.cpuLimit = parseFloat(cpuLimit);
       if (memoryLimit) body.memoryLimit = parseInt(memoryLimit, 10);
+      if (diskWriteAlertThreshold) body.diskWriteAlertThreshold = Math.round(parseFloat(diskWriteAlertThreshold) * 1_073_741_824);
       if (rootDirectory.trim()) body.rootDirectory = rootDirectory.trim();
 
       // Create GitHub repo if opted in
@@ -868,7 +872,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
             )}
 
             {/* Resource Limits */}
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-3">
               <div className="grid gap-2">
                 <Label htmlFor="cpu-limit">CPU Limit (cores)</Label>
                 <Input id="cpu-limit" type="number" step="0.1" min="0.1" placeholder="No limit" value={cpuLimit} onChange={(e) => setCpuLimit(e.target.value)} />
@@ -876,6 +880,11 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], default
               <div className="grid gap-2">
                 <Label htmlFor="memory-limit">Memory Limit (MB)</Label>
                 <Input id="memory-limit" type="number" step="64" min="64" placeholder="No limit" value={memoryLimit} onChange={(e) => setMemoryLimit(e.target.value)} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="disk-write-threshold">Disk Write Alert (GB/hr)</Label>
+                <Input id="disk-write-threshold" type="number" step="0.5" min="0.1" placeholder="Default: 1 GB" value={diskWriteAlertThreshold} onChange={(e) => setDiskWriteAlertThreshold(e.target.value)} />
+                <p className="text-xs text-muted-foreground">{diskWriteAlertThreshold ? diskWriteAlertThreshold + " GB/hr" : "Default: 1 GB/hr"}</p>
               </div>
             </div>
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/route.ts
@@ -33,6 +33,7 @@ const updateAppSchema = z.object({
   })).nullable().optional(),
   cpuLimit: z.number().positive().max(64).nullable().optional(),
   memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
+  diskWriteAlertThreshold: z.number().int().min(0).nullable().optional(), // bytes/hour, null = default 1GB
   autoRollback: z.boolean().optional(),
   rollbackGracePeriod: z.number().int().min(10).max(600).optional(),
   projectId: z.string().nullable().optional(),

--- a/app/api/v1/organizations/[orgId]/apps/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/route.ts
@@ -52,6 +52,7 @@ const createAppSchema = z
     })).optional(),
     cpuLimit: z.number().positive().max(64).nullable().optional(),
     memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
+    diskWriteAlertThreshold: z.number().int().min(0).nullable().optional(),
     projectId: z.string().optional(),
   })
   .refine(
@@ -193,6 +194,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         connectionInfo: data.connectionInfo,
         cpuLimit: data.cpuLimit ?? null,
         memoryLimit: data.memoryLimit ?? null,
+        diskWriteAlertThreshold: data.diskWriteAlertThreshold ?? null,
       })
       .returning();
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -342,6 +342,7 @@ export const apps = pgTable(
     needsRedeploy: boolean("needs_redeploy").default(false),
     cpuLimit: real("cpu_limit"), // CPU cores (e.g. 0.5, 1, 2)
     memoryLimit: integer("memory_limit"), // Memory in MB (e.g. 256, 512, 1024)
+    diskWriteAlertThreshold: bigint("disk_write_alert_threshold", { mode: "number" }), // bytes/hour, null = default 1GB
     autoRollback: boolean("auto_rollback").default(false), // Rollback on crash after deploy
     rollbackGracePeriod: integer("rollback_grace_period").default(60), // Seconds to monitor after deploy
     envContent: text("env_content"), // Encrypted env file blob (AES-256-GCM)

--- a/lib/metrics/cadvisor.ts
+++ b/lib/metrics/cadvisor.ts
@@ -13,6 +13,7 @@ export type ContainerMetrics = {
   networkTxBytes: number;
   diskUsage: number;
   diskLimit: number;
+  diskWriteBytes: number; // cumulative block I/O writes
   timestamp: number;
 };
 
@@ -28,6 +29,10 @@ type V2StatEntry = {
   };
   has_filesystem: boolean;
   filesystem?: { device: string; usage: number; capacity: number }[];
+  has_diskio: boolean;
+  diskio?: {
+    io_service_bytes?: { device: string; major: number; minor: number; stats: Record<string, number> }[];
+  };
 };
 
 type V2SpecEntry = {
@@ -118,6 +123,14 @@ export async function fetchAllContainerMetrics(): Promise<ContainerMetrics[]> {
       }
     }
 
+    // Disk I/O writes (cumulative)
+    let diskWriteBytes = 0;
+    if (curr.diskio?.io_service_bytes) {
+      for (const dev of curr.diskio.io_service_bytes) {
+        diskWriteBytes += dev.stats?.Write || 0;
+      }
+    }
+
     const containerName = spec.aliases?.[0] || key.split("/").pop() || "";
     const containerId = key.split("/").pop()?.slice(0, 12) || "";
 
@@ -134,6 +147,7 @@ export async function fetchAllContainerMetrics(): Promise<ContainerMetrics[]> {
       networkTxBytes,
       diskUsage,
       diskLimit,
+      diskWriteBytes,
       timestamp: new Date(curr.timestamp).getTime(),
     });
   }

--- a/lib/metrics/collector.ts
+++ b/lib/metrics/collector.ts
@@ -1,6 +1,7 @@
 import { isMetricsEnabled } from "./config";
 import { fetchAllContainerMetrics } from "./cadvisor";
-import { storeMetrics, storeDiskUsage, storeProjectDisk, storeBusinessMetric, storeOrgBusinessMetric } from "./store";
+import { storeMetrics, storeDiskUsage, storeDiskWrite, storeProjectDisk, storeBusinessMetric, storeOrgBusinessMetric } from "./store";
+import { checkDiskWriteAlerts } from "./disk-write-alerts";
 import { getSystemDiskUsage, getPerProjectDiskUsage } from "@/lib/docker/client";
 import { db } from "@/lib/db";
 import { sql } from "drizzle-orm";
@@ -45,18 +46,20 @@ function scheduleTick() {
 }
 
 async function collect() {
+  let metrics: Awaited<ReturnType<typeof fetchAllContainerMetrics>> = [];
   try {
-    const metrics = await fetchAllContainerMetrics();
+    metrics = await fetchAllContainerMetrics();
     const results = await Promise.allSettled(
-      metrics.map((m) =>
+      metrics.flatMap((m) => [
         storeMetrics(m.projectName, m.containerId, m.containerName, m.timestamp, {
           cpuPercent: m.cpuPercent,
           memoryUsage: m.memoryUsage,
           memoryLimit: m.memoryLimit,
           networkRxBytes: m.networkRxBytes,
           networkTxBytes: m.networkTxBytes,
-        }, m.organizationId)
-      )
+        }, m.organizationId),
+        storeDiskWrite(m.projectName, m.containerId, m.containerName, m.timestamp, m.diskWriteBytes, m.organizationId),
+      ])
     );
     const failed = results.filter((r) => r.status === "rejected").length;
     if (failed > 0) {
@@ -64,6 +67,16 @@ async function collect() {
     }
   } catch (err) {
     console.error("[collector] Error:", (err as Error).message);
+  }
+
+  // Disk write alert check: every 6th tick after warmup (~3 min at 30s interval)
+  // During warmup, skip to accumulate baseline data
+  if (tickCount >= WARMUP_TICKS && tickCount % 6 === 0 && metrics.length > 0) {
+    try {
+      await checkDiskWriteAlerts(metrics);
+    } catch (err) {
+      console.error("[collector] Disk write alert check error:", (err as Error).message);
+    }
   }
 
   // Disk usage: every 10th tick during warmup, every 10th tick after (~5 min at 30s)

--- a/lib/metrics/disk-write-alerts.ts
+++ b/lib/metrics/disk-write-alerts.ts
@@ -1,0 +1,136 @@
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { notify } from "@/lib/notifications/dispatch";
+import { queryDiskWriteRange } from "./store";
+import type { ContainerMetrics } from "./cadvisor";
+
+// Default threshold: 1 GB/hour
+const DEFAULT_THRESHOLD_BYTES = 1_073_741_824;
+
+// Rate limit: don't re-alert for the same container within 1 hour
+const ALERT_COOLDOWN_MS = 60 * 60 * 1000;
+
+// In-memory map of last alert times: containerKey -> timestamp
+const lastAlertTimes = new Map<string, number>();
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) return (bytes / 1_073_741_824).toFixed(1) + " GB";
+  if (bytes >= 1_048_576) return (bytes / 1_048_576).toFixed(1) + " MB";
+  return (bytes / 1024).toFixed(1) + " KB";
+}
+
+function formatThreshold(bytes: number): string {
+  if (bytes >= 1_073_741_824) {
+    const gb = bytes / 1_073_741_824;
+    return Number.isInteger(gb) ? gb + " GB" : gb.toFixed(1) + " GB";
+  }
+  if (bytes >= 1_048_576) {
+    const mb = bytes / 1_048_576;
+    return Number.isInteger(mb) ? mb + " MB" : mb.toFixed(1) + " MB";
+  }
+  return (bytes / 1024).toFixed(0) + " KB";
+}
+
+/**
+ * Check disk write rates for all containers from the latest collection tick.
+ * Compares the delta of cumulative disk writes over the last hour against
+ * per-app thresholds (or the default 1 GB/hour).
+ *
+ * This is alert-only -- it never blocks deploys or operations.
+ */
+export async function checkDiskWriteAlerts(
+  metrics: ContainerMetrics[],
+): Promise<void> {
+  const now = Date.now();
+  const oneHourAgo = now - 60 * 60 * 1000;
+
+  // Group containers by their project name to batch DB lookups
+  const projectContainers = new Map<string, ContainerMetrics[]>();
+  for (const m of metrics) {
+    if (!m.projectName) continue;
+    const list = projectContainers.get(m.projectName) || [];
+    list.push(m);
+    projectContainers.set(m.projectName, list);
+  }
+
+  for (const [projectName, containers] of projectContainers) {
+    for (const container of containers) {
+      const alertKey = `${projectName}:${container.containerId}`;
+
+      // Rate limit check
+      const lastAlert = lastAlertTimes.get(alertKey);
+      if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) continue;
+
+      // Query the last hour of disk write data from Redis TimeSeries
+      const points = await queryDiskWriteRange(
+        projectName,
+        container.containerId,
+        oneHourAgo,
+        now,
+      );
+
+      if (points.length < 2) continue;
+
+      // Compute delta: cumulative counter difference between oldest and newest
+      const oldest = points[0][1];
+      const newest = points[points.length - 1][1];
+      const writtenInHour = newest - oldest;
+
+      if (writtenInHour <= 0) continue;
+
+      // Look up the app's configured threshold
+      let threshold = DEFAULT_THRESHOLD_BYTES;
+      try {
+        // Match app by containerName (most reliable) or project name
+        const app = await db.query.apps.findFirst({
+          where: eq(apps.containerName, container.containerName),
+          columns: {
+            id: true,
+            displayName: true,
+            organizationId: true,
+            diskWriteAlertThreshold: true,
+            templateName: true,
+          },
+        });
+
+        if (app?.diskWriteAlertThreshold) {
+          threshold = app.diskWriteAlertThreshold;
+        }
+
+        if (writtenInHour > threshold) {
+          lastAlertTimes.set(alertKey, now);
+
+          const appName = app?.displayName || container.containerName;
+          const orgId = app?.organizationId || container.organizationId;
+
+          if (orgId) {
+            notify(orgId, {
+              type: "disk-write-alert",
+              title: `High disk writes: ${appName}`,
+              message: `App '${appName}' wrote ${formatBytes(writtenInHour)} in the last hour (threshold: ${formatThreshold(threshold)})`,
+              metadata: {
+                appId: app?.id || "",
+                containerName: container.containerName,
+                containerId: container.containerId,
+                writtenBytes: writtenInHour.toString(),
+                thresholdBytes: threshold.toString(),
+                window: "1h",
+              },
+            });
+
+            console.warn(
+              `[disk-write-alert] ${appName} (${container.containerName}): ` +
+              `${formatBytes(writtenInHour)}/hour exceeds ${formatThreshold(threshold)} threshold`,
+            );
+          }
+        }
+      } catch (err) {
+        console.error(
+          `[disk-write-alert] Error checking ${container.containerName}:`,
+          (err as Error).message,
+        );
+      }
+    }
+  }
+}

--- a/lib/metrics/store.ts
+++ b/lib/metrics/store.ts
@@ -107,6 +107,50 @@ export async function storeMetrics(
 }
 
 /**
+ * Store cumulative disk write bytes for a container.
+ */
+export async function storeDiskWrite(
+  projectName: string,
+  containerId: string,
+  containerName: string,
+  timestamp: number,
+  writeBytes: number,
+  organizationId?: string | null,
+) {
+  const key = tsKey(projectName, "diskWrite", containerId);
+  const labels: Record<string, string> = {
+    project: projectName,
+    container: containerId,
+    containerName: containerName,
+    metric: "diskWrite",
+  };
+  if (organizationId) labels.organization = organizationId;
+  await ensureTimeSeries(key, labels);
+  await tsRedis.call("TS.ADD", key, timestamp.toString(), writeBytes.toString());
+}
+
+/**
+ * Query disk write bytes for a specific container over a time range.
+ * Returns raw [timestamp, value] pairs (cumulative counters).
+ */
+export async function queryDiskWriteRange(
+  projectName: string,
+  containerId: string,
+  fromMs: number,
+  toMs: number,
+): Promise<TimeSeriesPoint[]> {
+  const key = tsKey(projectName, "diskWrite", containerId);
+  try {
+    const result = (await tsRedis.call(
+      "TS.RANGE", key, fromMs.toString(), toMs.toString(),
+    )) as [string, string][];
+    return result.map(([ts, val]) => [parseInt(ts), parseFloat(val)]);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Store system-level disk usage (not per-project).
  */
 export async function storeDiskUsage(
@@ -286,7 +330,7 @@ export type TimeSeriesPoint = [number, number]; // [timestamp, value]
  * Query historical metrics for a project.
  * Returns data points within the given time range.
  */
-type MetricName = "cpu" | "memory" | "memoryLimit" | "networkRx" | "networkTx" | "disk";
+type MetricName = "cpu" | "memory" | "memoryLimit" | "networkRx" | "networkTx" | "disk" | "diskWrite";
 type Aggregation = { type: "avg" | "max" | "min" | "sum"; bucketMs: number };
 
 /**

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -1,3 +1,3 @@
-export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed" | "volume-drift";
+export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed" | "volume-drift" | "disk-write-alert";
 export type NotificationEvent = { type: NotificationEventType; title: string; message: string; metadata: Record<string, string> };
 export interface NotificationChannel { send(event: NotificationEvent): Promise<void>; }

--- a/lib/templates/load.ts
+++ b/lib/templates/load.ts
@@ -34,6 +34,7 @@ export type Template = {
     | null;
   defaultCpuLimit: number | null;
   defaultMemoryLimit: number | null;
+  defaultDiskWriteAlertThreshold: number | null; // bytes/hour, null = system default (1GB)
   isBuiltIn: boolean;
 };
 
@@ -78,6 +79,7 @@ export async function loadTemplates(): Promise<Template[]> {
         defaultCronJobs: (raw.cronJobs as Template["defaultCronJobs"]) ?? null,
         defaultCpuLimit: (raw.cpuLimit as number) ?? null,
         defaultMemoryLimit: (raw.memoryLimit as number) ?? null,
+        defaultDiskWriteAlertThreshold: (raw.diskWriteAlertThreshold as number) ?? null,
         isBuiltIn: true,
       });
     } catch (err) {

--- a/templates/mariadb.toml
+++ b/templates/mariadb.toml
@@ -8,6 +8,7 @@ source = "direct"
 deployType = "image"
 imageName = "mariadb:11"
 defaultPort = 3306
+diskWriteAlertThreshold = 5368709120  # 5 GB/hour (databases write more)
 
 [[envVars]]
 key = "MARIADB_ROOT_PASSWORD"

--- a/templates/mongo.toml
+++ b/templates/mongo.toml
@@ -8,6 +8,7 @@ source = "direct"
 deployType = "image"
 imageName = "mongo:7"
 defaultPort = 27017
+diskWriteAlertThreshold = 5368709120  # 5 GB/hour (databases write more)
 
 [[envVars]]
 key = "MONGO_INITDB_ROOT_USERNAME"

--- a/templates/mysql.toml
+++ b/templates/mysql.toml
@@ -8,6 +8,7 @@ source = "direct"
 deployType = "image"
 imageName = "mysql:8"
 defaultPort = 3306
+diskWriteAlertThreshold = 5368709120  # 5 GB/hour (databases write more)
 
 [[envVars]]
 key = "MYSQL_ROOT_PASSWORD"

--- a/templates/postgres.toml
+++ b/templates/postgres.toml
@@ -8,6 +8,7 @@ source = "direct"
 deployType = "image"
 imageName = "postgres:16"
 defaultPort = 5432
+diskWriteAlertThreshold = 5368709120  # 5 GB/hour (databases write more)
 
 [[envVars]]
 key = "POSTGRES_PASSWORD"

--- a/templates/redis.toml
+++ b/templates/redis.toml
@@ -8,6 +8,7 @@ source = "direct"
 deployType = "image"
 imageName = "redis:7-alpine"
 defaultPort = 6379
+diskWriteAlertThreshold = 5368709120  # 5 GB/hour (data stores write more)
 
 [[envVars]]
 key = "REDIS_PASSWORD"


### PR DESCRIPTION
## Summary
- Track cumulative block I/O writes per container from cAdvisor v2 diskio stats
- Store disk write counters in Redis TimeSeries alongside existing metrics
- Alert via notification system when any container exceeds its hourly write threshold
- Default threshold: 1 GB/hour, configurable per app via `diskWriteAlertThreshold` column
- Database templates (postgres, mysql, mariadb, mongo, redis) default to 5 GB/hour
- Rate-limited: max one alert per container per hour
- Alert only -- never blocks deploys or operations
- UI: threshold input in app settings alongside CPU/memory resource limits

## Changed files
- `lib/db/schema.ts` -- new `disk_write_alert_threshold` bigint column on apps
- `lib/metrics/cadvisor.ts` -- parse diskio write bytes from cAdvisor v2
- `lib/metrics/store.ts` -- `storeDiskWrite` / `queryDiskWriteRange` helpers
- `lib/metrics/disk-write-alerts.ts` -- threshold checker with rate limiting
- `lib/metrics/collector.ts` -- store writes every tick, check thresholds every ~3min
- `lib/notifications/port.ts` -- new `disk-write-alert` event type
- `lib/templates/load.ts` -- `defaultDiskWriteAlertThreshold` on Template type
- `app/api/v1/.../apps/route.ts` -- accept field on POST
- `app/api/v1/.../apps/[appId]/route.ts` -- accept field on PATCH
- `app/(app)/apps/new/new-app-flow.tsx` -- threshold input in create flow
- `app/(app)/apps/[...slug]/app-detail.tsx` -- threshold input in edit settings
- `templates/{postgres,mysql,mariadb,mongo,redis}.toml` -- 5 GB default

## Test plan
- [ ] Deploy a container with heavy writes, confirm alert fires after 1hr window
- [ ] Set custom threshold on an app, confirm it's respected
- [ ] Verify rate limiting: same container does not re-alert within 1 hour
- [ ] Verify database templates show 5 GB default in new-app-flow
- [ ] Confirm no deploy blocking -- alerts are fire-and-forget
- [ ] Run `pnpm typecheck` -- no new errors introduced