### PR TITLE
fix(setup): require app admin on post-setup config endpoints

### DIFF
--- a/app/api/setup/backup/route.ts
+++ b/app/api/setup/backup/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
-import { requireSession } from "@/lib/auth/session";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
 import { db } from "@/lib/db";
 import { systemSettings } from "@/lib/db/schema";
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   const setup = await needsSetup();
   if (!setup) {
-    await requireSession();
+    await requireAdminAuth(request);
   }
 
   const body = await request.json();

--- a/app/api/setup/email/route.ts
+++ b/app/api/setup/email/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from "next/server";
-import { requireSession } from "@/lib/auth/session";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
 import { db } from "@/lib/db";
 import { systemSettings } from "@/lib/db/schema";
 
-export async function POST(request: Request) {
-  // Only accessible during setup or by admin
+export async function POST(request: NextRequest) {
+  // Only accessible during initial setup or by an app admin
   const setup = await needsSetup();
   if (!setup) {
-    await requireSession();
+    await requireAdminAuth(request);
   }
 
   const body = await request.json();

--- a/app/api/setup/github/route.ts
+++ b/app/api/setup/github/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
-import { requireSession } from "@/lib/auth/session";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
 import { db } from "@/lib/db";
 import { systemSettings } from "@/lib/db/schema";
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   const setup = await needsSetup();
   if (!setup) {
-    await requireSession();
+    await requireAdminAuth(request);
   }
 
   const body = await request.json();

--- a/app/api/setup/services/route.ts
+++ b/app/api/setup/services/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
-import { requireSession } from "@/lib/auth/session";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
 import { db } from "@/lib/db";
 import { systemSettings } from "@/lib/db/schema";
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   const setup = await needsSetup();
   if (!setup) {
-    await requireSession();
+    await requireAdminAuth(request);
   }
 
   const body = await request.json();


### PR DESCRIPTION
## Summary

- `/api/setup/github`, `/api/setup/email`, `/api/setup/backup`, and `/api/setup/services` all used `requireSession()` in the post-setup branch
- Any authenticated user — including non-admin members — could overwrite the GitHub App private key, email provider credentials, backup storage keys, and optional services config
- Replaced `requireSession()` with `requireAdminAuth(request)` across all four routes, which enforces app-admin privilege via session cookie or Bearer API token

Fixes #72

## Test plan

- [ ] Authenticated non-admin user receives 403 when POSTing to any of the four setup endpoints after setup is complete
- [ ] App admin user (session) can successfully POST to all four endpoints
- [ ] App admin user (Bearer token) can successfully POST to all four endpoints
- [ ] During initial setup (`needsSetup()` returns true), endpoints remain accessible without auth