### PR TITLE
fix(ux): guard Stop All and app Stop with confirmation dialogs

### DIFF
--- a/app/(app)/apps/[...slug]/app-detail.tsx
+++ b/app/(app)/apps/[...slug]/app-detail.tsx
@@ -737,6 +737,7 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteEnvOpen, setDeleteEnvOpen] = useState(false);
+  const [stopOpen, setStopOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deletingEnv, setDeletingEnv] = useState(false);
@@ -1210,6 +1211,17 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
     }
   }
 
+  async function handleStop() {
+    try {
+      const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/stop`, { method: "POST" });
+      const data = await res.json();
+      data.success ? toast.success("Stopped") : toast.error(data.error || "Stop failed");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Stop failed");
+    }
+    router.refresh();
+  }
+
   async function handleDelete() {
     setDeleting(true);
     try {
@@ -1658,18 +1670,10 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                     <RotateCcw className="mr-2 size-4" />
                     Restart
                   </DropdownMenuItem>
+                  <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
-                    onClick={async () => {
-                      try {
-                        const res = await fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/stop`, { method: "POST" });
-                        const data = await res.json();
-                        data.success ? toast.success("Stopped") : toast.error(data.error || "Stop failed");
-                      } catch (err) {
-                        toast.error(err instanceof Error ? err.message : "Stop failed");
-                      }
-                      router.refresh();
-                    }}
+                    onClick={() => setStopOpen(true)}
                   >
                     <Square className="mr-2 size-4" />
                     Stop
@@ -3082,6 +3086,16 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
           </BottomSheet>
         );
       })()}
+
+      {/* Stop Confirmation */}
+      <ConfirmDeleteDialog
+        open={stopOpen}
+        onOpenChange={setStopOpen}
+        title="Stop app"
+        description={`Stop "${app.displayName}"? The app will go offline until you redeploy or restart it.`}
+        onConfirm={handleStop}
+        confirmLabel="Stop"
+      />
 
       {/* Delete Project Confirmation */}
       <ConfirmDeleteDialog

--- a/app/(app)/projects/[...slug]/project-detail.tsx
+++ b/app/(app)/projects/[...slug]/project-detail.tsx
@@ -779,6 +779,7 @@ export function ProjectDetail({
   const [editDisplayName, setEditDisplayName] = useState(project.displayName);
   const [editDescription, setEditDescription] = useState(project.description || "");
   const [editSaving, setEditSaving] = useState(false);
+  const [stopAllOpen, setStopAllOpen] = useState(false);
 
   // Filter out compose child apps — they render nested under their parent
   const topLevelApps = useMemo(
@@ -1118,9 +1119,10 @@ export function ProjectDetail({
                         <RotateCcw className="mr-2 size-4" />
                         Restart All
                       </DropdownMenuItem>
+                      <DropdownMenuSeparator />
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
-                        onClick={handleStopAll}
+                        onClick={() => setStopAllOpen(true)}
                       >
                         <Square className="mr-2 size-4" />
                         Stop All
@@ -1403,6 +1405,16 @@ export function ProjectDetail({
             ? `This will remove the project "${project.displayName}" but keep its ${topLevelApps.length} app(s). They will become unassigned.`
             : `Delete the project "${project.displayName}"?`
         }
+      />
+
+      {/* Stop All confirmation */}
+      <ConfirmDeleteDialog
+        open={stopAllOpen}
+        onOpenChange={setStopAllOpen}
+        onConfirm={handleStopAll}
+        title="Stop all apps"
+        description={`This will stop all ${topLevelApps.length} running app${topLevelApps.length === 1 ? "" : "s"} in "${project.displayName}". You can restart them at any time.`}
+        confirmLabel="Stop All"
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- "Stop All" on a project and "Stop" on an individual app both fired immediately on click with no way to cancel
- Both actions now route through `ConfirmDeleteDialog` before calling the API
- Added `DropdownMenuSeparator` above each Stop item to visually separate it from the safe operational actions (Redeploy, Restart)
- Stop All dialog shows a count of affected apps and uses "Stop All" as the confirm label
- Single-app Stop dialog explains the app will go offline and how to recover

## Test plan

- [ ] Open a project with running apps — click the Running dropdown → Stop All → confirm the dialog appears, cancel dismisses without action
- [ ] Confirm "Stop All" in the dialog stops all apps and shows the success toast
- [ ] Open an app detail page — click the Running dropdown → Stop → confirm dialog appears, cancel dismisses without action
- [ ] Confirm "Stop" in the app dialog stops the app and shows the success toast
- [ ] Verify visual separator between Restart / Restart All and Stop in both dropdowns

Closes #154