### PR TITLE
fix(a11y): add prefers-reduced-motion support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -195,6 +195,17 @@
   --status-neutral-muted: oklch(0.45 0.005 260 / 12%);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary

Fixes #151 by adding global `prefers-reduced-motion` support to disable animations when users have enabled the OS-level motion reduction preference.

## Changes

- Added `@media (prefers-reduced-motion: reduce)` rule in `app/globals.css`
- Disables animation-duration, animation-iteration-count, transition-duration, and scroll-behavior for all elements
- Provides broad coverage across all animation patterns (animate-pulse, animate-spin, shimmer-slide, etc.)

## Test Plan

- [ ] Enable "Reduce motion" in OS settings (macOS: System Settings > Accessibility > Display > Reduce motion, Windows: Settings > Ease of Access > Display > Show animations)
- [ ] Verify animations are disabled when the setting is enabled
- [ ] Verify animations work normally when the setting is disabled
- [ ] Test across multiple browsers (Chrome, Safari, Firefox)
- [ ] Confirm no console errors in DevTools