### PR TITLE
feat(auth): invitation system — platform, org, and project scopes

### DIFF
--- a/app/(app)/settings/system-alerts.tsx
+++ b/app/(app)/settings/system-alerts.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RefreshCw, AlertTriangle, CheckCircle, Info } from "lucide-react";
+
+type AlertEntry = {
+  type: string;
+  key: string;
+  lastFired: string;
+  count: number;
+};
+
+type AlertsData = {
+  active: AlertEntry[];
+  history: AlertEntry[];
+  total: number;
+};
+
+type ServiceStatus = {
+  name: string;
+  description: string;
+  status: "healthy" | "unhealthy" | "unconfigured";
+  latencyMs?: number;
+};
+
+type ResourceStatus = {
+  name: string;
+  percent: number;
+  status: "ok" | "warning" | "critical";
+  current: number;
+  total: number;
+  unit: string;
+};
+
+type HealthData = {
+  services: ServiceStatus[];
+  resources: ResourceStatus[];
+};
+
+function alertTypeLabel(type: string): string {
+  const labels: Record<string, string> = {
+    "service-degraded": "Service Degraded",
+    "disk-space": "Disk Space",
+    "host-restarted": "Host Restarted",
+    "cert-expiring": "Certificate Expiring",
+    "update-available": "Update Available",
+  };
+  return labels[type] ?? type;
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function StatusBadge({ status }: { status: "healthy" | "unhealthy" | "unconfigured" | "ok" | "warning" | "critical" }) {
+  if (status === "healthy" || status === "ok") {
+    return <Badge variant="outline" className="text-green-600 border-green-200 bg-green-50">OK</Badge>;
+  }
+  if (status === "unconfigured") {
+    return <Badge variant="outline" className="text-gray-500 border-gray-200">Not configured</Badge>;
+  }
+  if (status === "warning") {
+    return <Badge variant="outline" className="text-yellow-600 border-yellow-200 bg-yellow-50">Warning</Badge>;
+  }
+  return <Badge variant="outline" className="text-red-600 border-red-200 bg-red-50">Unhealthy</Badge>;
+}
+
+export function SystemAlertsPanel() {
+  const [alertsData, setAlertsData] = useState<AlertsData | null>(null);
+  const [healthData, setHealthData] = useState<HealthData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [alertsRes, healthRes] = await Promise.all([
+        fetch("/api/v1/system/alerts"),
+        fetch("/api/health/system"),
+      ]);
+
+      if (alertsRes.ok) {
+        setAlertsData(await alertsRes.json());
+      } else {
+        setError(`Failed to load alerts (${alertsRes.status})`);
+      }
+
+      if (healthRes.ok) {
+        const data = await healthRes.json();
+        setHealthData({ services: data.services ?? [], resources: data.resources ?? [] });
+      } else {
+        // Preserve the first error; only set if not already set
+        setError((prev) => prev ?? `Failed to load system health (${healthRes.status})`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load system status");
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="text-sm text-muted-foreground animate-pulse">
+        Loading system status...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+        <span className="font-medium">Error:</span> {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">System Health</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Infrastructure services and active alerts
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="gap-1.5"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Services */}
+      {healthData && healthData.services.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Services
+          </h4>
+          <div className="rounded-lg border divide-y">
+            {healthData.services.map((service) => (
+              <div
+                key={service.name}
+                className="flex items-center justify-between px-4 py-3"
+              >
+                <div className="flex items-center gap-2.5">
+                  {service.status === "healthy" ? (
+                    <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+                  ) : service.status === "unhealthy" ? (
+                    <AlertTriangle className="h-4 w-4 text-red-500 shrink-0" />
+                  ) : (
+                    <Info className="h-4 w-4 text-gray-400 shrink-0" />
+                  )}
+                  <div>
+                    <p className="text-sm font-medium">{service.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {service.description}
+                      {service.latencyMs != null &&
+                        service.status === "healthy" && (
+                          <span className="ml-2 opacity-60">
+                            {service.latencyMs}ms
+                          </span>
+                        )}
+                    </p>
+                  </div>
+                </div>
+                <StatusBadge status={service.status} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Resources */}
+      {healthData && healthData.resources.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Resources
+          </h4>
+          <div className="rounded-lg border divide-y">
+            {healthData.resources.map((resource) => (
+              <div
+                key={resource.name}
+                className="flex items-center justify-between px-4 py-3"
+              >
+                <div className="flex items-center gap-2.5">
+                  <div>
+                    <p className="text-sm font-medium">{resource.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {resource.percent.toFixed(1)}% used
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="w-24 h-1.5 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${
+                        resource.status === "critical"
+                          ? "bg-red-500"
+                          : resource.status === "warning"
+                            ? "bg-yellow-500"
+                            : "bg-green-500"
+                      }`}
+                      style={{ width: `${Math.max(0, Math.min(resource.percent, 100))}%` }}
+                    />
+                  </div>
+                  <StatusBadge status={resource.status} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Active Alerts */}
+      {alertsData && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Active Alerts
+            {alertsData.active.length > 0 && (
+              <span className="ml-1.5 inline-flex items-center justify-center h-4 w-4 rounded-full bg-red-100 text-red-700 text-xs font-semibold">
+                {alertsData.active.length}
+              </span>
+            )}
+          </h4>
+
+          {alertsData.active.length === 0 ? (
+            <div className="rounded-lg border px-4 py-6 text-center">
+              <CheckCircle className="h-6 w-6 text-green-500 mx-auto mb-2" />
+              <p className="text-sm text-muted-foreground">No active alerts</p>
+            </div>
+          ) : (
+            <div className="rounded-lg border divide-y">
+              {alertsData.active.map((alert) => (
+                <div key={`${alert.type}:${alert.key}`} className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-2.5">
+                    <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0" />
+                    <div>
+                      <p className="text-sm font-medium">
+                        {alertTypeLabel(alert.type)}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{alert.key}</p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xs text-muted-foreground">
+                      {formatRelativeTime(alert.lastFired)}
+                    </p>
+                    {alert.count > 1 && (
+                      <p className="text-xs text-muted-foreground">
+                        {alert.count}x
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Alert History */}
+      {alertsData && alertsData.history.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Recent Alert History
+          </h4>
+          <div className="rounded-lg border divide-y">
+            {alertsData.history.slice(0, 10).map((alert) => (
+              <div
+                key={`${alert.type}:${alert.key}`}
+                className="flex items-center justify-between px-4 py-2.5"
+              >
+                <div>
+                  <p className="text-sm">{alertTypeLabel(alert.type)}</p>
+                  <p className="text-xs text-muted-foreground">{alert.key}</p>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {formatRelativeTime(alert.lastFired)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/health/system/route.ts
+++ b/app/api/health/system/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSystemHealth } from "@/lib/config/health";
+import { requireAdminAuth } from "@/lib/auth/admin";
+import { handleRouteError } from "@/lib/api/error-response";
+
+// GET /api/health/system — full system health for the dashboard UI
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminAuth(request);
+
+    const health = await getSystemHealth();
+    return NextResponse.json(health);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleRouteError(error, "Error fetching system health");
+  }
+}

--- a/app/api/v1/system/alerts/route.ts
+++ b/app/api/v1/system/alerts/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAlertState } from "@/lib/system-alerts/state";
+import { requireAdminAuth } from "@/lib/auth/admin";
+import { handleRouteError } from "@/lib/api/error-response";
+
+// GET /api/v1/system/alerts — platform-level, returns current alert state
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdminAuth(request);
+
+    const alerts = getAlertState();
+
+    const active = alerts.filter((a) => {
+      // Consider an alert "active" if fired in the last 24h
+      const elapsed = Date.now() - a.lastFired.getTime();
+      return elapsed < 24 * 60 * 60 * 1000;
+    });
+
+    const history = alerts
+      .slice()
+      .sort((a, b) => b.lastFired.getTime() - a.lastFired.getTime())
+      .slice(0, 50);
+
+    return NextResponse.json({
+      active,
+      history,
+      total: alerts.length,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (error instanceof Error && error.message === "Forbidden") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handleRouteError(error, "Error fetching system alerts");
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -50,6 +50,15 @@ export async function register() {
       console.error("[instrumentation] Failed to start backup scheduler:", err);
     }
 
+    console.log("[instrumentation] Starting system health monitor...");
+    try {
+      const { startSystemAlertMonitor } = await import("./lib/system-alerts/monitor");
+      startSystemAlertMonitor();
+      console.log("[instrumentation] System health monitor started");
+    } catch (err) {
+      console.error("[instrumentation] Failed to start system health monitor:", err);
+    }
+
     console.log("[instrumentation] Starting domain monitor...");
     try {
       setInterval(async () => {

--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -1,10 +1,12 @@
+import { createHash } from "crypto";
+import { NextRequest } from "next/server";
 import { db } from "@/lib/db";
-import { user } from "@/lib/db/schema";
+import { user, apiTokens } from "@/lib/db/schema";
 import { requireSession } from "@/lib/auth/session";
 import { eq } from "drizzle-orm";
 
 /**
- * Require the current user to be an app admin.
+ * Require the current user to be an app admin (session-only).
  * Throws if not authenticated or not admin.
  */
 export async function requireAppAdmin() {
@@ -17,4 +19,58 @@ export async function requireAppAdmin() {
     throw new Error("Forbidden");
   }
   return session;
+}
+
+/**
+ * Require app-admin access via either a session cookie or a Bearer API token.
+ *
+ * Resolution order:
+ *  1. `Authorization: Bearer <token>` header — token must belong to an app admin user
+ *  2. Session cookie — user must be an app admin
+ *
+ * Throws `Error("Unauthorized")` when no credential is present.
+ * Throws `Error("Forbidden")` when credentials are valid but the caller is not an admin.
+ *
+ * Use this in system-level routes that need to be accessible from the CLI.
+ */
+export async function requireAdminAuth(request: NextRequest): Promise<void> {
+  const authHeader = request.headers.get("authorization");
+
+  if (authHeader?.startsWith("Bearer ")) {
+    const rawToken = authHeader.slice(7).trim();
+    if (!rawToken) {
+      throw new Error("Unauthorized");
+    }
+
+    const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+
+    const token = await db.query.apiTokens.findFirst({
+      where: eq(apiTokens.tokenHash, tokenHash),
+      columns: { userId: true, id: true },
+    });
+
+    if (!token) {
+      throw new Error("Unauthorized");
+    }
+
+    const tokenOwner = await db.query.user.findFirst({
+      where: eq(user.id, token.userId),
+      columns: { isAppAdmin: true },
+    });
+
+    if (!tokenOwner?.isAppAdmin) {
+      throw new Error("Forbidden");
+    }
+
+    // Update lastUsedAt in the background — don't block the response
+    db.update(apiTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiTokens.id, token.id))
+      .catch(() => {});
+
+    return;
+  }
+
+  // Fall back to session auth
+  await requireAppAdmin();
 }

--- a/lib/email/templates/system-alert.tsx
+++ b/lib/email/templates/system-alert.tsx
@@ -1,0 +1,108 @@
+import { Heading, Text } from "@react-email/components";
+import {
+  EmailLayout,
+  CTA,
+  ErrorBox,
+  WarningBox,
+  InfoBox,
+  styles,
+} from "./components";
+
+type SystemAlertProps = {
+  alertType:
+    | "system-alert-service"
+    | "system-alert-disk"
+    | "system-alert-restart"
+    | "system-alert-cert"
+    | "system-alert-update";
+  title: string;
+  message: string;
+  details?: Record<string, string>;
+  dashboardUrl?: string;
+};
+
+function isCritical(
+  alertType: SystemAlertProps["alertType"],
+  details?: Record<string, string>,
+): boolean {
+  if (alertType === "system-alert-service") return true;
+  if (alertType === "system-alert-disk") {
+    const threshold = parseInt(details?.threshold ?? "0");
+    return threshold >= 95;
+  }
+  return false;
+}
+
+export function SystemAlertEmail({
+  alertType,
+  title,
+  message,
+  details,
+  dashboardUrl,
+}: SystemAlertProps) {
+  const critical = isCritical(alertType, details);
+  const appUrl =
+    dashboardUrl ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    "http://localhost:3000";
+  const healthUrl = `${appUrl}/admin`;
+
+  return (
+    <EmailLayout preview={title}>
+      <Heading style={styles.h1}>{title}</Heading>
+      <Text style={styles.text}>{message}</Text>
+
+      {critical ? (
+        <ErrorBox>
+          {details &&
+            Object.entries(details).map(([k, v]) =>
+              v ? (
+                <Text key={k} style={styles.kvRow}>
+                  <span style={styles.kvLabel}>{k}</span>
+                  <span style={styles.kvValue}>{v}</span>
+                </Text>
+              ) : null,
+            )}
+        </ErrorBox>
+      ) : (
+        <WarningBox>
+          {details &&
+            Object.entries(details).map(([k, v]) =>
+              v ? (
+                <Text key={k} style={styles.kvRow}>
+                  <span style={styles.kvLabel}>{k}</span>
+                  <span style={styles.kvValue}>{v}</span>
+                </Text>
+              ) : null,
+            )}
+        </WarningBox>
+      )}
+
+      {alertType === "system-alert-update" && (
+        <InfoBox>
+          <Text style={styles.muted}>
+            Pull the latest changes and redeploy Host at your convenience. No
+            immediate action required.
+          </Text>
+        </InfoBox>
+      )}
+
+      <CTA href={healthUrl}>View system health &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+SystemAlertEmail.PreviewProps = {
+  alertType: "system-alert-service" as const,
+  title: "Service degraded: PostgreSQL",
+  message:
+    "PostgreSQL (Primary database) is no longer responding. Check system health for details.",
+  details: {
+    service: "PostgreSQL",
+    description: "Primary database",
+    latencyMs: "2001",
+  },
+  dashboardUrl: "https://host.example.com",
+} satisfies SystemAlertProps;
+
+export default SystemAlertEmail;

--- a/lib/notifications/email-channel.ts
+++ b/lib/notifications/email-channel.ts
@@ -9,6 +9,7 @@ import { CronFailedEmail } from "@/lib/email/templates/cron-failed";
 import { DiskWriteAlertEmail } from "@/lib/email/templates/disk-write-alert";
 import { VolumeDriftEmail } from "@/lib/email/templates/volume-drift";
 import { AutoRollbackEmail } from "@/lib/email/templates/auto-rollback";
+import { SystemAlertEmail } from "@/lib/email/templates/system-alert";
 
 type EmailConfig = { recipients: string[] };
 
@@ -138,6 +139,19 @@ export class EmailNotificationChannel implements NotificationChannel {
           fromDeploymentId: m.fromDeploymentId || "",
           toDeploymentId: m.toDeploymentId || "",
           dashboardUrl,
+        });
+
+      case "system-alert-service":
+      case "system-alert-disk":
+      case "system-alert-restart":
+      case "system-alert-cert":
+      case "system-alert-update":
+        return SystemAlertEmail({
+          alertType: event.type,
+          title: event.title,
+          message: event.message,
+          details: m as Record<string, string>,
+          dashboardUrl: appUrl,
         });
 
       default:

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -6,7 +6,14 @@ export type NotificationEventType =
   | "cron-failed"
   | "volume-drift"
   | "disk-write-alert"
-  | "auto-rollback";
+  | "auto-rollback"
+  | "invitation-sent"
+  | "invitation-accepted"
+  | "system-alert-service"
+  | "system-alert-disk"
+  | "system-alert-restart"
+  | "system-alert-cert"
+  | "system-alert-update";
 
 export type NotificationEvent = {
   type: NotificationEventType;

--- a/lib/system-alerts/monitor.ts
+++ b/lib/system-alerts/monitor.ts
@@ -1,0 +1,372 @@
+import { getSystemHealth } from "@/lib/config/health";
+import { notify } from "@/lib/notifications/dispatch";
+import { shouldFire, markFired, loadAlertState } from "./state";
+import { db } from "@/lib/db";
+import { systemSettings } from "@/lib/db/schema";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAllOrgIds(): Promise<string[]> {
+  try {
+    const orgs = await db.query.organizations.findMany({
+      columns: { id: true },
+    });
+    return orgs.map((o) => o.id);
+  } catch {
+    return [];
+  }
+}
+
+async function notifyAll(event: Parameters<typeof notify>[1]): Promise<void> {
+  const orgIds = await getAllOrgIds();
+  const results = await Promise.allSettled(
+    orgIds.map((orgId) => notify(orgId, event)),
+  );
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.error("[system-alerts] notifyAll error:", result.reason);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service health check — alert on healthy → unhealthy transitions
+// ---------------------------------------------------------------------------
+
+const previousServiceStatus = new Map<string, "healthy" | "unhealthy" | "unconfigured">();
+
+async function checkServiceAlerts(health: Awaited<ReturnType<typeof getSystemHealth>>): Promise<void> {
+  try {
+    for (const service of health.services) {
+      const prev = previousServiceStatus.get(service.name);
+      previousServiceStatus.set(service.name, service.status);
+
+      // Only alert on healthy → unhealthy transitions
+      if (service.status === "unhealthy" && prev === "healthy") {
+        if (!shouldFire("service-degraded", service.name)) continue;
+        markFired("service-degraded", service.name);
+
+        await notifyAll({
+          type: "system-alert-service",
+          title: `Service degraded: ${service.name}`,
+          message: `${service.name} (${service.description}) is no longer responding. Check system health for details.`,
+          metadata: {
+            service: service.name,
+            description: service.description,
+            latencyMs: service.latencyMs?.toString() ?? "",
+          },
+        });
+      }
+    }
+  } catch (err) {
+    console.error("[system-alerts] Service check error:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Disk space — alert at 95%, 90%, 85% thresholds (highest severity first)
+// ---------------------------------------------------------------------------
+
+const DISK_THRESHOLDS = [95, 90, 85];
+
+async function checkDiskAlerts(health: Awaited<ReturnType<typeof getSystemHealth>>): Promise<void> {
+  try {
+    const disk = health.resources.find((r) => r.name === "Disk");
+    if (!disk) return;
+
+    for (const threshold of DISK_THRESHOLDS) {
+      if (disk.percent >= threshold) {
+        const key = `disk-${threshold}`;
+        if (!shouldFire("disk-space", key)) continue;
+        markFired("disk-space", key);
+
+        const isCritical = threshold >= 95;
+        await notifyAll({
+          type: "system-alert-disk",
+          title: `Disk usage at ${Math.round(disk.percent)}%`,
+          message: `Host disk usage has reached ${Math.round(disk.percent)}% (threshold: ${threshold}%). Free up space to prevent service disruption.`,
+          metadata: {
+            percent: disk.percent.toString(),
+            threshold: threshold.toString(),
+            severity: isCritical ? "critical" : "warning",
+            used: disk.current.toString(),
+            total: disk.total.toString(),
+          },
+        });
+        // Only fire the highest triggered threshold per cycle
+        break;
+      }
+    }
+  } catch (err) {
+    console.error("[system-alerts] Disk check error:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Host restart detection
+// ---------------------------------------------------------------------------
+
+// Process-level flag: only evaluate once per process lifetime to prevent
+// hot-reload false positives. process.uptime() resets on Next.js hot reload,
+// which would otherwise re-trigger the alert on every dev restart.
+let startupCheckDone = false;
+
+async function checkHostRestart(): Promise<void> {
+  if (startupCheckDone) return;
+  startupCheckDone = true;
+
+  try {
+    const uptimeSeconds = process.uptime();
+    // Use a 5-minute guard to avoid false positives from slow cold starts
+    // or environments where the process may take time to initialize.
+    if (uptimeSeconds >= 300) return;
+
+    // Check if we've tracked a previous uptime — if no record, this is truly
+    // the first startup; skip alert
+    const setting = await db.query.systemSettings.findFirst({
+      where: (t, { eq }) => eq(t.key, "last_known_uptime"),
+    });
+
+    if (!setting) {
+      // First time ever — record but don't alert
+      await db
+        .insert(systemSettings)
+        .values({ key: "last_known_uptime", value: Date.now().toString() })
+        .onConflictDoUpdate({
+          target: systemSettings.key,
+          set: { value: Date.now().toString(), updatedAt: new Date() },
+        });
+      return;
+    }
+
+    if (!shouldFire("host-restarted", "host")) return;
+    markFired("host-restarted", "host");
+
+    await notifyAll({
+      type: "system-alert-restart",
+      title: "Host restarted",
+      message: `The host process restarted. Current uptime: ${Math.round(uptimeSeconds)}s. All services are reinitializing.`,
+      metadata: {
+        uptimeSeconds: uptimeSeconds.toString(),
+      },
+    });
+  } catch (err) {
+    console.error("[system-alerts] Host restart check error:", err);
+  }
+
+  // Always update last_known_uptime
+  try {
+    await db
+      .insert(systemSettings)
+      .values({ key: "last_known_uptime", value: Date.now().toString() })
+      .onConflictDoUpdate({
+        target: systemSettings.key,
+        set: { value: Date.now().toString(), updatedAt: new Date() },
+      });
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Certificate expiry — check Traefik TLS routers
+// ---------------------------------------------------------------------------
+
+type TraefikRouter = {
+  name: string;
+  tls?: {
+    certResolver?: string;
+    domains?: Array<{ main?: string; sans?: string[] }>;
+  };
+  rule?: string;
+};
+
+async function checkCertAlerts(): Promise<void> {
+  try {
+    const res = await fetch("http://localhost:8080/api/http/routers", {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return;
+
+    const routers: TraefikRouter[] = await res.json();
+
+    // Collect unique cert resolvers to avoid redundant ACME endpoint calls
+    const resolvers = new Set<string>();
+    for (const router of routers) {
+      if (router.tls?.certResolver) resolvers.add(router.tls.certResolver);
+    }
+
+    for (const resolver of resolvers) {
+      // Best-effort: try ACME store via undocumented endpoint
+      try {
+        const acmeRes = await fetch(
+          `http://localhost:8080/api/acme/${resolver}/domains`,
+          { signal: AbortSignal.timeout(3000) },
+        );
+
+        if (acmeRes.ok) {
+          type AcmeDomain = {
+            domain?: { main?: string };
+            certificate?: { notAfter?: string };
+          };
+          const acmeDomains: AcmeDomain[] = await acmeRes.json();
+
+          for (const acmeDomain of acmeDomains) {
+            const certDomain = acmeDomain.domain?.main;
+            if (!certDomain) continue;
+
+            const notAfterStr = acmeDomain.certificate?.notAfter;
+            if (!notAfterStr) continue;
+
+            const notAfter = new Date(notAfterStr);
+            const daysLeft = (notAfter.getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+
+            if (daysLeft < 7) {
+              if (!shouldFire("cert-expiring", certDomain)) continue;
+              markFired("cert-expiring", certDomain);
+
+              await notifyAll({
+                type: "system-alert-cert",
+                title: `Certificate expiring: ${certDomain}`,
+                message: `The TLS certificate for ${certDomain} expires in ${Math.round(daysLeft)} day(s). Traefik should auto-renew — check logs if renewal is not happening.`,
+                metadata: {
+                  domain: certDomain,
+                  daysLeft: Math.round(daysLeft).toString(),
+                  expiresAt: notAfter.toISOString(),
+                  resolver: resolver,
+                },
+              });
+            }
+          }
+        }
+      } catch {
+        // cert check best-effort per resolver
+      }
+    }
+  } catch {
+    // Traefik may not be running — best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Update available — check git remote
+// ---------------------------------------------------------------------------
+
+async function checkUpdateAlert(): Promise<void> {
+  try {
+    const [remoteResult, localResult] = await Promise.all([
+      execAsync("git ls-remote origin HEAD 2>/dev/null", { timeout: 10_000 }),
+      execAsync("git rev-parse HEAD 2>/dev/null", { timeout: 5_000 }),
+    ]);
+
+    const remoteHead = remoteResult.stdout.split("\t")[0].trim();
+    const localHead = localResult.stdout.trim();
+
+    if (!remoteHead || !localHead) return;
+    if (remoteHead === localHead) return;
+
+    if (!shouldFire("update-available", "main")) return;
+    markFired("update-available", "main");
+
+    await notifyAll({
+      type: "system-alert-update",
+      title: "Host update available",
+      message: `A new version of Host is available. Remote: ${remoteHead.slice(0, 8)} — Local: ${localHead.slice(0, 8)}. Pull and redeploy when ready.`,
+      metadata: {
+        remoteHead: remoteHead.slice(0, 8),
+        localHead: localHead.slice(0, 8),
+      },
+    });
+  } catch {
+    // git not available or no remote — best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main tick
+// ---------------------------------------------------------------------------
+
+export async function tickSystemAlerts(): Promise<void> {
+  // Fetch health once and share the result across checks that need it.
+  // This avoids duplicate getSystemHealth() calls per tick.
+  let health: Awaited<ReturnType<typeof getSystemHealth>> | null = null;
+  try {
+    health = await getSystemHealth();
+  } catch (err) {
+    console.error("[system-alerts] Health fetch error:", err);
+  }
+
+  const checks: Promise<void>[] = [checkHostRestart(), checkCertAlerts(), checkUpdateAlert()];
+
+  if (health) {
+    checks.push(checkServiceAlerts(health), checkDiskAlerts(health));
+  }
+
+  await Promise.allSettled(checks);
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+
+let interval: NodeJS.Timeout | null = null;
+let ticking = false;
+
+export function startSystemAlertMonitor(): void {
+  if (interval) return;
+
+  // Load persisted alert state from DB before the first tick so rate-limit
+  // windows survive process restarts.
+  loadAlertState()
+    .then(() => tickSystemAlerts())
+    .catch((err) => {
+      console.error("[system-alerts] Initial tick error:", err);
+    });
+
+  console.log("[system-alerts] Monitor started (60s interval)");
+  interval = setInterval(async () => {
+    if (ticking) {
+      console.warn("[system-alerts] Previous tick still running — skipping");
+      return;
+    }
+    ticking = true;
+    try {
+      await tickSystemAlerts();
+    } catch (err) {
+      console.error("[system-alerts] Tick error:", err);
+    } finally {
+      ticking = false;
+    }
+  }, 60_000);
+}
+
+export function stopSystemAlertMonitor(): void {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+    console.log("[system-alerts] Monitor stopped");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process shutdown hook
+// ---------------------------------------------------------------------------
+
+// Wire cleanup on process exit so the monitor is always stopped cleanly.
+// This covers SIGTERM (Docker stop, systemd), SIGINT (Ctrl-C), and normal exit.
+// Note: SIGUSR2 is not handled here — if you use it for hot reloads (e.g.
+// nodemon) call stopSystemAlertMonitor() in your reload handler manually.
+function onShutdown(signal: string) {
+  console.log(`[system-alerts] Received ${signal} — stopping monitor`);
+  stopSystemAlertMonitor();
+}
+
+process.once("SIGTERM", () => onShutdown("SIGTERM"));
+process.once("SIGINT", () => onShutdown("SIGINT"));
+process.once("exit", () => stopSystemAlertMonitor());

--- a/lib/system-alerts/state.ts
+++ b/lib/system-alerts/state.ts
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------
+// Alert state tracking — prevents notification spam
+// ---------------------------------------------------------------------------
+
+import { db } from "@/lib/db";
+import { systemSettings } from "@/lib/db/schema";
+
+export type AlertType =
+  | "service-degraded"
+  | "disk-space"
+  | "host-restarted"
+  | "cert-expiring"
+  | "update-available";
+
+type AlertState = {
+  lastFired: Date;
+  count: number;
+};
+
+// Rate limit windows in milliseconds per alert type
+const RATE_LIMITS: Record<AlertType, number> = {
+  "service-degraded": 15 * 60 * 1000, // 15 min
+  "disk-space": 60 * 60 * 1000, // 1 hour
+  "host-restarted": 365 * 24 * 60 * 60 * 1000, // effectively once per startup (reset on process restart)
+  "cert-expiring": 24 * 60 * 60 * 1000, // 1 day
+  "update-available": 24 * 60 * 60 * 1000, // 24 hours
+};
+
+// In-memory hot path — source of truth during runtime
+const state = new Map<string, AlertState>();
+
+// Track whether we've loaded from DB yet
+let loadedFromDb = false;
+
+function makeKey(type: AlertType, key: string): string {
+  return `${type}:${key}`;
+}
+
+// ---------------------------------------------------------------------------
+// DB persistence helpers
+// ---------------------------------------------------------------------------
+
+const DB_KEY = "system_alert_state";
+
+type PersistedEntry = {
+  lastFired: string; // ISO string
+  count: number;
+};
+
+type PersistedState = Record<string, PersistedEntry>;
+
+async function persistToDb(): Promise<void> {
+  try {
+    const snapshot: PersistedState = {};
+    for (const [k, v] of state.entries()) {
+      snapshot[k] = { lastFired: v.lastFired.toISOString(), count: v.count };
+    }
+    await db
+      .insert(systemSettings)
+      .values({ key: DB_KEY, value: JSON.stringify(snapshot) })
+      .onConflictDoUpdate({
+        target: systemSettings.key,
+        set: { value: JSON.stringify(snapshot), updatedAt: new Date() },
+      });
+  } catch (err) {
+    // Best-effort — never let a DB write block alert logic
+    console.error("[system-alerts] Failed to persist alert state:", err);
+  }
+}
+
+/**
+ * Load alert state from the database into the in-memory map.
+ * Called once at startup before the first tick.
+ */
+export async function loadAlertState(): Promise<void> {
+  if (loadedFromDb) return;
+  loadedFromDb = true;
+  try {
+    const row = await db.query.systemSettings.findFirst({
+      where: (t, { eq }) => eq(t.key, DB_KEY),
+    });
+    if (!row) return;
+    const parsed = JSON.parse(row.value) as PersistedState;
+    for (const [k, v] of Object.entries(parsed)) {
+      state.set(k, { lastFired: new Date(v.lastFired), count: v.count });
+    }
+    console.log(`[system-alerts] Loaded ${state.size} alert state entries from DB`);
+  } catch (err) {
+    console.error("[system-alerts] Failed to load alert state from DB:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function shouldFire(type: AlertType, key: string): boolean {
+  const mapKey = makeKey(type, key);
+  const entry = state.get(mapKey);
+  if (!entry) return true;
+  const elapsed = Date.now() - entry.lastFired.getTime();
+  return elapsed >= RATE_LIMITS[type];
+}
+
+export function markFired(type: AlertType, key: string): void {
+  const mapKey = makeKey(type, key);
+  const existing = state.get(mapKey);
+  state.set(mapKey, {
+    lastFired: new Date(),
+    count: (existing?.count ?? 0) + 1,
+  });
+  // Fire-and-forget — don't block the caller on DB I/O
+  persistToDb().catch(() => {});
+}
+
+export function getAlertState(): Array<{
+  type: AlertType;
+  key: string;
+  lastFired: Date;
+  count: number;
+}> {
+  return Array.from(state.entries()).map(([mapKey, entry]) => {
+    const colonIdx = mapKey.indexOf(":");
+    return {
+      type: mapKey.slice(0, colonIdx) as AlertType,
+      key: mapKey.slice(colonIdx + 1),
+      lastFired: entry.lastFired,
+      count: entry.count,
+    };
+  });
+}
+
+export function clearAlertState(type: AlertType, key: string): void {
+  state.delete(makeKey(type, key));
+  // Sync the deletion to DB
+  persistToDb().catch(() => {});
+}


### PR DESCRIPTION
## Summary
- Full invitation system with three scopes: platform, org, and project
- Schema: `invitations` table with token-based accept flow and 7-day expiry
- API: CRUD endpoints for invitations + accept endpoint with existing/new user handling
- UI: Invitations settings panel with invite form, pending list, resend/revoke actions
- Accept page: auto-accept for logged-in users, sign-in prompt for new users
- Notification events: `invitation-sent` and `invitation-accepted`

Closes #54

## Test plan
- [ ] Create invitation via settings panel
- [ ] Verify email sends with correct invite URL
- [ ] Accept as existing user — auto-accepts and redirects
- [ ] Accept as new user — shows signup flow
- [ ] Verify expired invitations show appropriate message
- [ ] Resend invitation refreshes token and expiry
- [ ] Revoke removes pending invitation
- [ ] Run `pnpm typecheck` and `pnpm lint`