### PR TITLE
refactor(security): migrate exec string interpolation to execFile in backup and rollback

### DIFF
--- a/lib/backup/engine.ts
+++ b/lib/backup/engine.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { mkdir, rm } from "fs/promises";
 import { resolve, join } from "path";
@@ -14,7 +14,7 @@ import type { BackupStorage } from "./storage-port";
 import { createBackupStorage } from "./storage-factory";
 import { assertSafeName } from "@/lib/docker/validate";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const BACKUPS_DIR = resolve(process.env.HOST_BACKUPS_DIR || "./.host/backups");
 
@@ -64,13 +64,14 @@ async function backupVolume(
   const archiveFile = "volume.tar.gz";
 
   try {
-    // Validate volume name before interpolating into shell command
+    // Validate volume name before use
     assertSafeName(dockerVolumeName);
 
     // Tar the volume contents using a temporary Alpine container
     logFn(`Archiving volume ${dockerVolumeName}`);
-    await execAsync(
-      `docker run --rm -v ${dockerVolumeName}:/data -v ${tmpDir}:/backup alpine tar czf /backup/${archiveFile} -C /data .`,
+    await execFileAsync(
+      "docker",
+      ["run", "--rm", "-v", `${dockerVolumeName}:/data`, "-v", `${tmpDir}:/backup`, "alpine", "tar", "czf", `/backup/${archiveFile}`, "-C", "/data", "."],
       { timeout: 600_000 }, // 10 minute timeout
     );
 
@@ -166,13 +167,13 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
       let dockerVolumeName: string;
       try {
         // Check if blue volume exists
-        await execAsync(`docker volume inspect ${blueVolume}`, {
+        await execFileAsync("docker", ["volume", "inspect", blueVolume], {
           timeout: 10_000,
         });
         dockerVolumeName = blueVolume;
       } catch {
         try {
-          await execAsync(`docker volume inspect ${greenVolume}`, {
+          await execFileAsync("docker", ["volume", "inspect", greenVolume], {
             timeout: 10_000,
           });
           dockerVolumeName = greenVolume;
@@ -348,20 +349,20 @@ export async function restoreBackup(
 
     let dockerVolumeName: string;
     try {
-      await execAsync(`docker volume inspect ${blueVolume}`, {
+      await execFileAsync("docker", ["volume", "inspect", blueVolume], {
         timeout: 10_000,
       });
       dockerVolumeName = blueVolume;
     } catch {
       try {
-        await execAsync(`docker volume inspect ${greenVolume}`, {
+        await execFileAsync("docker", ["volume", "inspect", greenVolume], {
           timeout: 10_000,
         });
         dockerVolumeName = greenVolume;
       } catch {
         // Create the blue volume if neither exists
         log(`Creating volume ${blueVolume}`);
-        await execAsync(`docker volume create ${blueVolume}`, {
+        await execFileAsync("docker", ["volume", "create", blueVolume], {
           timeout: 10_000,
         });
         dockerVolumeName = blueVolume;
@@ -370,8 +371,9 @@ export async function restoreBackup(
 
     // 3. Restore: clear and repopulate the volume
     log(`Restoring to volume ${dockerVolumeName}`);
-    await execAsync(
-      `docker run --rm -v ${dockerVolumeName}:/data -v ${tmpDir}:/backup alpine sh -c "rm -rf /data/* /data/.[!.]* 2>/dev/null; tar xzf /backup/volume.tar.gz -C /data"`,
+    await execFileAsync(
+      "docker",
+      ["run", "--rm", "-v", `${dockerVolumeName}:/data`, "-v", `${tmpDir}:/backup`, "alpine", "sh", "-c", "rm -rf /data/* /data/.[!.]* 2>/dev/null; tar xzf /backup/volume.tar.gz -C /data"],
       { timeout: 600_000 },
     );
     log("Restore complete");

--- a/lib/docker/rollback-monitor.ts
+++ b/lib/docker/rollback-monitor.ts
@@ -1,15 +1,14 @@
 import { db } from "@/lib/db";
 import { deployments, apps } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { join, resolve } from "path";
-import { readFile } from "fs/promises";
 import { listContainers, inspectContainer } from "./client";
 import { publishEvent, appChannel } from "@/lib/events";
 import { recordActivity } from "@/lib/activity";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const PROJECTS_DIR = resolve(process.env.HOST_PROJECTS_DIR || "./.host/projects");
 const POLL_INTERVAL_MS = 5000;
 
@@ -179,8 +178,9 @@ async function performRollback(opts: PerformRollbackOpts): Promise<void> {
   const crashedComposePath = join(crashedSlotDir, "docker-compose.yml");
 
   try {
-    await execAsync(
-      `docker compose -f "${crashedComposePath}" -p "${crashedProjectName}" down --remove-orphans`,
+    await execFileAsync(
+      "docker",
+      ["compose", "-f", crashedComposePath, "-p", crashedProjectName, "down", "--remove-orphans"],
       { cwd: crashedSlotDir, timeout: 30000 }
     );
   } catch (err) {
@@ -196,8 +196,9 @@ async function performRollback(opts: PerformRollbackOpts): Promise<void> {
   const prevComposePath = join(prevSlotDir, "docker-compose.yml");
 
   try {
-    await execAsync(
-      `docker compose -f "${prevComposePath}" -p "${prevProjectName}" up -d`,
+    await execFileAsync(
+      "docker",
+      ["compose", "-f", prevComposePath, "-p", prevProjectName, "up", "-d"],
       { cwd: prevSlotDir, timeout: 60000 }
     );
   } catch (err) {


### PR DESCRIPTION
## Summary
- Migrates `exec()` with string-interpolated shell commands to `execFile()` with discrete argument arrays in `lib/backup/engine.ts` (fixes #183) and `lib/docker/rollback-monitor.ts` (fixes #184)
- Follows the pattern established in PR #180 — `execFile` prevents shell injection by bypassing the shell entirely
- Both files were already guarded by `assertSafeName`, but this makes the approach consistent across all Docker-invoking code
- Removes an unused `readFile` import from `rollback-monitor.ts`

## Test plan
- [ ] Verify backup job runs and produces a valid archive (docker volume inspect, docker run tar, docker volume create all converted)
- [ ] Verify restore job downloads and repopulates a volume correctly
- [ ] Verify rollback monitor tears down the crashing slot and brings up the previous slot (docker compose down/up converted)
- [ ] `pnpm typecheck` passes (pre-existing test errors in `state.test.ts` are unrelated to this change)