### PR TITLE
fix(docker): run runner stage as non-root user with docker group access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,25 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/drizzle ./drizzle
-COPY --from=builder /app/scripts/migrate.mjs ./scripts/migrate.mjs
+# Create a non-root user for the Node process.
+# The docker group (GID 999) matches the conventional Docker socket GID on
+# Debian/Ubuntu hosts so the process can communicate with the mounted socket
+# without running as root. If the host's docker group uses a different GID,
+# override at runtime with: --group-add <host-docker-gid>
+RUN addgroup --system --gid 1001 nodejs && \
+    addgroup --system --gid 999 docker && \
+    adduser --system --uid 1001 --ingroup nodejs nextjs && \
+    adduser nextjs docker && \
+    mkdir -p /var/lib/host/projects && \
+    chown nextjs:nodejs /var/lib/host/projects
+
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/migrate.mjs ./scripts/migrate.mjs
+
+USER nextjs
 
 EXPOSE 3000
 ENV PORT=3000


### PR DESCRIPTION
## Summary

- Adds a dedicated `nextjs` user (UID 1001) and `nodejs` group (GID 1001) in the runner stage — the Node process no longer runs as root
- Creates a `docker` group (GID 999) inside the image matching the conventional Docker socket GID on Debian/Ubuntu hosts, and adds `nextjs` to it so the mounted `/var/run/docker.sock` remains accessible without elevated privilege
- All `COPY` instructions in the runner stage now use `--chown=nextjs:nodejs` so app files are owned by the non-root user from the start
- Pre-creates `/var/lib/host/projects` with correct ownership so the projects volume mounts cleanly under the new user

Addresses CIS Docker Benchmark 4.1 (do not run containers as root). Closes #70.

## Notes

If the host's `docker` group uses a GID other than 999, the container can be started with `--group-add <host-docker-gid>` to grant socket access without rebuilding the image.

## Test plan

- [ ] Build image locally: `docker compose build`
- [ ] Start stack: `docker compose --env-file .env.prod up -d`
- [ ] Confirm process user: `docker compose exec host whoami` should return `nextjs`
- [ ] Confirm Docker socket access works (deploy a project from the UI)
- [ ] Confirm migrations run on startup (check logs for `[migrate]` output)
- [ ] Confirm `/var/lib/host/projects` volume mounts and is writable