### PR TITLE
feat: weekly project health digest email system

### DIFF
--- a/app/(app)/settings/digest-settings.tsx
+++ b/app/(app)/settings/digest-settings.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+import { Loader2, Mail } from "lucide-react";
+
+type DigestSettingsData = {
+  enabled: boolean;
+  dayOfWeek: number;
+  hourOfDay: number;
+  lastSentAt: string | null;
+};
+
+const DAY_LABELS: Record<number, string> = {
+  0: "Sunday",
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+};
+
+const HOUR_LABELS: Record<number, string> = Object.fromEntries(
+  Array.from({ length: 24 }, (_, i) => {
+    const h = i % 12 || 12;
+    const ampm = i < 12 ? "AM" : "PM";
+    return [i, `${h}:00 ${ampm} UTC`];
+  }),
+);
+
+export function DigestSettingsEditor({ orgId }: { orgId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [settings, setSettings] = useState<DigestSettingsData>({
+    enabled: false,
+    dayOfWeek: 1,
+    hourOfDay: 8,
+    lastSentAt: null,
+  });
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/v1/organizations/${orgId}/digest`);
+      if (res.ok) {
+        const d = await res.json();
+        setSettings(d.digestSettings);
+        setLoadError(false);
+      } else {
+        setLoadError(true);
+        toast.error("Failed to load digest settings");
+      }
+    } catch {
+      setLoadError(true);
+      toast.error("Failed to load digest settings");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const save = useCallback(
+    async (patch: Partial<DigestSettingsData>) => {
+      setSaving(true);
+      // Optimistically update
+      setSettings((prev) => ({ ...prev, ...patch }));
+      try {
+        const res = await fetch(`/api/v1/organizations/${orgId}/digest`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(patch),
+        });
+        if (!res.ok) {
+          const d = await res.json();
+          toast.error(d.error || "Failed to save digest settings");
+          // Revert optimistic update
+          load();
+          return;
+        }
+        const d = await res.json();
+        setSettings(d.digestSettings);
+      } catch {
+        toast.error("Failed to save digest settings");
+        load();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [orgId, load],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground py-8">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading...
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <p className="text-sm text-destructive py-8">
+        Could not load digest settings. Please refresh the page and try again.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Mail className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-medium">Weekly Digest</p>
+            {saving && (
+              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Receive a weekly summary of deploys, backups, cron failures, and
+            alerts across all your projects. Sent to all enabled email
+            notification channels.
+          </p>
+        </div>
+        <Switch
+          checked={settings.enabled}
+          onCheckedChange={(checked) => save({ enabled: checked })}
+          aria-label="Enable weekly digest"
+        />
+      </div>
+
+      {settings.enabled && (
+        <div className="space-y-3 pl-6 border-l border-border">
+          <p className="text-xs text-muted-foreground">
+            Schedule times are in UTC.
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="digest-day">Day of week</Label>
+              <Select
+                value={String(settings.dayOfWeek)}
+                onValueChange={(v) => save({ dayOfWeek: parseInt(v) })}
+              >
+                <SelectTrigger id="digest-day" className="squircle">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(DAY_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="digest-hour">Time (UTC)</Label>
+              <Select
+                value={String(settings.hourOfDay)}
+                onValueChange={(v) => save({ hourOfDay: parseInt(v) })}
+              >
+                <SelectTrigger id="digest-hour" className="squircle">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(HOUR_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {settings.lastSentAt && (
+        <p className="text-xs text-muted-foreground">
+          Last sent{" "}
+          {new Date(settings.lastSentAt).toLocaleDateString("en-US", {
+            weekday: "long",
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            timeZoneName: "short",
+          })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -9,6 +9,7 @@ import { OrgSwitcher } from "@/components/layout/org-switcher";
 import { TeamMembers } from "@/app/(app)/team/team-members";
 import { OrgDomainEditor } from "./org-domain-editor";
 import { NotificationChannelsEditor } from "./notification-channels";
+import { DigestSettingsEditor } from "./digest-settings";
 
 export default async function SettingsPage({
   searchParams,
@@ -77,7 +78,12 @@ export default async function SettingsPage({
         </TabsContent>
 
         <TabsContent value="notifications" className="pt-4">
-          <NotificationChannelsEditor orgId={orgId} />
+          <div className="space-y-8">
+            <NotificationChannelsEditor orgId={orgId} />
+            <div className="border-t border-border pt-6">
+              <DigestSettingsEditor orgId={orgId} />
+            </div>
+          </div>
         </TabsContent>
 
         <TabsContent value="team" className="pt-4">

--- a/app/api/v1/organizations/[orgId]/digest/route.ts
+++ b/app/api/v1/organizations/[orgId]/digest/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { digestSettings, notificationChannels, organizations } from "@/lib/db/schema";
+import { requireOrg } from "@/lib/auth/session";
+import { requireAdmin } from "@/lib/auth/permissions";
+import { eq, and } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { collectDigestData } from "@/lib/digest/collector";
+import { createChannel } from "@/lib/notifications/factory";
+
+type RouteParams = { params: Promise<{ orgId: string }> };
+
+const patchSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    dayOfWeek: z.number().int().min(0).max(6).optional(),
+    hourOfDay: z.number().int().min(0).max(23).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "No fields to update",
+  });
+
+// GET /api/v1/organizations/[orgId]/digest
+// Returns the digest settings for the org, creating defaults if missing.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    let setting = await db.query.digestSettings.findFirst({
+      where: eq(digestSettings.organizationId, orgId),
+    });
+
+    if (!setting) {
+      // Return defaults without persisting — settings are created on first PATCH
+      return NextResponse.json({
+        digestSettings: {
+          enabled: false,
+          dayOfWeek: 1,
+          hourOfDay: 8,
+          lastSentAt: null,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      digestSettings: {
+        enabled: setting.enabled,
+        dayOfWeek: setting.dayOfWeek,
+        hourOfDay: setting.hourOfDay,
+        lastSentAt: setting.lastSentAt?.toISOString() ?? null,
+      },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error fetching digest settings");
+  }
+}
+
+// PATCH /api/v1/organizations/[orgId]/digest
+// Creates or updates digest settings for the org.
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId } = await params;
+    const { organization } = await requireOrg();
+    if (organization.id !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const parsed = patchSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 },
+      );
+    }
+
+    const now = new Date();
+
+    // Upsert — eliminates the read-then-write race condition
+    const [upserted] = await db
+      .insert(digestSettings)
+      .values({
+        id: nanoid(),
+        organizationId: orgId,
+        enabled: parsed.data.enabled ?? false,
+        dayOfWeek: parsed.data.dayOfWeek ?? 1,
+        hourOfDay: parsed.data.hourOfDay ?? 8,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: digestSettings.organizationId,
+        set: {
+          ...(parsed.data.enabled !== undefined && { enabled: parsed.data.enabled }),
+          ...(parsed.data.dayOfWeek !== undefined && { dayOfWeek: parsed.data.dayOfWeek }),
+          ...(parsed.data.hourOfDay !== undefined && { hourOfDay: parsed.data.hourOfDay }),
+          updatedAt: now,
+        },
+      })
+      .returning();
+
+    return NextResponse.json({
+      digestSettings: {
+        enabled: upserted.enabled,
+        dayOfWeek: upserted.dayOfWeek,
+        hourOfDay: upserted.hourOfDay,
+        lastSentAt: upserted.lastSentAt?.toISOString() ?? null,
+      },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error updating digest settings");
+  }
+}
+
+// POST /api/v1/organizations/[orgId]/digest
+// Trigger an immediate on-demand digest send for the org.
+// Requires admin or owner role. Returns the collected digest data as a preview.
+export async function POST(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const { orgId } = await params;
+    const { organization, membership } = await requireOrg();
+
+    if (organization.id !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    requireAdmin(membership.role);
+
+    const org = await db.query.organizations.findFirst({
+      where: eq(organizations.id, orgId),
+      columns: { id: true, name: true },
+    });
+
+    if (!org) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+    }
+
+    const data = await collectDigestData(org.id, org.name);
+
+    const event = {
+      type: "weekly-digest" as const,
+      title: `Weekly Digest — ${org.name}`,
+      message: `Weekly health summary for ${org.name}: ${data.deploys.total} deploys, ${data.deploys.failed} failures.`,
+      metadata: {
+        orgName: org.name,
+        weekLabel: data.weekLabel,
+        deploysTotal: String(data.deploys.total),
+        deploysSucceeded: String(data.deploys.succeeded),
+        deploysFailed: String(data.deploys.failed),
+        backupsTotal: String(data.backups.total),
+        backupsSucceeded: String(data.backups.succeeded),
+        backupsFailed: String(data.backups.failed),
+        cronFailures: String(data.cron.totalFailures),
+        cronAffectedJobs: JSON.stringify(data.cron.affectedJobs),
+        diskWriteAlerts: String(data.alerts.diskWriteAlerts),
+        volumeDrifts: String(data.alerts.volumeDrifts),
+        projects: JSON.stringify(data.projects),
+      },
+    };
+
+    // Send synchronously so the caller gets an accurate result
+    const channels = await db.query.notificationChannels.findMany({
+      where: and(
+        eq(notificationChannels.organizationId, orgId),
+        eq(notificationChannels.enabled, true),
+      ),
+    });
+
+    const results = await Promise.allSettled(
+      channels.map((row) => createChannel(row).send(event)),
+    );
+
+    const sent = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.filter((r) => r.status === "rejected").length;
+
+    return NextResponse.json({
+      digest: data,
+      channels: { sent, failed, total: channels.length },
+    });
+  } catch (error) {
+    return handleRouteError(error, "Error sending on-demand digest");
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -50,6 +50,15 @@ export async function register() {
       console.error("[instrumentation] Failed to start backup scheduler:", err);
     }
 
+    console.log("[instrumentation] Starting digest scheduler...");
+    try {
+      const { startDigestScheduler } = await import("./lib/digest/scheduler");
+      startDigestScheduler();
+      console.log("[instrumentation] Digest scheduler started");
+    } catch (err) {
+      console.error("[instrumentation] Failed to start digest scheduler:", err);
+    }
+
     console.log("[instrumentation] Starting domain monitor...");
     try {
       setInterval(async () => {

--- a/lib/api/error-response.ts
+++ b/lib/api/error-response.ts
@@ -8,6 +8,9 @@ export function handleRouteError(error: unknown, context?: string) {
   if (error instanceof Error && error.message === "Unauthorized") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (error instanceof Error && error.message === "Forbidden") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
   if (context) {
     console.error(`${context}:`, error);
   }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -880,6 +880,26 @@ export const notificationChannels = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Host: Weekly Digest Settings (per-org)
+// ---------------------------------------------------------------------------
+
+export const digestSettings = pgTable("digest_setting", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id")
+    .notNull()
+    .unique()
+    .references(() => organizations.id, { onDelete: "cascade" }),
+  enabled: boolean("enabled").default(true).notNull(),
+  // 0 = Sunday … 6 = Saturday
+  dayOfWeek: integer("day_of_week").default(1).notNull(),
+  // 0-23 UTC
+  hourOfDay: integer("hour_of_day").default(8).notNull(),
+  lastSentAt: timestamp("last_sent_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// ---------------------------------------------------------------------------
 // Relations
 // ---------------------------------------------------------------------------
 
@@ -895,7 +915,7 @@ export const userRelations = relations(user, ({ many }) => ({
   respondedTransfers: many(appTransfers, { relationName: "respondedByUser" }),
 }));
 
-export const organizationsRelations = relations(organizations, ({ many }) => ({
+export const organizationsRelations = relations(organizations, ({ many, one }) => ({
   memberships: many(memberships),
   projects: many(projects),
   apps: many(apps),
@@ -910,6 +930,10 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   outgoingTransfers: many(appTransfers, { relationName: "sourceOrg" }),
   incomingTransfers: many(appTransfers, { relationName: "destinationOrg" }),
   notificationChannels: many(notificationChannels),
+  digestSetting: one(digestSettings, {
+    fields: [organizations.id],
+    references: [digestSettings.organizationId],
+  }),
 }));
 
 export const membershipsRelations = relations(memberships, ({ one }) => ({
@@ -1236,6 +1260,13 @@ export const appTransfersRelations = relations(
 );
 
 export const notificationChannelsRelations = relations(notificationChannels, ({ one }) => ({ organization: one(organizations, { fields: [notificationChannels.organizationId], references: [organizations.id] }) }));
+
+export const digestSettingsRelations = relations(digestSettings, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [digestSettings.organizationId],
+    references: [organizations.id],
+  }),
+}));
 
 // ---------------------------------------------------------------------------
 // System settings (key-value store for setup wizard + global config)

--- a/lib/digest/collector.ts
+++ b/lib/digest/collector.ts
@@ -1,0 +1,288 @@
+import { db } from "@/lib/db";
+import {
+  apps,
+  backups,
+  cronJobs,
+  cronJobRuns,
+  deployments,
+  activities,
+} from "@/lib/db/schema";
+import { eq, and, gte, inArray, count, sql } from "drizzle-orm";
+import type {
+  DigestDeploySummary,
+  DigestBackupSummary,
+  DigestCronSummary,
+  DigestAlertSummary,
+  DigestProjectRow,
+} from "@/lib/email/templates/weekly-digest";
+
+export type DigestData = {
+  orgName: string;
+  weekLabel: string;
+  deploys: DigestDeploySummary;
+  backups: DigestBackupSummary;
+  cron: DigestCronSummary;
+  alerts: DigestAlertSummary;
+  projects: DigestProjectRow[];
+};
+
+/**
+ * Collect past 7 days of health data for a given org.
+ */
+export async function collectDigestData(
+  orgId: string,
+  orgName: string,
+): Promise<DigestData> {
+  const now = new Date();
+  const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  // Week label e.g. "Mar 14 – Mar 20, 2026"
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const weekLabel = `${fmt(since)} – ${fmt(now)}, ${now.getFullYear()}`;
+
+  // All apps in org
+  const orgApps = await db.query.apps.findMany({
+    where: eq(apps.organizationId, orgId),
+    columns: { id: true, name: true, projectId: true },
+  });
+
+  if (orgApps.length === 0) {
+    return {
+      orgName,
+      weekLabel,
+      deploys: { total: 0, succeeded: 0, failed: 0 },
+      backups: { total: 0, succeeded: 0, failed: 0 },
+      cron: { totalFailures: 0, affectedJobs: [] },
+      alerts: { diskWriteAlerts: 0, volumeDrifts: 0 },
+      projects: [],
+    };
+  }
+
+  const appIds = orgApps.map((a) => a.id);
+
+  // Fetch cron job ids scoped to this org's apps (needed before Promise.all)
+  const orgCronJobs = await db.query.cronJobs.findMany({
+    where: inArray(cronJobs.appId, appIds),
+    columns: { id: true, name: true, appId: true },
+  });
+
+  const orgCronJobIds = orgCronJobs.map((j) => j.id);
+
+  // ---------------------------------------------------------------------------
+  // Run remaining queries in parallel
+  // ---------------------------------------------------------------------------
+  const [
+    deployCountRows,
+    backupCountRows,
+    cronRuns,
+    alertCountRows,
+  ] = await Promise.all([
+    // Deployment counts grouped by status — no full row loads
+    db
+      .select({ status: deployments.status, n: count() })
+      .from(deployments)
+      .where(
+        and(
+          inArray(deployments.appId, appIds),
+          gte(deployments.startedAt, since),
+        ),
+      )
+      .groupBy(deployments.status),
+
+    // Backup counts grouped by status — no full row loads
+    db
+      .select({ status: backups.status, n: count() })
+      .from(backups)
+      .where(
+        and(
+          inArray(backups.appId, appIds),
+          gte(backups.startedAt, since),
+        ),
+      )
+      .groupBy(backups.status),
+
+    // Cron runs — only fetch if there are cron jobs; keep full rows for
+    // per-project breakdown (cronJobId needed)
+    orgCronJobIds.length > 0
+      ? db.query.cronJobRuns.findMany({
+          where: and(
+            inArray(cronJobRuns.cronJobId, orgCronJobIds),
+            gte(cronJobRuns.startedAt, since),
+          ),
+          columns: {
+            id: true,
+            cronJobId: true,
+            status: true,
+          },
+        })
+      : Promise.resolve([]),
+
+    // Alert counts — filter by action at the DB level
+    db
+      .select({ action: activities.action, n: count() })
+      .from(activities)
+      .where(
+        and(
+          eq(activities.organizationId, orgId),
+          gte(activities.createdAt, since),
+          inArray(activities.action, ["disk-write-alert", "volume-drift"]),
+        ),
+      )
+      .groupBy(activities.action),
+  ]);
+
+  // ---------------------------------------------------------------------------
+  // Aggregate deploy counts
+  // ---------------------------------------------------------------------------
+  let deployTotal = 0;
+  let deploySucceeded = 0;
+  let deployFailed = 0;
+  for (const row of deployCountRows) {
+    deployTotal += row.n;
+    if (row.status === "success") deploySucceeded = row.n;
+    if (row.status === "failed") deployFailed = row.n;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Aggregate backup counts
+  // ---------------------------------------------------------------------------
+  let backupTotal = 0;
+  let backupSucceeded = 0;
+  let backupFailed = 0;
+  for (const row of backupCountRows) {
+    backupTotal += row.n;
+    if (row.status === "success") backupSucceeded = row.n;
+    if (row.status === "failed") backupFailed = row.n;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cron failures
+  // ---------------------------------------------------------------------------
+  const cronJobById = new Map(orgCronJobs.map((j) => [j.id, j]));
+
+  const failedCronRuns = cronRuns.filter((r) => r.status === "failed");
+  const affectedJobNames = [
+    ...new Set(
+      failedCronRuns
+        .map((r) => cronJobById.get(r.cronJobId)?.name)
+        .filter((n): n is string => Boolean(n)),
+    ),
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Alert counts (already aggregated from DB)
+  // ---------------------------------------------------------------------------
+  let diskWriteAlerts = 0;
+  let volumeDrifts = 0;
+  for (const row of alertCountRows) {
+    if (row.action === "disk-write-alert") diskWriteAlerts = row.n;
+    if (row.action === "volume-drift") volumeDrifts = row.n;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-project breakdown
+  // ---------------------------------------------------------------------------
+  const projectMap = new Map<string, DigestProjectRow>();
+
+  for (const app of orgApps) {
+    const projectKey = app.projectId ?? `__no_project_${app.id}`;
+    if (!projectMap.has(projectKey)) {
+      projectMap.set(projectKey, {
+        name: app.name,
+        deploys: 0,
+        failures: 0,
+        backupFailures: 0,
+        cronFailures: 0,
+      });
+    }
+  }
+
+  // For per-project deploy/backup breakdowns we need the appId → status rows.
+  // Re-use the same time window but fetch only appId + status (lightweight).
+  const [deployRows, backupRows] = await Promise.all([
+    deployTotal > 0
+      ? db
+          .select({ appId: deployments.appId, status: deployments.status })
+          .from(deployments)
+          .where(
+            and(
+              inArray(deployments.appId, appIds),
+              gte(deployments.startedAt, since),
+            ),
+          )
+      : Promise.resolve([]),
+    backupTotal > 0
+      ? db
+          .select({ appId: backups.appId, status: backups.status })
+          .from(backups)
+          .where(
+            and(
+              inArray(backups.appId, appIds),
+              gte(backups.startedAt, since),
+            ),
+          )
+      : Promise.resolve([]),
+  ]);
+
+  const appById = new Map(orgApps.map((a) => [a.id, a]));
+
+  for (const dep of deployRows) {
+    const app = appById.get(dep.appId);
+    if (!app) continue;
+    const projectKey = app.projectId ?? `__no_project_${app.id}`;
+    const row = projectMap.get(projectKey);
+    if (!row) continue;
+    row.deploys += 1;
+    if (dep.status === "failed") row.failures += 1;
+  }
+
+  for (const bk of backupRows) {
+    const app = appById.get(bk.appId);
+    if (!app) continue;
+    const projectKey = app.projectId ?? `__no_project_${app.id}`;
+    const row = projectMap.get(projectKey);
+    if (!row) continue;
+    if (bk.status === "failed") row.backupFailures += 1;
+  }
+
+  for (const run of failedCronRuns) {
+    const job = cronJobById.get(run.cronJobId);
+    if (!job) continue;
+    const app = appById.get(job.appId);
+    if (!app) continue;
+    const projectKey = app.projectId ?? `__no_project_${app.id}`;
+    const row = projectMap.get(projectKey);
+    if (!row) continue;
+    row.cronFailures += 1;
+  }
+
+  // Only include projects that had activity
+  const projects = [...projectMap.values()].filter(
+    (p) => p.deploys > 0 || p.failures > 0 || p.backupFailures > 0 || p.cronFailures > 0,
+  );
+
+  return {
+    orgName,
+    weekLabel,
+    deploys: {
+      total: deployTotal,
+      succeeded: deploySucceeded,
+      failed: deployFailed,
+    },
+    backups: {
+      total: backupTotal,
+      succeeded: backupSucceeded,
+      failed: backupFailed,
+    },
+    cron: {
+      totalFailures: failedCronRuns.length,
+      affectedJobs: affectedJobNames,
+    },
+    alerts: {
+      diskWriteAlerts,
+      volumeDrifts,
+    },
+    projects,
+  };
+}

--- a/lib/digest/scheduler.ts
+++ b/lib/digest/scheduler.ts
@@ -1,0 +1,32 @@
+import { tickDigestJobs } from "./tick";
+
+let interval: NodeJS.Timeout | null = null;
+let ticking = false;
+
+export function startDigestScheduler(): void {
+  if (interval) return; // Already running
+
+  console.log("[digest] Scheduler started (60s interval)");
+  interval = setInterval(async () => {
+    if (ticking) {
+      console.log("[digest] Previous tick still running, skipping");
+      return;
+    }
+    ticking = true;
+    try {
+      await tickDigestJobs();
+    } catch (err) {
+      console.error("[digest] Tick error:", err);
+    } finally {
+      ticking = false;
+    }
+  }, 60_000); // Every minute
+}
+
+export function stopDigestScheduler(): void {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+    console.log("[digest] Scheduler stopped");
+  }
+}

--- a/lib/digest/tick.ts
+++ b/lib/digest/tick.ts
@@ -1,0 +1,85 @@
+import { db } from "@/lib/db";
+import { digestSettings } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { notify } from "@/lib/notifications/dispatch";
+import { collectDigestData } from "./collector";
+
+/**
+ * Check all orgs with digest settings and fire the digest for any that are due.
+ * Called every minute by the digest scheduler.
+ */
+export async function tickDigestJobs(): Promise<void> {
+  const now = new Date();
+  const currentDay = now.getUTCDay(); // 0 = Sunday
+  const currentHour = now.getUTCHours();
+  // Only fire once per hour — check minute is 0-4 to avoid drift issues
+  const currentMinute = now.getUTCMinutes();
+  if (currentMinute >= 5) return;
+
+  const settings = await db.query.digestSettings.findMany({
+    where: eq(digestSettings.enabled, true),
+    with: { organization: true },
+  });
+
+  // Process all orgs concurrently — one failure won't block others
+  await Promise.allSettled(
+    settings.map(async (setting) => {
+      try {
+        if (setting.dayOfWeek !== currentDay) return;
+        if (setting.hourOfDay !== currentHour) return;
+
+        // Atomic claim: update lastSentAt only if it hasn't been set in the past
+        // 50 minutes. If 0 rows are returned, another process already claimed this
+        // tick — skip to prevent duplicate emails in multi-instance deployments.
+        const claimed = await db
+          .update(digestSettings)
+          .set({ lastSentAt: now, updatedAt: now })
+          .where(
+            sql`${digestSettings.id} = ${setting.id} AND (${digestSettings.lastSentAt} IS NULL OR ${digestSettings.lastSentAt} < NOW() - INTERVAL '50 minutes')`,
+          )
+          .returning({ id: digestSettings.id });
+
+        if (claimed.length === 0) {
+          console.log(
+            `[digest] Skipping org ${setting.organizationId} — already claimed by another process`,
+          );
+          return;
+        }
+
+        const org = setting.organization;
+
+        console.log(`[digest] Sending weekly digest to org "${org.name}" (${org.id})`);
+
+        const data = await collectDigestData(org.id, org.name);
+
+        await notify(org.id, {
+          type: "weekly-digest",
+          title: `Weekly Digest — ${org.name}`,
+          message: `Weekly health summary for ${org.name}: ${data.deploys.total} deploys, ${data.deploys.failed} failures.`,
+          metadata: {
+            orgName: org.name,
+            weekLabel: data.weekLabel,
+            deploysTotal: String(data.deploys.total),
+            deploysSucceeded: String(data.deploys.succeeded),
+            deploysFailed: String(data.deploys.failed),
+            backupsTotal: String(data.backups.total),
+            backupsSucceeded: String(data.backups.succeeded),
+            backupsFailed: String(data.backups.failed),
+            cronFailures: String(data.cron.totalFailures),
+            cronAffectedJobs: JSON.stringify(data.cron.affectedJobs),
+            diskWriteAlerts: String(data.alerts.diskWriteAlerts),
+            volumeDrifts: String(data.alerts.volumeDrifts),
+            projects: JSON.stringify(data.projects),
+          },
+        });
+
+        console.log(`[digest] Digest sent for org "${org.name}"`);
+      } catch (err) {
+        console.error(
+          `[digest] Error sending digest for org ${setting.organizationId}:`,
+          err,
+        );
+      }
+    }),
+  );
+}

--- a/lib/email/templates/weekly-digest.tsx
+++ b/lib/email/templates/weekly-digest.tsx
@@ -1,0 +1,271 @@
+import { Heading, Section, Text } from "@react-email/components";
+import {
+  EmailLayout,
+  CTA,
+  InfoBox,
+  SuccessBox,
+  ErrorBox,
+  WarningBox,
+  Label,
+  styles,
+} from "./components";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DigestDeploySummary = {
+  total: number;
+  succeeded: number;
+  failed: number;
+};
+
+export type DigestBackupSummary = {
+  total: number;
+  succeeded: number;
+  failed: number;
+};
+
+export type DigestCronSummary = {
+  totalFailures: number;
+  affectedJobs: string[];
+};
+
+export type DigestAlertSummary = {
+  diskWriteAlerts: number;
+  volumeDrifts: number;
+};
+
+export type DigestProjectRow = {
+  name: string;
+  deploys: number;
+  failures: number;
+  backupFailures: number;
+  cronFailures: number;
+};
+
+export type WeeklyDigestEmailProps = {
+  orgName: string;
+  weekLabel: string; // e.g. "Mar 14 – Mar 20, 2026"
+  deploys: DigestDeploySummary;
+  backups: DigestBackupSummary;
+  cron: DigestCronSummary;
+  alerts: DigestAlertSummary;
+  projects: DigestProjectRow[];
+  dashboardUrl: string;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pct(n: number, total: number): string {
+  if (total === 0) return "0%";
+  return `${Math.round((n / total) * 100)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Template
+// ---------------------------------------------------------------------------
+
+export function WeeklyDigestEmail({
+  orgName,
+  weekLabel,
+  deploys,
+  backups,
+  cron,
+  alerts,
+  projects,
+  dashboardUrl,
+}: WeeklyDigestEmailProps) {
+  const hasAnyIssues =
+    deploys.failed > 0 ||
+    backups.failed > 0 ||
+    cron.totalFailures > 0 ||
+    alerts.diskWriteAlerts > 0 ||
+    alerts.volumeDrifts > 0;
+
+  const preview = hasAnyIssues
+    ? `${orgName} weekly digest — ${deploys.failed + backups.failed + cron.totalFailures} issues need attention`
+    : `${orgName} weekly digest — all systems healthy`;
+
+  return (
+    <EmailLayout preview={preview}>
+      <Heading style={styles.h1}>Weekly Digest</Heading>
+      <Text style={{ ...styles.muted, marginBottom: "4px" }}>{orgName}</Text>
+      <Text style={{ ...styles.muted, marginTop: "0" }}>{weekLabel}</Text>
+
+      {/* Deploy summary */}
+      <Label>Deploys</Label>
+      {deploys.total === 0 ? (
+        <InfoBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>This week</span>{" "}
+            <span style={styles.kvValue}>No deploys</span>
+          </Text>
+        </InfoBox>
+      ) : deploys.failed === 0 ? (
+        <SuccessBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Total</span>{" "}
+            <span style={styles.kvValue}>{deploys.total}</span>
+          </Text>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Success rate</span>{" "}
+            <span style={styles.kvValue}>
+              {pct(deploys.succeeded, deploys.total)} ({deploys.succeeded}/
+              {deploys.total})
+            </span>
+          </Text>
+        </SuccessBox>
+      ) : (
+        <ErrorBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Total</span>{" "}
+            <span style={styles.kvValue}>{deploys.total}</span>
+          </Text>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Succeeded</span>{" "}
+            <span style={styles.kvValue}>{deploys.succeeded}</span>
+          </Text>
+          <Text style={{ ...styles.kvRow }}>
+            <span style={{ ...styles.kvLabel, color: "#991b1b" }}>Failed</span>{" "}
+            <span style={{ ...styles.kvValue, color: "#991b1b" }}>
+              {deploys.failed}
+            </span>
+          </Text>
+        </ErrorBox>
+      )}
+
+      {/* Backup summary */}
+      <Label>Backups</Label>
+      {backups.total === 0 ? (
+        <InfoBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>This week</span>{" "}
+            <span style={styles.kvValue}>No backups scheduled</span>
+          </Text>
+        </InfoBox>
+      ) : backups.failed === 0 ? (
+        <SuccessBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Total</span>{" "}
+            <span style={styles.kvValue}>{backups.total}</span>
+          </Text>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>All successful</span>{" "}
+            <span style={styles.kvValue}>{backups.succeeded}</span>
+          </Text>
+        </SuccessBox>
+      ) : (
+        <ErrorBox>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Total</span>{" "}
+            <span style={styles.kvValue}>{backups.total}</span>
+          </Text>
+          <Text style={styles.kvRow}>
+            <span style={styles.kvLabel}>Succeeded</span>{" "}
+            <span style={styles.kvValue}>{backups.succeeded}</span>
+          </Text>
+          <Text style={styles.kvRow}>
+            <span style={{ ...styles.kvLabel, color: "#991b1b" }}>Failed</span>{" "}
+            <span style={{ ...styles.kvValue, color: "#991b1b" }}>
+              {backups.failed}
+            </span>
+          </Text>
+        </ErrorBox>
+      )}
+
+      {/* Cron failures */}
+      {cron.totalFailures > 0 && (
+        <>
+          <Label>Cron Failures</Label>
+          <WarningBox>
+            <Text style={styles.kvRow}>
+              <span style={styles.kvLabel}>Failures</span>{" "}
+              <span style={{ ...styles.kvValue, color: "#92400e" }}>
+                {cron.totalFailures}
+              </span>
+            </Text>
+            {cron.affectedJobs.length > 0 && (
+              <Text style={{ ...styles.muted, margin: "4px 0 0" }}>
+                Affected: {cron.affectedJobs.slice(0, 5).join(", ")}
+                {cron.affectedJobs.length > 5
+                  ? ` and ${cron.affectedJobs.length - 5} more`
+                  : ""}
+              </Text>
+            )}
+          </WarningBox>
+        </>
+      )}
+
+      {/* Alerts */}
+      {(alerts.diskWriteAlerts > 0 || alerts.volumeDrifts > 0) && (
+        <>
+          <Label>Alerts</Label>
+          <WarningBox>
+            {alerts.diskWriteAlerts > 0 && (
+              <Text style={styles.kvRow}>
+                <span style={styles.kvLabel}>Disk writes</span>{" "}
+                <span style={{ ...styles.kvValue, color: "#92400e" }}>
+                  {alerts.diskWriteAlerts} alert
+                  {alerts.diskWriteAlerts !== 1 ? "s" : ""}
+                </span>
+              </Text>
+            )}
+            {alerts.volumeDrifts > 0 && (
+              <Text style={styles.kvRow}>
+                <span style={styles.kvLabel}>Volume drift</span>{" "}
+                <span style={{ ...styles.kvValue, color: "#92400e" }}>
+                  {alerts.volumeDrifts} event
+                  {alerts.volumeDrifts !== 1 ? "s" : ""}
+                </span>
+              </Text>
+            )}
+          </WarningBox>
+        </>
+      )}
+
+      {/* Per-project breakdown */}
+      {projects.length > 0 && (
+        <Section style={{ margin: "0 0 16px" }}>
+          <Label>Projects</Label>
+          {projects.map((p) => (
+            <Text key={p.name} style={styles.stageRow}>
+              <span style={{ fontWeight: p.failures > 0 ? "600" : "normal" }}>
+                {p.name}
+              </span>
+              <span style={styles.stageDuration}>
+                {p.deploys}d
+                {p.failures > 0 ? ` · ${p.failures} fail` : ""}
+                {p.backupFailures > 0
+                  ? ` · ${p.backupFailures} bkp fail`
+                  : ""}
+                {p.cronFailures > 0 ? ` · ${p.cronFailures} cron fail` : ""}
+              </span>
+            </Text>
+          ))}
+        </Section>
+      )}
+
+      <CTA href={dashboardUrl}>View Dashboard &rarr;</CTA>
+    </EmailLayout>
+  );
+}
+
+WeeklyDigestEmail.PreviewProps = {
+  orgName: "Acme Corp",
+  weekLabel: "Mar 14 – Mar 20, 2026",
+  deploys: { total: 12, succeeded: 10, failed: 2 },
+  backups: { total: 7, succeeded: 7, failed: 0 },
+  cron: { totalFailures: 3, affectedJobs: ["db-cleanup", "report-gen"] },
+  alerts: { diskWriteAlerts: 1, volumeDrifts: 2 },
+  projects: [
+    { name: "acme-web", deploys: 6, failures: 1, backupFailures: 0, cronFailures: 0 },
+    { name: "acme-api", deploys: 4, failures: 1, backupFailures: 0, cronFailures: 2 },
+    { name: "acme-worker", deploys: 2, failures: 0, backupFailures: 0, cronFailures: 1 },
+  ],
+  dashboardUrl: "https://host.example.com",
+} satisfies WeeklyDigestEmailProps;
+
+export default WeeklyDigestEmail;

--- a/lib/notifications/email-channel.ts
+++ b/lib/notifications/email-channel.ts
@@ -9,6 +9,7 @@ import { CronFailedEmail } from "@/lib/email/templates/cron-failed";
 import { DiskWriteAlertEmail } from "@/lib/email/templates/disk-write-alert";
 import { VolumeDriftEmail } from "@/lib/email/templates/volume-drift";
 import { AutoRollbackEmail } from "@/lib/email/templates/auto-rollback";
+import { WeeklyDigestEmail } from "@/lib/email/templates/weekly-digest";
 
 type EmailConfig = { recipients: string[] };
 
@@ -137,6 +138,32 @@ export class EmailNotificationChannel implements NotificationChannel {
             m.reason || "Container crashed within grace period",
           fromDeploymentId: m.fromDeploymentId || "",
           toDeploymentId: m.toDeploymentId || "",
+          dashboardUrl,
+        });
+
+      case "weekly-digest":
+        return WeeklyDigestEmail({
+          orgName: m.orgName || "Your Organization",
+          weekLabel: m.weekLabel || "",
+          deploys: {
+            total: parseInt(m.deploysTotal || "0"),
+            succeeded: parseInt(m.deploysSucceeded || "0"),
+            failed: parseInt(m.deploysFailed || "0"),
+          },
+          backups: {
+            total: parseInt(m.backupsTotal || "0"),
+            succeeded: parseInt(m.backupsSucceeded || "0"),
+            failed: parseInt(m.backupsFailed || "0"),
+          },
+          cron: {
+            totalFailures: parseInt(m.cronFailures || "0"),
+            affectedJobs: m.cronAffectedJobs ? JSON.parse(m.cronAffectedJobs) : [],
+          },
+          alerts: {
+            diskWriteAlerts: parseInt(m.diskWriteAlerts || "0"),
+            volumeDrifts: parseInt(m.volumeDrifts || "0"),
+          },
+          projects: m.projects ? JSON.parse(m.projects) : [],
           dashboardUrl,
         });
 

--- a/lib/notifications/port.ts
+++ b/lib/notifications/port.ts
@@ -6,7 +6,8 @@ export type NotificationEventType =
   | "cron-failed"
   | "volume-drift"
   | "disk-write-alert"
-  | "auto-rollback";
+  | "auto-rollback"
+  | "weekly-digest";
 
 export type NotificationEvent = {
   type: NotificationEventType;


### PR DESCRIPTION
## Summary

- Adds a per-org weekly digest that emails a 7-day health summary (deploys, backups, cron failures, disk-write alerts, volume drift) to all enabled email notification channels
- Digest fires on a configurable day-of-week + hour-of-day (UTC); scheduler follows the exact `backup/scheduler.ts` pattern with 60s tick
- Settings UI lives in the Notifications tab of Settings with an enable toggle, day picker, and time picker

## What was built

- `lib/db/schema.ts` — `digest_setting` table (per-org, `enabled`, `dayOfWeek`, `hourOfDay`, `lastSentAt`)
- `lib/notifications/port.ts` — `"weekly-digest"` added to `NotificationEventType`
- `lib/email/templates/weekly-digest.tsx` — React Email template with deploy/backup/cron/alert sections and per-project breakdown
- `lib/digest/collector.ts` — queries past 7 days per org (deployments, backups, cronJobRuns, activities)
- `lib/digest/tick.ts` — checks enabled settings against UTC day/hour, guards double-fire with 60-min lastSentAt check
- `lib/digest/scheduler.ts` — `startDigestScheduler` / `stopDigestScheduler` (60s interval)
- `lib/notifications/email-channel.ts` — `weekly-digest` case renders the template from notification metadata
- `instrumentation.ts` — digest scheduler wired into server startup
- `app/api/v1/organizations/[orgId]/digest/route.ts` — GET (returns settings or defaults) / PATCH (upserts)
- `app/(app)/settings/digest-settings.tsx` — client component with optimistic updates
- `app/(app)/settings/page.tsx` — `DigestSettingsEditor` mounted below notification channels

## Test plan

- [ ] Run `pnpm db:push` to apply the `digest_setting` table migration
- [ ] Go to Settings > Notifications — verify the Weekly Digest section renders below channels
- [ ] Toggle digest on — verify PATCH fires and day/time selects appear
- [ ] PATCH with specific `dayOfWeek`/`hourOfDay` — verify GET reflects updated values
- [ ] Confirm `GET /api/v1/organizations/[orgId]/digest` returns defaults when no row exists
- [ ] Verify `pnpm typecheck` passes (clean)
- [ ] Inspect the email template preview via react-email dev server
- [ ] Set digest to fire at the current UTC hour/day and confirm the scheduler calls `notify()` after a tick

Closes #52