### PR TITLE
fix(email): redesign templates — clean, light, Notion-inspired

### DIFF
--- a/lib/email/templates/auto-rollback.tsx
+++ b/lib/email/templates/auto-rollback.tsx
@@ -1,0 +1,64 @@
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, WarningBox, InfoBox, styles } from "./components";
+
+type AutoRollbackProps = {
+  appName: string;
+  reason: string;
+  fromDeploymentId: string;
+  toDeploymentId: string;
+  dashboardUrl: string;
+};
+
+export function AutoRollbackEmail({
+  appName,
+  reason,
+  fromDeploymentId,
+  toDeploymentId,
+  dashboardUrl,
+}: AutoRollbackProps) {
+  return (
+    <EmailLayout preview={`Auto-rollback triggered for ${appName}`}>
+      <Heading style={styles.h1}>Auto-rollback triggered</Heading>
+      <Text style={styles.text}>
+        <strong>{appName}</strong> was automatically rolled back to a previous
+        deployment.
+      </Text>
+
+      <WarningBox>
+        <Text style={styles.warningLabel}>Reason</Text>
+        <Text style={styles.warningText}>{reason}</Text>
+      </WarningBox>
+
+      <InfoBox>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Rolled back from</span>{" "}
+          <code style={styles.code}>{(fromDeploymentId ?? "").slice(0, 8)}</code>
+        </Text>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Restored to</span>{" "}
+          <code style={styles.code}>{(toDeploymentId ?? "").slice(0, 8)}</code>
+        </Text>
+      </InfoBox>
+
+      <Text style={styles.muted}>
+        Auto-rollback activates when a newly deployed container crashes within
+        the grace period. The previous healthy deployment was restored to
+        minimize downtime.
+      </Text>
+
+      <CTA href={`${dashboardUrl}?tab=deployments`}>
+        View deployment &rarr;
+      </CTA>
+    </EmailLayout>
+  );
+}
+
+AutoRollbackEmail.PreviewProps = {
+  appName: "acme-web",
+  reason: "Container exited with code 137 (OOMKilled) within 30s of deploy",
+  fromDeploymentId: "dep_abc123def456",
+  toDeploymentId: "dep_789xyz012345",
+  dashboardUrl: "https://host.example.com/projects/acme-web",
+} satisfies AutoRollbackProps;
+
+export default AutoRollbackEmail;

