### PR TITLE
feat(loading): add skeleton loading states for all async app pages

### DIFF
--- a/app/(app)/activity/loading.tsx
+++ b/app/(app)/activity/loading.tsx
@@ -1,0 +1,29 @@
+export default function ActivityLoading() {
+  return (
+    <div className="space-y-6">
+      {/* PageToolbar skeleton */}
+      <div className="flex items-center gap-4">
+        <div className="h-8 w-24 bg-muted animate-pulse rounded-lg" />
+      </div>
+
+      {/* Activity feed skeleton */}
+      <div className="space-y-1">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-3 rounded-lg px-3 py-3">
+            {/* Avatar */}
+            <div className="h-8 w-8 bg-muted animate-pulse rounded-full shrink-0 mt-0.5" />
+
+            {/* Content */}
+            <div className="flex-1 space-y-1.5 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <div className="h-4 w-24 bg-muted animate-pulse rounded-md" />
+                <div className="h-4 w-48 bg-muted animate-pulse rounded-md" />
+              </div>
+              <div className="h-3 w-28 bg-muted animate-pulse rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/admin/[[...slug]]/loading.tsx
+++ b/app/(app)/admin/[[...slug]]/loading.tsx
@@ -1,0 +1,48 @@
+export default function AdminLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="h-8 w-28 bg-muted animate-pulse rounded-lg" />
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 border-b border-border">
+        {[88, 72, 120, 72, 120, 88].map((w, i) => (
+          <div
+            key={i}
+            className="h-9 bg-muted animate-pulse rounded-t-md"
+            style={{ width: `${w}px` }}
+          />
+        ))}
+      </div>
+
+      {/* Overview cards */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 pt-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-xl border bg-card p-4 space-y-2">
+            <div className="h-3 w-20 bg-muted animate-pulse rounded-md" />
+            <div className="h-8 w-16 bg-muted animate-pulse rounded-md" />
+          </div>
+        ))}
+      </div>
+
+      {/* Table area */}
+      <div className="rounded-xl border overflow-hidden">
+        <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
+          {[120, 160, 100, 80].map((w, i) => (
+            <div key={i} className="h-3 bg-muted animate-pulse rounded-md" style={{ width: `${w}px` }} />
+          ))}
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b last:border-0 bg-card px-4 py-3">
+            <div className="h-4 w-28 bg-muted animate-pulse rounded-md" />
+            <div className="h-4 w-40 bg-muted animate-pulse rounded-md" />
+            <div className="h-4 w-24 bg-muted animate-pulse rounded-md" />
+            <div className="h-5 w-16 bg-muted animate-pulse rounded-full ml-auto" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/apps/[...slug]/loading.tsx
+++ b/app/(app)/apps/[...slug]/loading.tsx
@@ -1,0 +1,46 @@
+export default function AppDetailLoading() {
+  return (
+    <div className="space-y-6">
+      {/* App header: icon + name + status badge */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 bg-muted animate-pulse rounded-xl shrink-0" />
+          <div className="space-y-1.5">
+            <div className="h-6 w-40 bg-muted animate-pulse rounded-md" />
+            <div className="h-4 w-24 bg-muted animate-pulse rounded-md" />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-24 bg-muted animate-pulse rounded-lg" />
+          <div className="h-9 w-9 bg-muted animate-pulse rounded-lg" />
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 border-b border-border pb-0">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-9 bg-muted animate-pulse rounded-t-md"
+            style={{ width: `${60 + i * 8}px` }}
+          />
+        ))}
+      </div>
+
+      {/* Content area: deployment list placeholder */}
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3">
+            <div className="h-4 w-4 bg-muted animate-pulse rounded-full shrink-0" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-4 w-64 bg-muted animate-pulse rounded-md" />
+              <div className="h-3 w-40 bg-muted animate-pulse rounded-md" />
+            </div>
+            <div className="h-5 w-16 bg-muted animate-pulse rounded-full shrink-0" />
+            <div className="h-4 w-20 bg-muted animate-pulse rounded-md shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/backups/loading.tsx
+++ b/app/(app)/backups/loading.tsx
@@ -1,0 +1,35 @@
+export default function BackupsLoading() {
+  return (
+    <div className="space-y-6">
+      {/* PageToolbar skeleton */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="h-8 w-24 bg-muted animate-pulse rounded-lg" />
+        <div className="h-9 w-28 bg-muted animate-pulse rounded-lg" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="rounded-xl border overflow-hidden">
+        {/* Table header */}
+        <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
+          {[100, 80, 120, 80, 60].map((w, i) => (
+            <div key={i} className="h-3 bg-muted animate-pulse rounded-md" style={{ width: `${w}px` }} />
+          ))}
+        </div>
+
+        {/* Table rows */}
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b last:border-0 bg-card px-4 py-3"
+          >
+            <div className="h-4 w-24 bg-muted animate-pulse rounded-md" />
+            <div className="h-4 w-20 bg-muted animate-pulse rounded-md" />
+            <div className="h-4 w-28 bg-muted animate-pulse rounded-md" />
+            <div className="h-5 w-16 bg-muted animate-pulse rounded-full" />
+            <div className="ml-auto h-7 w-16 bg-muted animate-pulse rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/metrics/loading.tsx
+++ b/app/(app)/metrics/loading.tsx
@@ -1,0 +1,43 @@
+export default function MetricsLoading() {
+  return (
+    <div className="space-y-6">
+      {/* PageToolbar skeleton */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="h-8 w-24 bg-muted animate-pulse rounded-lg" />
+      </div>
+
+      {/* App selector + chart area */}
+      <div className="space-y-4">
+        {/* App selector row */}
+        <div className="flex items-center gap-2 flex-wrap">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-8 w-20 bg-muted animate-pulse rounded-full" />
+          ))}
+        </div>
+
+        {/* Metric cards */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-xl border bg-card p-4 space-y-2">
+              <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
+              <div className="h-7 w-24 bg-muted animate-pulse rounded-md" />
+            </div>
+          ))}
+        </div>
+
+        {/* Main chart area */}
+        <div className="rounded-xl border bg-card p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="h-5 w-20 bg-muted animate-pulse rounded-md" />
+            <div className="flex gap-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-7 w-12 bg-muted animate-pulse rounded-md" />
+              ))}
+            </div>
+          </div>
+          <div className="h-56 w-full bg-muted/50 animate-pulse rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/profile/loading.tsx
+++ b/app/(app)/profile/loading.tsx
@@ -1,0 +1,32 @@
+export default function ProfileLoading() {
+  return (
+    <div className="space-y-8">
+      {/* Page title */}
+      <div className="h-8 w-20 bg-muted animate-pulse rounded-lg" />
+
+      {/* Account settings card */}
+      <div className="rounded-xl border bg-card p-6 space-y-4">
+        <div className="h-5 w-36 bg-muted animate-pulse rounded-md" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-1.5">
+              <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
+              <div className="h-10 w-full bg-muted animate-pulse rounded-lg" />
+            </div>
+          ))}
+          <div className="h-9 w-24 bg-muted animate-pulse rounded-lg pt-2" />
+        </div>
+      </div>
+
+      {/* Theme switcher card */}
+      <div className="rounded-xl border bg-card p-6 space-y-4">
+        <div className="h-5 w-24 bg-muted animate-pulse rounded-md" />
+        <div className="flex items-center gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-9 w-24 bg-muted animate-pulse rounded-lg" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/projects/loading.tsx
+++ b/app/(app)/projects/loading.tsx
@@ -1,0 +1,58 @@
+export default function ProjectsLoading() {
+  return (
+    <div className="space-y-6">
+      {/* PageToolbar skeleton */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex flex-1 flex-wrap items-center gap-3">
+          <div className="h-8 w-28 bg-muted animate-pulse rounded-lg" />
+          <div className="h-6 w-24 bg-muted animate-pulse rounded-md" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-28 bg-muted animate-pulse rounded-lg" />
+          <div className="h-5 w-16 bg-muted animate-pulse rounded-md" />
+        </div>
+      </div>
+
+      {/* Project group skeletons */}
+      <div className="space-y-8">
+        {[1, 2].map((group) => (
+          <div key={group} className="space-y-3">
+            {/* Project group header */}
+            <div className="flex items-center gap-2">
+              <div className="h-3 w-3 bg-muted animate-pulse rounded-full" />
+              <div className="h-5 w-32 bg-muted animate-pulse rounded-md" />
+            </div>
+
+            {/* App cards grid */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: group === 1 ? 3 : 2 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="rounded-xl border bg-card p-4 space-y-3"
+                >
+                  {/* App header: icon + name + status */}
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <div className="h-8 w-8 bg-muted animate-pulse rounded-lg shrink-0" />
+                      <div className="space-y-1">
+                        <div className="h-4 w-24 bg-muted animate-pulse rounded-md" />
+                        <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
+                      </div>
+                    </div>
+                    <div className="h-5 w-5 bg-muted animate-pulse rounded-full shrink-0" />
+                  </div>
+
+                  {/* Sparkline placeholder */}
+                  <div className="h-10 w-full bg-muted/50 animate-pulse rounded-md" />
+
+                  {/* Footer: domain */}
+                  <div className="h-3 w-36 bg-muted animate-pulse rounded-md" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/settings/loading.tsx
+++ b/app/(app)/settings/loading.tsx
@@ -1,0 +1,36 @@
+export default function SettingsLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Header: title + org switcher */}
+      <div className="flex items-center gap-3">
+        <div className="h-8 w-24 bg-muted animate-pulse rounded-lg" />
+        <div className="h-6 w-28 bg-muted animate-pulse rounded-md" />
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 border-b border-border">
+        {[120, 88, 128, 72, 100].map((w, i) => (
+          <div
+            key={i}
+            className="h-9 bg-muted animate-pulse rounded-t-md"
+            style={{ width: `${w}px` }}
+          />
+        ))}
+      </div>
+
+      {/* Tab content: key-value rows */}
+      <div className="space-y-3 pt-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3">
+            <div className="space-y-1">
+              <div className="h-4 w-32 bg-muted animate-pulse rounded-md" />
+              <div className="h-3 w-48 bg-muted animate-pulse rounded-md" />
+            </div>
+            <div className="h-8 w-16 bg-muted animate-pulse rounded-lg shrink-0" />
+          </div>
+        ))}
+        <div className="h-9 w-36 bg-muted animate-pulse rounded-lg" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #121

## Summary
- Adds `loading.tsx` files to all eight server-component pages that perform async DB queries: projects, app detail, metrics, backups, activity, settings, admin, and profile
- Next.js App Router picks these up automatically and streams them during navigation, replacing the blank-flash users see while the server resolves data
- Each skeleton approximates the real page layout (toolbar, grid/table/feed structure) using `animate-pulse` divs — consistent with the `LoginSkeleton` pattern already in the codebase
- No new dependencies, no changes to existing files

## Test plan
- [ ] Navigate to `/projects` — skeleton toolbar + project group cards should flash in briefly before content loads
- [ ] Navigate to `/apps/<name>` — app header + tab bar + deployment row skeletons should show
- [ ] Navigate to `/metrics`, `/backups`, `/activity`, `/settings` — each shows a layout-appropriate skeleton
- [ ] Navigate to `/admin` — admin tab bar + overview cards + table skeleton should show
- [ ] Navigate to `/profile` — form field + theme card skeletons should show
- [ ] Verify no layout shift once real content replaces the skeleton
- [ ] Verify skeletons respect `prefers-reduced-motion` (Tailwind `animate-pulse` pauses when motion is reduced)