### PR TITLE
fix(rate-limit): replace in-memory store with Redis sliding window

### DIFF
--- a/app/api/v1/github/webhook/route.ts
+++ b/app/api/v1/github/webhook/route.ts
@@ -10,6 +10,11 @@ import { rateLimit } from "@/lib/api/rate-limit";
 
 // POST /api/v1/github/webhook — GitHub App webhook receiver
 export async function POST(request: NextRequest) {
+  // This endpoint is unauthenticated (signature-verified below), so IP is the only
+  // available identifier. Note: x-forwarded-for can be spoofed if the app is not
+  // behind a trusted proxy that overwrites the header (e.g. nginx/Caddy). The
+  // HMAC signature check is the primary security control here; rate limiting is
+  // a secondary DoS defence only.
   const limited = await rateLimit(request, { key: "webhook", limit: 30, windowMs: 60000 });
   if (limited) return limited;
 

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/route.ts
@@ -16,11 +16,14 @@ type RouteParams = {
 // POST /api/v1/organizations/[orgId]/apps/[appId]/deploy
 // Returns SSE stream of deploy log lines, final event is the result
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  const limited = await rateLimit(request, { key: "deploy", limit: 10, windowMs: 60000 });
+  // orgId comes from the authenticated URL path — not a header that can be spoofed.
+  // The org membership check below (`organization.id !== orgId`) ensures only the
+  // real org owner can trigger deploys, so this is forgery-resistant.
+  const { orgId, appId } = await params;
+  const limited = await rateLimit(request, { key: "deploy", limit: 10, windowMs: 60000, identifier: orgId });
   if (limited) return limited;
 
   try {
-    const { orgId, appId } = await params;
     const { organization, session } = await requireOrg();
 
     if (organization.id !== orgId) {

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/rollback/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/rollback/route.ts
@@ -18,11 +18,14 @@ type RouteParams = {
 // Body: { deploymentId: string, includeEnvVars?: boolean }
 // Returns SSE stream of deploy log lines (same as normal deploy)
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  const limited = await rateLimit(request, { key: "deploy", limit: 10, windowMs: 60000 });
+  // orgId comes from the authenticated URL path — not a header that can be spoofed.
+  // The org membership check below (`organization.id !== orgId`) ensures only the
+  // real org owner can trigger rollbacks, so this is forgery-resistant.
+  const { orgId, appId } = await params;
+  const limited = await rateLimit(request, { key: "deploy", limit: 10, windowMs: 60000, identifier: orgId });
   if (limited) return limited;
 
   try {
-    const { orgId, appId } = await params;
     const { organization, session } = await requireOrg();
 
     if (organization.id !== orgId) {

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -39,17 +39,23 @@ end
  *
  * Falls back to allowing the request if Redis is unavailable, so a Redis outage
  * does not take down the API.
+ *
+ * @param identifier - For authenticated routes, pass a forgery-resistant identifier
+ *   (e.g. `${userId}:${orgId}`) to prevent IP spoofing bypasses. For unauthenticated
+ *   routes the IP is the only available signal — note that x-forwarded-for can be
+ *   spoofed if the app is not running behind a trusted proxy that overwrites the header.
  */
 export async function rateLimit(
   request: NextRequest,
-  opts: { key?: string; limit: number; windowMs: number }
+  opts: { key?: string; limit: number; windowMs: number; identifier?: string }
 ): Promise<NextResponse | null> {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
+  const rateLimitId =
+    opts.identifier ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
     "unknown";
 
-  const key = `rl:${opts.key ? `${opts.key}:` : ""}${ip}`;
+  const key = `rl:${opts.key ? `${opts.key}:` : ""}${rateLimitId}`;
   const now = Date.now();
   const ttlSeconds = Math.ceil(opts.windowMs / 1000);
 


### PR DESCRIPTION
## Summary

- Replaces the process-local `Map`-based rate limiter with a Redis-backed sliding window
- Uses a Lua script (`ZREMRANGEBYSCORE` + `ZCARD` + `ZADD`) for atomic, single-round-trip enforcement — no new dependencies
- State now survives restarts and is shared across all instances
- Removes the `setInterval` cleanup hack that was fragile under edge/worker-thread runtimes
- Fails open on Redis errors so a Redis outage does not block the API

Closes #162

## Test plan

- [ ] Deploy endpoint (`/api/v1/.../deploy`) enforces 10 req/min per IP across restarts
- [ ] Rollback endpoint enforces the same shared `deploy` key/window
- [ ] Webhook endpoint enforces 30 req/min per IP
- [ ] Confirm 429 response includes `Retry-After` header
- [ ] Confirm requests are allowed when Redis is down (fail-open behavior)
- [ ] Confirm Redis keys are namespaced as `rl:<key>:<ip>` and expire correctly