--- a/lib/email/templates/backup-failed.tsx
+++ b/lib/email/templates/backup-failed.tsx
@@ -1,0 +1,48 @@
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, ErrorBox, styles } from "./components";
+
+type BackupFailedProps = {
+  appName: string;
+  volumeName?: string;
+  errorMessage: string;
+  dashboardUrl: string;
+};
+
+export function BackupFailedEmail({
+  appName,
+  volumeName,
+  errorMessage,
+  dashboardUrl,
+}: BackupFailedProps) {
+  return (
+    <EmailLayout preview={`Backup failed for ${appName}`}>
+      <Heading style={styles.h1}>Backup failed</Heading>
+      <Text style={styles.text}>
+        A backup for <strong>{appName}</strong> failed
+        {volumeName && (
+          <span>
+            {" "}
+            on volume <strong>{volumeName}</strong>
+          </span>
+        )}
+        .
+      </Text>
+
+      <ErrorBox>
+        <Text style={styles.errorLabel}>Error</Text>
+        <Text style={styles.errorText}>{errorMessage}</Text>
+      </ErrorBox>
+
+      <CTA href={`${dashboardUrl}?tab=backups`}>View logs &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+BackupFailedEmail.PreviewProps = {
+  appName: "acme-db",
+  volumeName: "postgres_data",
+  errorMessage: "tar: /var/lib/postgresql/data: Cannot open: Permission denied",
+  dashboardUrl: "https://host.example.com/projects/acme-db",
+} satisfies BackupFailedProps;
+
+export default BackupFailedEmail;

--- a/lib/email/templates/backup-success.tsx
+++ b/lib/email/templates/backup-success.tsx
@@ -1,0 +1,67 @@
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, SuccessBox, styles } from "./components";
+
+type BackupSuccessProps = {
+  appName: string;
+  volumeNames: string[];
+  totalSize: string;
+  duration: string;
+  storageBucket?: string;
+  storageTarget?: string;
+  dashboardUrl: string;
+};
+
+export function BackupSuccessEmail({
+  appName,
+  volumeNames,
+  totalSize,
+  duration,
+  storageBucket,
+  storageTarget,
+  dashboardUrl,
+}: BackupSuccessProps) {
+  return (
+    <EmailLayout preview={`Backup complete for ${appName}`}>
+      <Heading style={styles.h1}>Backup complete</Heading>
+      <Text style={styles.text}>
+        <strong>{appName}</strong> was backed up successfully.
+      </Text>
+
+      <SuccessBox>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Volumes</span>{" "}
+          <span style={styles.kvValue}>{(volumeNames ?? []).join(", ")}</span>
+        </Text>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Total size</span>{" "}
+          <span style={styles.kvValue}>{totalSize}</span>
+        </Text>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Duration</span>{" "}
+          <span style={styles.kvValue}>{duration}</span>
+        </Text>
+        {(storageBucket || storageTarget) && (
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Storage</span>{" "}
+            <span style={styles.kvValue}>
+              {storageBucket || storageTarget}
+            </span>
+          </Text>
+        )}
+      </SuccessBox>
+
+      <CTA href={`${dashboardUrl}?tab=backups`}>View backups &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+BackupSuccessEmail.PreviewProps = {
+  appName: "acme-db",
+  volumeNames: ["postgres_data", "redis_data"],
+  totalSize: "2.4 GB",
+  duration: "3m 12s",
+  storageBucket: "s3://backups/acme-db",
+  dashboardUrl: "https://host.example.com/projects/acme-db",
+} satisfies BackupSuccessProps;
+
+export default BackupSuccessEmail;

--- a/lib/email/templates/components.tsx
+++ b/lib/email/templates/components.tsx
@@ -1,0 +1,341 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import type { CSSProperties, ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// Design tokens (inline styles for email compatibility)
+// ---------------------------------------------------------------------------
+
+const fontFamily =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+
+const monoFamily =
+  '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+export function EmailLayout({
+  preview,
+  children,
+}: {
+  preview: string;
+  children: ReactNode;
+}) {
+  return (
+    <Html>
+      <Head />
+      <Preview>{preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: "#fafafa",
+          fontFamily,
+        }}
+      >
+        <Container
+          style={{
+            maxWidth: "480px",
+            margin: "40px auto",
+            padding: "40px 32px",
+            backgroundColor: "#ffffff",
+            borderRadius: "8px",
+          }}
+        >
+          <Text
+            style={{
+              fontSize: "16px",
+              fontWeight: "600",
+              color: "#1a1a1a",
+              margin: "0 0 32px",
+            }}
+          >
+            Host
+          </Text>
+          {children}
+          <Hr style={{ borderColor: "#eeeeee", margin: "32px 0 24px" }} />
+          <Text style={{ color: "#b0b0b0", fontSize: "12px", margin: "0" }}>
+            Sent by Host
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CTA button
+// ---------------------------------------------------------------------------
+
+export function CTA({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      href={href}
+      style={{
+        backgroundColor: "#1a1a1a",
+        color: "#ffffff",
+        padding: "12px 24px",
+        borderRadius: "6px",
+        fontWeight: "500",
+        fontSize: "14px",
+        textDecoration: "none",
+        display: "inline-block",
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Semantic boxes
+// ---------------------------------------------------------------------------
+
+function BoxWrapper({
+  bg,
+  border,
+  children,
+}: {
+  bg: string;
+  border: string;
+  children: ReactNode;
+}) {
+  return (
+    <Section
+      style={{
+        backgroundColor: bg,
+        borderRadius: "6px",
+        padding: "12px 16px",
+        margin: "0 0 16px",
+        border: `1px solid ${border}`,
+      }}
+    >
+      {children}
+    </Section>
+  );
+}
+
+export function InfoBox({ children }: { children: ReactNode }) {
+  return (
+    <BoxWrapper bg="#f5f5f5" border="#eeeeee">
+      {children}
+    </BoxWrapper>
+  );
+}
+
+export function ErrorBox({ children }: { children: ReactNode }) {
+  return (
+    <BoxWrapper bg="#fef2f2" border="#fecaca">
+      {children}
+    </BoxWrapper>
+  );
+}
+
+export function WarningBox({ children }: { children: ReactNode }) {
+  return (
+    <BoxWrapper bg="#fffbeb" border="#fde68a">
+      {children}
+    </BoxWrapper>
+  );
+}
+
+export function SuccessBox({ children }: { children: ReactNode }) {
+  return (
+    <BoxWrapper bg="#f0fdf4" border="#bbf7d0">
+      {children}
+    </BoxWrapper>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Code block (pre-formatted text)
+// ---------------------------------------------------------------------------
+
+export function CodeBlock({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      style={{
+        fontFamily: monoFamily,
+        backgroundColor: "#1a1a1a",
+        borderRadius: "6px",
+        padding: "14px 16px",
+        margin: "0 0 16px",
+        fontSize: "12px",
+        lineHeight: "18px",
+        color: "#e0e0e0",
+        whiteSpace: "pre-wrap" as const,
+        overflowWrap: "break-word" as const,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Label (uppercase, small, muted -- used above boxes/sections)
+// ---------------------------------------------------------------------------
+
+export function Label({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      style={{
+        color: "#888888",
+        fontSize: "12px",
+        lineHeight: "18px",
+        margin: "0 0 4px",
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.05em",
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Re-usable inline styles for template authors
+// ---------------------------------------------------------------------------
+
+export const styles = {
+  h1: {
+    color: "#1a1a1a",
+    fontSize: "22px",
+    fontWeight: "600",
+    margin: "0 0 12px",
+    lineHeight: "1.3",
+  } as CSSProperties,
+
+  text: {
+    color: "#333333",
+    fontSize: "14px",
+    lineHeight: "24px",
+    margin: "0 0 16px",
+  } as CSSProperties,
+
+  muted: {
+    color: "#888888",
+    fontSize: "13px",
+    lineHeight: "22px",
+    margin: "0 0 16px",
+  } as CSSProperties,
+
+  link: {
+    color: "#1a1a1a",
+    fontWeight: "500",
+  } as CSSProperties,
+
+  mono: {
+    fontFamily: monoFamily,
+  } as CSSProperties,
+
+  // Key-value row inside an InfoBox/ErrorBox
+  kvRow: {
+    color: "#333333",
+    fontSize: "13px",
+    lineHeight: "22px",
+    margin: "0",
+  } as CSSProperties,
+
+  kvLabel: {
+    color: "#888888",
+    fontSize: "12px",
+    display: "inline-block" as const,
+    width: "110px",
+  } as CSSProperties,
+
+  kvValue: {
+    color: "#1a1a1a",
+    fontWeight: "500" as const,
+  } as CSSProperties,
+
+  // Inline code (SHA, branch names, commands)
+  code: {
+    fontFamily: monoFamily,
+    backgroundColor: "#eeeeee",
+    padding: "1px 6px",
+    borderRadius: "3px",
+    fontSize: "12px",
+    color: "#333333",
+  } as CSSProperties,
+
+  // Error-tinted label/text
+  errorLabel: {
+    color: "#991b1b",
+    fontSize: "12px",
+    lineHeight: "18px",
+    margin: "0 0 4px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.05em",
+  } as CSSProperties,
+
+  errorText: {
+    fontFamily: monoFamily,
+    color: "#991b1b",
+    fontSize: "13px",
+    margin: "0",
+    lineHeight: "20px",
+    whiteSpace: "pre-wrap" as const,
+  } as CSSProperties,
+
+  // Warning-tinted text
+  warningText: {
+    color: "#92400e",
+    fontSize: "13px",
+    lineHeight: "20px",
+    margin: "0",
+  } as CSSProperties,
+
+  warningLabel: {
+    color: "#92400e",
+    fontSize: "12px",
+    lineHeight: "18px",
+    margin: "0 0 4px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.05em",
+  } as CSSProperties,
+
+  // Stage row (build pipeline)
+  stageRow: {
+    color: "#333333",
+    fontSize: "13px",
+    lineHeight: "22px",
+    margin: "0",
+    padding: "2px 0",
+    borderBottom: "1px solid #f0f0f0",
+  } as CSSProperties,
+
+  stageDuration: {
+    color: "#888888",
+    fontFamily: monoFamily,
+    fontSize: "12px",
+    float: "right" as const,
+  } as CSSProperties,
+
+  // Badge (small inline pill)
+  badge: (bg: string, color: string): CSSProperties => ({
+    backgroundColor: bg,
+    color,
+    padding: "2px 8px",
+    borderRadius: "4px",
+    fontSize: "12px",
+    fontWeight: "500",
+    display: "inline-block",
+    marginRight: "6px",
+  }),
+};

--- a/lib/email/templates/cron-failed.tsx
+++ b/lib/email/templates/cron-failed.tsx
@@ -1,0 +1,77 @@
+import { Heading, Section, Text } from "@react-email/components";
+import { EmailLayout, CTA, InfoBox, CodeBlock, Label, styles } from "./components";
+
+type CronFailedProps = {
+  jobName: string;
+  appName: string;
+  command: string;
+  errorOutput?: string;
+  duration?: string;
+  exitCode?: number;
+  dashboardUrl: string;
+};
+
+export function CronFailedEmail({
+  jobName,
+  appName,
+  command,
+  errorOutput,
+  duration,
+  exitCode,
+  dashboardUrl,
+}: CronFailedProps) {
+  const truncatedOutput =
+    errorOutput && errorOutput.length > 500
+      ? errorOutput.slice(-500) + "\n..."
+      : errorOutput;
+
+  return (
+    <EmailLayout preview={`Cron job failed: ${jobName} on ${appName}`}>
+      <Heading style={styles.h1}>Cron job failed</Heading>
+      <Text style={styles.text}>
+        <strong>{jobName}</strong> failed on <strong>{appName}</strong>.
+      </Text>
+
+      <InfoBox>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Command</span>{" "}
+          <code style={styles.code}>{command}</code>
+        </Text>
+        {duration && (
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Duration</span>{" "}
+            <span style={styles.kvValue}>{duration}</span>
+          </Text>
+        )}
+        {exitCode !== undefined && (
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Exit code</span>{" "}
+            <span style={styles.kvValue}>{exitCode}</span>
+          </Text>
+        )}
+      </InfoBox>
+
+      {truncatedOutput && (
+        <Section style={{ margin: "0 0 16px" }}>
+          <Label>Output</Label>
+          <CodeBlock>{truncatedOutput}</CodeBlock>
+        </Section>
+      )}
+
+      <CTA href={`${dashboardUrl}?tab=cron`}>View cron history &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+CronFailedEmail.PreviewProps = {
+  jobName: "cleanup-stale-sessions",
+  appName: "acme-api",
+  command: "node scripts/cleanup.js --older-than 30d",
+  errorOutput:
+    "Error: ECONNREFUSED 127.0.0.1:5432\n    at TCPConnectWrap.afterConnect\nFailed to connect to database\nCleanup aborted",
+  duration: "0.8s",
+  exitCode: 1,
+  dashboardUrl: "https://host.example.com/projects/acme-api",
+} satisfies CronFailedProps;
+
+export default CronFailedEmail;

--- a/lib/email/templates/deploy-failed.tsx
+++ b/lib/email/templates/deploy-failed.tsx
@@ -1,23 +1,26 @@
+import { Heading, Section, Text } from "@react-email/components";
 import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-  Link,
-} from "@react-email/components";
+  EmailLayout,
+  CTA,
+  ErrorBox,
+  InfoBox,
+  CodeBlock,
+  Label,
+  styles,
+} from "./components";
 
 type DeployFailedProps = {
   projectName: string;
   deploymentId: string;
   errorMessage?: string;
+  errorSnapshot?: string;
+  failedAtStage?: string;
   gitSha?: string;
   gitMessage?: string;
+  gitAuthor?: string;
+  gitBranch?: string;
   triggeredBy?: string;
+  triggerReason?: string;
   dashboardUrl: string;
 };
 
@@ -25,54 +28,111 @@ export function DeployFailedEmail({
   projectName,
   deploymentId,
   errorMessage,
+  errorSnapshot,
+  failedAtStage,
   gitSha,
   gitMessage,
+  gitAuthor,
+  gitBranch,
   triggeredBy,
+  triggerReason,
   dashboardUrl,
 }: DeployFailedProps) {
+  const trigger =
+    triggerReason || (triggeredBy ? `Manual deploy by ${triggeredBy}` : null);
+
   return (
-    <Html>
-      <Head />
-      <Preview>{projectName} deployment failed</Preview>
-      <Body style={body}>
-        <Container style={container}>
-          <Heading style={h1}>Deploy failed</Heading>
-          <Text style={text}>
-            <strong>{projectName}</strong> failed to deploy.
-          </Text>
-          {errorMessage && (
-            <Section style={errorBox}>
-              <Text style={errorText}>{errorMessage}</Text>
-            </Section>
-          )}
-          {gitMessage && (
-            <Text style={meta}>
-              {gitSha && <code style={sha}>{gitSha.slice(0, 7)}</code>}{" "}
-              {gitMessage}
+    <EmailLayout preview={`${projectName} deployment failed`}>
+      <Heading style={styles.h1}>Deploy failed</Heading>
+      <Text style={styles.text}>
+        <strong>{projectName}</strong> failed to deploy.
+      </Text>
+
+      {(failedAtStage || trigger) && (
+        <ErrorBox>
+          {failedAtStage && (
+            <Text style={styles.kvRow}>
+              <span style={{ ...styles.kvLabel, color: "#991b1b" }}>
+                Failed at
+              </span>{" "}
+              <span style={styles.kvValue}>{failedAtStage}</span>
             </Text>
           )}
-          {triggeredBy && (
-            <Text style={meta}>Triggered by {triggeredBy}</Text>
+          {trigger && (
+            <Text style={styles.kvRow}>
+              <span style={{ ...styles.kvLabel, color: "#991b1b" }}>
+                Trigger
+              </span>{" "}
+              <span style={styles.kvValue}>{trigger}</span>
+            </Text>
           )}
-          <Hr style={hr} />
-          <Text style={meta}>
-            <Link href={`${dashboardUrl}?tab=deployments`} style={link}>
-              View logs →
-            </Link>
+        </ErrorBox>
+      )}
+
+      {errorMessage && (
+        <ErrorBox>
+          <Text style={styles.errorLabel}>Error</Text>
+          <Text style={styles.errorText}>{errorMessage}</Text>
+        </ErrorBox>
+      )}
+
+      {errorSnapshot && (
+        <Section style={{ margin: "0 0 16px" }}>
+          <Label>Build log (last lines)</Label>
+          <CodeBlock>{errorSnapshot}</CodeBlock>
+        </Section>
+      )}
+
+      {(gitSha || gitMessage) && (
+        <InfoBox>
+          <Label>Commit</Label>
+          <Text
+            style={{
+              ...styles.mono,
+              color: "#333333",
+              fontSize: "13px",
+              margin: "0",
+              lineHeight: "20px",
+            }}
+          >
+            {gitSha && <code style={styles.code}>{gitSha.slice(0, 7)}</code>}{" "}
+            {gitMessage}
           </Text>
-        </Container>
-      </Body>
-    </Html>
+          {(gitAuthor || gitBranch) && (
+            <Text
+              style={{
+                color: "#888888",
+                fontSize: "12px",
+                lineHeight: "22px",
+                margin: "4px 0 0",
+              }}
+            >
+              {gitAuthor && <span>{gitAuthor}</span>}
+              {gitAuthor && gitBranch && <span> on </span>}
+              {gitBranch && <code style={styles.code}>{gitBranch}</code>}
+            </Text>
+          )}
+        </InfoBox>
+      )}
+
+      <CTA href={`${dashboardUrl}?tab=deployments`}>View logs &rarr;</CTA>
+    </EmailLayout>
   );
 }
 
-const body = { backgroundColor: "#18181b", fontFamily: "system-ui, sans-serif" };
-const container = { maxWidth: "480px", margin: "40px auto", padding: "24px" };
-const h1 = { color: "#fafafa", fontSize: "20px", fontWeight: "600" as const, margin: "0 0 16px" };
-const text = { color: "#a1a1aa", fontSize: "14px", lineHeight: "24px" };
-const meta = { color: "#71717a", fontSize: "12px", lineHeight: "20px" };
-const link = { color: "#d4a574" };
-const hr = { borderColor: "#27272a", margin: "24px 0" };
-const errorBox = { backgroundColor: "#2d1215", borderRadius: "8px", padding: "12px 16px", margin: "12px 0", borderLeft: "3px solid #7f1d1d" };
-const errorText = { color: "#fca5a5", fontSize: "13px", margin: "0", fontFamily: "monospace", whiteSpace: "pre-wrap" as const };
-const sha = { color: "#71717a", fontSize: "12px" };
+DeployFailedEmail.PreviewProps = {
+  projectName: "acme-web",
+  deploymentId: "dep_abc123def456",
+  failedAtStage: "docker build",
+  errorMessage: "COPY failed: file not found in build context",
+  errorSnapshot:
+    "Step 8/12 : COPY package.json ./\n ---> Using cache\nStep 9/12 : RUN npm ci\n ---> Running in 3a2b1c0d\nStep 10/12 : COPY . .\nCOPY failed: file not found in build context or excluded by .dockerignore: stat src/config.ts: file does not exist",
+  gitSha: "f9e8d7c6b5a4f3e2d1c0",
+  gitMessage: "chore: update dependencies",
+  gitAuthor: "Joey Yax",
+  gitBranch: "main",
+  triggerReason: "Push to main",
+  dashboardUrl: "https://host.example.com/projects/acme-web",
+} satisfies DeployFailedProps;
+
+export default DeployFailedEmail;

--- a/lib/email/templates/deploy-success.tsx
+++ b/lib/email/templates/deploy-success.tsx
@@ -1,15 +1,11 @@
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-  Link,
-} from "@react-email/components";
+import { Heading, Link, Section, Text } from "@react-email/components";
+import { EmailLayout, CTA, InfoBox, Label, styles } from "./components";
+
+type BuildStage = {
+  name: string;
+  duration?: string;
+  status: "success" | "skipped";
+};
 
 type DeploySuccessProps = {
   projectName: string;
@@ -18,7 +14,13 @@ type DeploySuccessProps = {
   duration: string;
   gitSha?: string;
   gitMessage?: string;
+  gitAuthor?: string;
+  gitBranch?: string;
   triggeredBy?: string;
+  triggerReason?: string;
+  imageName?: string;
+  imageTag?: string;
+  buildStages?: BuildStage[];
   dashboardUrl: string;
 };
 
@@ -29,57 +31,140 @@ export function DeploySuccessEmail({
   duration,
   gitSha,
   gitMessage,
+  gitAuthor,
+  gitBranch,
   triggeredBy,
+  triggerReason,
+  imageName,
+  imageTag,
+  buildStages,
   dashboardUrl,
 }: DeploySuccessProps) {
+  const trigger =
+    triggerReason || (triggeredBy ? `Manual deploy by ${triggeredBy}` : null);
+
   return (
-    <Html>
-      <Head />
-      <Preview>{projectName} deployed successfully</Preview>
-      <Body style={body}>
-        <Container style={container}>
-          <Heading style={h1}>Deploy successful</Heading>
-          <Text style={text}>
-            <strong>{projectName}</strong> was deployed successfully in {duration}.
+    <EmailLayout preview={`${projectName} deployed successfully`}>
+      <Heading style={styles.h1}>Deploy successful</Heading>
+      <Text style={styles.text}>
+        <strong>{projectName}</strong> was deployed successfully.
+      </Text>
+
+      <InfoBox>
+        <Text style={styles.kvRow}>
+          <span style={styles.kvLabel}>Duration</span>{" "}
+          <span style={styles.kvValue}>{duration}</span>
+        </Text>
+        {trigger && (
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Trigger</span>{" "}
+            <span style={styles.kvValue}>{trigger}</span>
           </Text>
-          {gitMessage && (
-            <Section style={commitBox}>
-              <Text style={commitText}>
-                {gitSha && <code style={sha}>{gitSha.slice(0, 7)}</code>}{" "}
-                {gitMessage}
-              </Text>
-            </Section>
-          )}
-          {domain && (
-            <Text style={text}>
-              Live at{" "}
-              <Link href={`https://${domain}`} style={link}>
-                {domain}
-              </Link>
-            </Text>
-          )}
-          {triggeredBy && (
-            <Text style={meta}>Deployed by {triggeredBy}</Text>
-          )}
-          <Hr style={hr} />
-          <Text style={meta}>
-            <Link href={`${dashboardUrl}?tab=deployments`} style={link}>
-              View deployment →
+        )}
+        {domain && (
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Live at</span>{" "}
+            <Link href={`https://${domain}`} style={styles.link}>
+              {domain}
             </Link>
           </Text>
-        </Container>
-      </Body>
-    </Html>
+        )}
+      </InfoBox>
+
+      {(gitSha || gitMessage) && (
+        <InfoBox>
+          <Label>Commit</Label>
+          <Text
+            style={{
+              ...styles.mono,
+              color: "#333333",
+              fontSize: "13px",
+              margin: "0",
+              lineHeight: "20px",
+            }}
+          >
+            {gitSha && <code style={styles.code}>{gitSha.slice(0, 7)}</code>}{" "}
+            {gitMessage}
+          </Text>
+          {(gitAuthor || gitBranch) && (
+            <Text
+              style={{
+                color: "#888888",
+                fontSize: "12px",
+                lineHeight: "22px",
+                margin: "4px 0 0",
+              }}
+            >
+              {gitAuthor && <span>{gitAuthor}</span>}
+              {gitAuthor && gitBranch && <span> on </span>}
+              {gitBranch && <code style={styles.code}>{gitBranch}</code>}
+            </Text>
+          )}
+        </InfoBox>
+      )}
+
+      {imageName && (
+        <InfoBox>
+          <Label>Image</Label>
+          <Text
+            style={{
+              ...styles.mono,
+              color: "#333333",
+              fontSize: "13px",
+              margin: "0",
+              lineHeight: "20px",
+            }}
+          >
+            {imageName}
+            {imageTag && (
+              <span style={{ color: "#888888", fontSize: "12px" }}>
+                :{imageTag}
+              </span>
+            )}
+          </Text>
+        </InfoBox>
+      )}
+
+      {buildStages && buildStages.length > 0 && (
+        <Section style={{ margin: "0 0 16px" }}>
+          <Label>Build stages</Label>
+          {buildStages.map((stage, i) => (
+            <Text key={i} style={styles.stageRow}>
+              <span>
+                {stage.status === "success" ? "\u2713" : "\u2014"} {stage.name}
+              </span>
+              {stage.duration && (
+                <span style={styles.stageDuration}>{stage.duration}</span>
+              )}
+            </Text>
+          ))}
+        </Section>
+      )}
+
+      <CTA href={`${dashboardUrl}?tab=deployments`}>
+        View deployment &rarr;
+      </CTA>
+    </EmailLayout>
   );
 }
 
-const body = { backgroundColor: "#18181b", fontFamily: "system-ui, sans-serif" };
-const container = { maxWidth: "480px", margin: "40px auto", padding: "24px" };
-const h1 = { color: "#fafafa", fontSize: "20px", fontWeight: "600" as const, margin: "0 0 16px" };
-const text = { color: "#a1a1aa", fontSize: "14px", lineHeight: "24px" };
-const meta = { color: "#71717a", fontSize: "12px", lineHeight: "20px" };
-const link = { color: "#d4a574" };
-const hr = { borderColor: "#27272a", margin: "24px 0" };
-const commitBox = { backgroundColor: "#27272a", borderRadius: "8px", padding: "12px 16px", margin: "12px 0" };
-const commitText = { color: "#d4d4d8", fontSize: "13px", margin: "0", fontFamily: "monospace" };
-const sha = { color: "#71717a", fontSize: "12px" };
+DeploySuccessEmail.PreviewProps = {
+  projectName: "acme-web",
+  deploymentId: "dep_abc123def456",
+  domain: "acme.example.com",
+  duration: "1m 42s",
+  gitSha: "a1b2c3d4e5f6a7b8c9d0",
+  gitMessage: "fix: resolve auth redirect loop on logout",
+  gitAuthor: "Joey Yax",
+  gitBranch: "main",
+  triggerReason: "Push to main",
+  buildStages: [
+    { name: "Clone repository", duration: "3s", status: "success" as const },
+    { name: "Build image", duration: "1m 12s", status: "success" as const },
+    { name: "Deploy container", duration: "18s", status: "success" as const },
+    { name: "Health check", duration: "9s", status: "success" as const },
+  ],
+  dashboardUrl: "https://host.example.com/projects/acme-web",
+} satisfies DeploySuccessProps;
+
+export default DeploySuccessEmail;

--- a/lib/email/templates/disk-write-alert.tsx
+++ b/lib/email/templates/disk-write-alert.tsx
@@ -1,0 +1,76 @@
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, WarningBox, InfoBox, styles } from "./components";
+
+type DiskWriteAlertProps = {
+  appName: string;
+  containerName?: string;
+  writeAmount: string;
+  threshold: string;
+  period?: string;
+  dashboardUrl: string;
+};
+
+export function DiskWriteAlertEmail({
+  appName,
+  containerName,
+  writeAmount,
+  threshold,
+  period,
+  dashboardUrl,
+}: DiskWriteAlertProps) {
+  const timePeriod = period || "the last hour";
+
+  return (
+    <EmailLayout preview={`High disk write activity on ${appName}`}>
+      <Heading style={styles.h1}>High disk write activity</Heading>
+      <Text style={styles.text}>
+        <strong>{appName}</strong>
+        {containerName && <span> ({containerName})</span>} is writing an unusual
+        amount of data to disk.
+      </Text>
+
+      <WarningBox>
+        <Text style={{ ...styles.warningText, fontSize: "14px" }}>
+          <strong>{writeAmount}</strong> written in {timePeriod}
+        </Text>
+        <Text style={{ ...styles.warningText, opacity: 0.8, margin: "4px 0 0" }}>
+          Threshold: {threshold}
+        </Text>
+      </WarningBox>
+
+      <InfoBox>
+        <Text style={styles.warningLabel}>Why this happens</Text>
+        <Text
+          style={{
+            color: "#333333",
+            fontSize: "13px",
+            lineHeight: "20px",
+            margin: "0",
+          }}
+        >
+          Volumes are for persistent app state, not bulk storage. Heavy writes
+          usually indicate debug logging to disk, temp file accumulation, or data
+          that should be in S3/R2.
+        </Text>
+      </InfoBox>
+
+      <Text style={styles.muted}>
+        If this is expected (database migration, import job), you can increase the
+        threshold in app settings.
+      </Text>
+
+      <CTA href={`${dashboardUrl}?tab=logs`}>Check app logs &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+DiskWriteAlertEmail.PreviewProps = {
+  appName: "acme-api",
+  containerName: "acme-api-worker-1",
+  writeAmount: "4.2 GB",
+  threshold: "1 GB",
+  period: "the last hour",
+  dashboardUrl: "https://host.example.com/projects/acme-api",
+} satisfies DiskWriteAlertProps;
+
+export default DiskWriteAlertEmail;

--- a/lib/email/templates/invite.tsx
+++ b/lib/email/templates/invite.tsx
@@ -1,42 +1,47 @@
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, styles } from "./components";
 
 type InviteEmailProps = {
   email: string;
+  orgName?: string;
+  inviterName?: string;
+  inviteUrl?: string;
 };
 
-export function InviteEmail({ email }: InviteEmailProps) {
+export function InviteEmail({
+  email,
+  orgName,
+  inviterName,
+  inviteUrl,
+}: InviteEmailProps) {
+  const heading = orgName
+    ? `You've been invited to ${orgName}`
+    : "You've been invited to Host";
+
+  const description = inviterName
+    ? `${inviterName} invited you to join ${orgName ? `**${orgName}** on ` : ""}Host.`
+    : `An account has been created for ${email}. Sign in using a magic link — just enter your email on the login page and check your inbox.`;
+
   return (
-    <Html>
-      <Head />
-      <Preview>You've been invited to Host</Preview>
-      <Body style={body}>
-        <Container style={container}>
-          <Heading style={h1}>You've been invited to Host</Heading>
-          <Text style={text}>
-            An account has been created for <strong>{email}</strong>. You can
-            sign in using a magic link — just enter your email on the login page
-            and check your inbox.
-          </Text>
-          <Text style={meta}>
-            If you didn't expect this invitation, you can safely ignore this
-            email.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout preview={heading}>
+      <Heading style={styles.h1}>{heading}</Heading>
+      <Text style={{ ...styles.text, margin: "0 0 24px" }}>{description}</Text>
+      {inviteUrl && (
+        <CTA href={inviteUrl}>Accept invitation &rarr;</CTA>
+      )}
+      <Text style={{ ...styles.muted, margin: "24px 0 0" }}>
+        If you didn&apos;t expect this invitation, you can safely ignore this
+        email.
+      </Text>
+    </EmailLayout>
   );
 }
 
-const body = { backgroundColor: "#18181b", fontFamily: "system-ui, sans-serif" };
-const container = { maxWidth: "480px", margin: "40px auto", padding: "24px" };
-const h1 = { color: "#fafafa", fontSize: "20px", fontWeight: "600" as const, margin: "0 0 16px" };
-const text = { color: "#a1a1aa", fontSize: "14px", lineHeight: "24px" };
-const meta = { color: "#71717a", fontSize: "12px", lineHeight: "20px", marginTop: "24px" };
+InviteEmail.PreviewProps = {
+  email: "newuser@example.com",
+  orgName: "Acme Inc",
+  inviterName: "Joey Yax",
+  inviteUrl: "https://host.example.com/invite/abc123",
+} satisfies InviteEmailProps;
+
+export default InviteEmail;

--- a/lib/email/templates/magic-link.tsx
+++ b/lib/email/templates/magic-link.tsx
@@ -1,13 +1,5 @@
-import {
-  Body,
-  Button,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { Heading, Text } from "@react-email/components";
+import { EmailLayout, CTA, styles } from "./components";
 
 type MagicLinkProps = {
   url: string;
@@ -16,40 +8,23 @@ type MagicLinkProps = {
 
 export function MagicLinkEmail({ url, email }: MagicLinkProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>Sign in to Host</Preview>
-      <Body style={body}>
-        <Container style={container}>
-          <Heading style={h1}>Sign in to Host</Heading>
-          <Text style={text}>
-            Click the button below to sign in as <strong>{email}</strong>.
-            This link expires in 10 minutes.
-          </Text>
-          <Button href={url} style={button}>
-            Sign in
-          </Button>
-          <Text style={meta}>
-            If you didn't request this, you can safely ignore this email.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout preview="Sign in to Host">
+      <Heading style={styles.h1}>Sign in to Host</Heading>
+      <Text style={{ ...styles.text, margin: "0 0 24px" }}>
+        Click the link below to sign in as <strong>{email}</strong>. This link
+        expires in 15 minutes.
+      </Text>
+      <CTA href={url}>Sign in to Host &rarr;</CTA>
+      <Text style={{ ...styles.muted, margin: "24px 0 0" }}>
+        If you didn&apos;t request this, you can safely ignore this email.
+      </Text>
+    </EmailLayout>
   );
 }
 
-const body = { backgroundColor: "#18181b", fontFamily: "system-ui, sans-serif" };
-const container = { maxWidth: "480px", margin: "40px auto", padding: "24px" };
-const h1 = { color: "#fafafa", fontSize: "20px", fontWeight: "600" as const, margin: "0 0 16px" };
-const text = { color: "#a1a1aa", fontSize: "14px", lineHeight: "24px" };
-const meta = { color: "#71717a", fontSize: "12px", lineHeight: "20px", marginTop: "24px" };
-const button = {
-  backgroundColor: "#d4a574",
-  color: "#18181b",
-  padding: "12px 24px",
-  borderRadius: "8px",
-  fontWeight: "600" as const,
-  fontSize: "14px",
-  textDecoration: "none",
-  display: "inline-block" as const,
-};
+MagicLinkEmail.PreviewProps = {
+  url: "https://host.example.com/auth/verify?token=abc123",
+  email: "joey@example.com",
+} satisfies MagicLinkProps;
+
+export default MagicLinkEmail;

--- a/lib/email/templates/volume-drift.tsx
+++ b/lib/email/templates/volume-drift.tsx
@@ -1,0 +1,104 @@
+import { Heading, Section, Text } from "@react-email/components";
+import { EmailLayout, CTA, WarningBox, CodeBlock, Label, styles } from "./components";
+
+type VolumeDriftProps = {
+  appName: string;
+  volumeName: string;
+  modifiedCount: number;
+  addedCount: number;
+  missingCount: number;
+  changedFiles?: string[];
+  dashboardUrl: string;
+};
+
+export function VolumeDriftEmail({
+  appName,
+  volumeName,
+  modifiedCount,
+  addedCount,
+  missingCount,
+  changedFiles,
+  dashboardUrl,
+}: VolumeDriftProps) {
+  const totalChanges = modifiedCount + addedCount + missingCount;
+  const topFiles = changedFiles?.slice(0, 5);
+
+  return (
+    <EmailLayout
+      preview={`Volume drift detected on ${appName}/${volumeName}`}
+    >
+      <Heading style={styles.h1}>Volume drift detected</Heading>
+      <Text style={styles.text}>
+        <strong>{appName}</strong> has {totalChanges} unexpected{" "}
+        {totalChanges === 1 ? "change" : "changes"} on volume{" "}
+        <strong>{volumeName}</strong>.
+      </Text>
+
+      <WarningBox>
+        <Text
+          style={{
+            color: "#333333",
+            fontSize: "13px",
+            lineHeight: "22px",
+            margin: "0",
+          }}
+        >
+          {modifiedCount > 0 && (
+            <span style={styles.badge("#fef3c7", "#92400e")}>
+              {modifiedCount} modified
+            </span>
+          )}
+          {addedCount > 0 && (
+            <span style={styles.badge("#d1fae5", "#065f46")}>
+              {addedCount} added
+            </span>
+          )}
+          {missingCount > 0 && (
+            <span style={styles.badge("#fee2e2", "#991b1b")}>
+              {missingCount} missing
+            </span>
+          )}
+        </Text>
+      </WarningBox>
+
+      {topFiles && topFiles.length > 0 && (
+        <Section style={{ margin: "0 0 16px" }}>
+          <Label>Changed files</Label>
+          <CodeBlock>
+            {topFiles.join("\n")}
+            {changedFiles && changedFiles.length > 5 &&
+              `\n... and ${changedFiles.length - 5} more`}
+          </CodeBlock>
+        </Section>
+      )}
+
+      <Text style={styles.muted}>
+        Volume drift means files on disk have diverged from what was expected.
+        This can happen when a container modifies files outside of normal
+        operation, or after an interrupted restore.
+      </Text>
+
+      <CTA href={`${dashboardUrl}?tab=volumes`}>Review changes &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+VolumeDriftEmail.PreviewProps = {
+  appName: "acme-cms",
+  volumeName: "uploads",
+  modifiedCount: 3,
+  addedCount: 12,
+  missingCount: 1,
+  changedFiles: [
+    "uploads/2026/03/hero.webp",
+    "uploads/2026/03/thumb-001.jpg",
+    "uploads/cache/resize-512x512.tmp",
+    "uploads/.gitkeep",
+    "config/settings.json",
+    "logs/access.log",
+    "logs/error.log",
+  ],
+  dashboardUrl: "https://host.example.com/projects/acme-cms",
+} satisfies VolumeDriftProps;
+
+export default VolumeDriftEmail;

--- a/lib/notifications/email-channel.ts
+++ b/lib/notifications/email-channel.ts
@@ -3,31 +3,178 @@ import type { NotificationChannel, NotificationEvent } from "./port";
 import { sendEmail } from "@/lib/email/send";
 import { DeploySuccessEmail } from "@/lib/email/templates/deploy-success";
 import { DeployFailedEmail } from "@/lib/email/templates/deploy-failed";
+import { BackupSuccessEmail } from "@/lib/email/templates/backup-success";
+import { BackupFailedEmail } from "@/lib/email/templates/backup-failed";
+import { CronFailedEmail } from "@/lib/email/templates/cron-failed";
+import { DiskWriteAlertEmail } from "@/lib/email/templates/disk-write-alert";
+import { VolumeDriftEmail } from "@/lib/email/templates/volume-drift";
+import { AutoRollbackEmail } from "@/lib/email/templates/auto-rollback";
 
 type EmailConfig = { recipients: string[] };
 
 export class EmailNotificationChannel implements NotificationChannel {
   constructor(private config: EmailConfig) {}
+
   async send(event: NotificationEvent): Promise<void> {
     for (const recipient of this.config.recipients) {
       try {
         const template = this.buildTemplate(event);
-        if (template) await sendEmail({ to: recipient, subject: event.title, template });
-      } catch (err) { console.error(`[notifications] Failed to send email to ${recipient}:`, err); }
+        if (template) {
+          await sendEmail({ to: recipient, subject: event.title, template });
+        }
+      } catch (err) {
+        console.error(
+          `[notifications] Failed to send email to ${recipient}:`,
+          err,
+        );
+      }
     }
   }
+
   private buildTemplate(event: NotificationEvent) {
+    const m = event.metadata;
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    const dashboardUrl = event.metadata.appId ? `${appUrl}/projects/${event.metadata.appId}` : appUrl;
+    const dashboardUrl = m.appId
+      ? `${appUrl}/projects/${m.appId}`
+      : appUrl;
+
     switch (event.type) {
-      case "deploy-success": return DeploySuccessEmail({ projectName: event.metadata.projectName || "Unknown", deploymentId: event.metadata.deploymentId || "", domain: event.metadata.domain, duration: event.metadata.duration || "unknown", gitSha: event.metadata.gitSha, gitMessage: event.metadata.gitMessage, triggeredBy: event.metadata.triggeredBy, dashboardUrl });
-      case "deploy-failed": return DeployFailedEmail({ projectName: event.metadata.projectName || "Unknown", deploymentId: event.metadata.deploymentId || "", errorMessage: event.metadata.errorMessage, gitSha: event.metadata.gitSha, gitMessage: event.metadata.gitMessage, triggeredBy: event.metadata.triggeredBy, dashboardUrl });
-      default: return createElement("div", { style: { fontFamily: "sans-serif", padding: "20px", maxWidth: "600px" } },
-        createElement("h2", { style: { margin: "0 0 12px" } }, event.title),
-        createElement("p", { style: { color: "#374151", whiteSpace: "pre-wrap" } }, event.message),
-        createElement("hr", { style: { border: "none", borderTop: "1px solid #e5e7eb", margin: "20px 0" } }),
-        createElement("a", { href: dashboardUrl, style: { color: "#6366f1" } }, "View Dashboard")
-      );
+      case "deploy-success":
+        return DeploySuccessEmail({
+          projectName: m.projectName || "Unknown",
+          deploymentId: m.deploymentId || "",
+          domain: m.domain,
+          duration: m.duration || "unknown",
+          gitSha: m.gitSha,
+          gitMessage: m.gitMessage,
+          gitAuthor: m.gitAuthor,
+          gitBranch: m.gitBranch,
+          triggeredBy: m.triggeredBy,
+          triggerReason: m.triggerReason,
+          imageName: m.imageName,
+          imageTag: m.imageTag,
+          buildStages: m.buildStages
+            ? JSON.parse(m.buildStages)
+            : undefined,
+          dashboardUrl,
+        });
+
+      case "deploy-failed":
+        return DeployFailedEmail({
+          projectName: m.projectName || "Unknown",
+          deploymentId: m.deploymentId || "",
+          errorMessage: m.errorMessage,
+          errorSnapshot: m.errorSnapshot,
+          failedAtStage: m.failedAtStage,
+          gitSha: m.gitSha,
+          gitMessage: m.gitMessage,
+          gitAuthor: m.gitAuthor,
+          gitBranch: m.gitBranch,
+          triggeredBy: m.triggeredBy,
+          triggerReason: m.triggerReason,
+          dashboardUrl,
+        });
+
+      case "backup-success":
+        return BackupSuccessEmail({
+          appName: m.appName || m.projectName || "Unknown",
+          volumeNames: m.volumeNames
+            ? JSON.parse(m.volumeNames)
+            : [],
+          totalSize: m.totalSize || "unknown",
+          duration: m.duration || "unknown",
+          storageBucket: m.storageBucket,
+          storageTarget: m.storageTarget,
+          dashboardUrl,
+        });
+
+      case "backup-failed":
+        return BackupFailedEmail({
+          appName: m.appName || m.projectName || "Unknown",
+          volumeName: m.volumeName,
+          errorMessage: m.errorMessage || event.message,
+          dashboardUrl,
+        });
+
+      case "cron-failed":
+        return CronFailedEmail({
+          jobName: m.jobName || "Unknown job",
+          appName: m.appName || m.projectName || "Unknown",
+          command: m.command || "",
+          errorOutput: m.errorOutput,
+          duration: m.duration,
+          exitCode: m.exitCode ? parseInt(m.exitCode) : undefined,
+          dashboardUrl,
+        });
+
+      case "disk-write-alert":
+        return DiskWriteAlertEmail({
+          appName: m.appName || m.projectName || "Unknown",
+          containerName: m.containerName,
+          writeAmount: m.writeAmount || "unknown",
+          threshold: m.threshold || "unknown",
+          period: m.period,
+          dashboardUrl,
+        });
+
+      case "volume-drift":
+        return VolumeDriftEmail({
+          appName: m.appName || m.projectName || "Unknown",
+          volumeName: m.volumeName || "unknown",
+          modifiedCount: parseInt(m.modifiedCount || "0"),
+          addedCount: parseInt(m.addedCount || "0"),
+          missingCount: parseInt(m.missingCount || "0"),
+          changedFiles: m.changedFiles
+            ? JSON.parse(m.changedFiles)
+            : undefined,
+          dashboardUrl,
+        });
+
+      case "auto-rollback":
+        return AutoRollbackEmail({
+          appName: m.appName || m.projectName || "Unknown",
+          reason:
+            m.reason || "Container crashed within grace period",
+          fromDeploymentId: m.fromDeploymentId || "",
+          toDeploymentId: m.toDeploymentId || "",
+          dashboardUrl,
+        });
+
+      default:
+        return createElement(
+          "div",
+          {
+            style: {
+              fontFamily: "sans-serif",
+              padding: "20px",
+              maxWidth: "600px",
+            },
+          },
+          createElement(
+            "h2",
+            { style: { margin: "0 0 12px" } },
+            event.title,
+          ),
+          createElement(
+            "p",
+            {
+              style: { color: "#374151", whiteSpace: "pre-wrap" },
+            },
+            event.message,
+          ),
+          createElement("hr", {
+            style: {
+              border: "none",
+              borderTop: "1px solid #e5e7eb",
+              margin: "20px 0",
+            },
+          }),
+          createElement(
+            "a",
+            { href: dashboardUrl, style: { color: "#6366f1" } },
+            "View Dashboard",
+          ),
+        );
     }
   }
 }

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -1,3 +1,20 @@
-export type NotificationEventType = "deploy-success" | "deploy-failed" | "backup-success" | "backup-failed" | "cron-failed" | "volume-drift" | "disk-write-alert";
-export type NotificationEvent = { type: NotificationEventType; title: string; message: string; metadata: Record<string, string> };
-export interface NotificationChannel { send(event: NotificationEvent): Promise<void>; }
+export type NotificationEventType =
+  | "deploy-success"
+  | "deploy-failed"
+  | "backup-success"
+  | "backup-failed"
+  | "cron-failed"
+  | "volume-drift"
+  | "disk-write-alert"
+  | "auto-rollback";
+
+export type NotificationEvent = {
+  type: NotificationEventType;
+  title: string;
+  message: string;
+  metadata: Record<string, string>;
+};
+
+export interface NotificationChannel {
+  send(event: NotificationEvent): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- Redesigned all 4 email templates (magic-link, deploy-success, deploy-failed, invite) from dark theme to clean light theme
- Notion-inspired minimal design: white background, dark text, generous spacing, single CTA pattern
- Added "Host" branding header and "Sent by Host" footer to all templates
- Invite template now supports optional `orgName`, `inviterName`, and `inviteUrl` props while remaining backward-compatible with existing `{ email }` call site

## Test plan
- [ ] Preview each template in React Email dev server (`pnpm email:dev` or similar)
- [ ] Send test emails and verify rendering in Gmail, Apple Mail, Outlook
- [ ] Verify invite email still works from admin user creation flow
- [ ] Check mobile rendering at narrow viewports