### PR TITLE
refactor(profile): URL-driven tab routing for profile page

### DIFF
--- a/app/(app)/profile/[tab]/page.tsx
+++ b/app/(app)/profile/[tab]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound, redirect } from "next/navigation";
+import { getCurrentOrg } from "@/lib/auth/session";
+import { ProfileTabContent } from "./profile-tab-content";
+
+const VALID_TABS = ["account", "security", "tokens", "connections", "appearance"] as const;
+type ValidTab = (typeof VALID_TABS)[number];
+
+export default async function ProfileTabPage({
+  params,
+}: {
+  params: Promise<{ tab: string }>;
+}) {
+  const { tab } = await params;
+
+  if (!VALID_TABS.includes(tab as ValidTab)) {
+    notFound();
+  }
+
+  const orgData = await getCurrentOrg();
+  if (!orgData) redirect("/login");
+
+  const orgId = orgData.organization.id;
+
+  return <ProfileTabContent tab={tab as ValidTab} orgId={orgId} />;
+}

--- a/app/(app)/profile/[tab]/profile-tab-content.tsx
+++ b/app/(app)/profile/[tab]/profile-tab-content.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  AccountInfo,
+  PasswordManagement,
+  TwoFactorAuth,
+  ActiveSessions,
+  ApiTokens,
+} from "../account-settings";
+import { ThemeSwitcher } from "../theme-switcher";
+import { GitHubConnection } from "../github-connection";
+
+type ProfileTabContentProps = {
+  tab: "account" | "security" | "tokens" | "connections" | "appearance";
+  orgId: string;
+};
+
+export function ProfileTabContent({ tab, orgId }: ProfileTabContentProps) {
+  switch (tab) {
+    case "account":
+      return (
+        <div className="space-y-8">
+          <AccountInfo />
+          <PasswordManagement />
+        </div>
+      );
+    case "security":
+      return (
+        <div className="space-y-8">
+          <TwoFactorAuth />
+          <ActiveSessions />
+        </div>
+      );
+    case "tokens":
+      return <ApiTokens orgId={orgId} />;
+    case "connections":
+      return <GitHubConnection />;
+    case "appearance":
+      return <ThemeSwitcher />;
+  }
+}

--- a/app/(app)/profile/account-settings.tsx
+++ b/app/(app)/profile/account-settings.tsx
@@ -27,7 +27,7 @@ import { authClient, useSession } from "@/lib/auth/client";
 // Account Info
 // ---------------------------------------------------------------------------
 
-function AccountInfo() {
+export function AccountInfo() {
   const { data: sessionData, isPending } = useSession();
   const [editingName, setEditingName] = useState(false);
   const [name, setName] = useState("");
@@ -113,7 +113,7 @@ function AccountInfo() {
 // Password Management
 // ---------------------------------------------------------------------------
 
-function PasswordManagement() {
+export function PasswordManagement() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -238,7 +238,7 @@ function PasswordManagement() {
 // Two-Factor Authentication
 // ---------------------------------------------------------------------------
 
-function TwoFactorAuth() {
+export function TwoFactorAuth() {
   const { data: sessionData } = useSession();
   const [enabling, setEnabling] = useState(false);
   const [totpUri, setTotpUri] = useState<string | null>(null);
@@ -475,7 +475,7 @@ type SessionInfo = {
   expiresAt: Date;
 };
 
-function ActiveSessions() {
+export function ActiveSessions() {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [revoking, setRevoking] = useState<string | null>(null);
@@ -608,7 +608,7 @@ type ApiToken = {
   createdAt: string;
 };
 
-function ApiTokens({ orgId }: { orgId: string }) {
+export function ApiTokens({ orgId }: { orgId: string }) {
   const [tokens, setTokens] = useState<ApiToken[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);

--- a/app/(app)/profile/layout.tsx
+++ b/app/(app)/profile/layout.tsx
@@ -1,0 +1,38 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { SettingsNav } from "@/components/settings-nav";
+
+const PROFILE_TABS = [
+  { label: "Account", href: "/profile/account" },
+  { label: "Security", href: "/profile/security" },
+  { label: "Tokens", href: "/profile/tokens" },
+  { label: "Connections", href: "/profile/connections" },
+  { label: "Appearance", href: "/profile/appearance" },
+];
+
+export default async function ProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage your account and connected services.
+        </p>
+      </div>
+
+      <SettingsNav items={PROFILE_TABS} basePath="/profile" />
+
+      {children}
+    </div>
+  );
+}

--- a/app/(app)/profile/loading.tsx
+++ b/app/(app)/profile/loading.tsx
@@ -1,31 +1,18 @@
 export default function ProfileLoading() {
   return (
     <div className="space-y-8">
-      {/* Page title */}
-      <div className="h-8 w-20 bg-muted animate-pulse rounded-lg" />
+      {/* Section heading */}
+      <div className="h-5 w-36 bg-muted animate-pulse rounded-md" />
 
-      {/* Account settings card */}
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="h-5 w-36 bg-muted animate-pulse rounded-md" />
-        <div className="space-y-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="space-y-1.5">
-              <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
-              <div className="h-10 w-full bg-muted animate-pulse rounded-lg" />
-            </div>
-          ))}
-          <div className="h-9 w-24 bg-muted animate-pulse rounded-lg pt-2" />
-        </div>
-      </div>
-
-      {/* Theme switcher card */}
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="h-5 w-24 bg-muted animate-pulse rounded-md" />
-        <div className="flex items-center gap-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-9 w-24 bg-muted animate-pulse rounded-lg" />
-          ))}
-        </div>
+      {/* Fields */}
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
+            <div className="h-10 w-full bg-muted animate-pulse rounded-lg" />
+          </div>
+        ))}
+        <div className="h-9 w-24 bg-muted animate-pulse rounded-lg pt-2" />
       </div>
     </div>
   );

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,32 +1,5 @@
 import { redirect } from "next/navigation";
-import { getSession, getCurrentOrg } from "@/lib/auth/session";
-import { AccountSettings } from "./account-settings";
-import { ThemeSwitcher } from "./theme-switcher";
-import { GitHubConnection } from "./github-connection";
 
-export default async function ProfilePage() {
-  const session = await getSession();
-
-  if (!session?.user) {
-    redirect("/login");
-  }
-
-  const orgData = await getCurrentOrg();
-  const orgId = orgData?.organization.id;
-
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your account and connected services.
-        </p>
-      </div>
-
-      {orgId && <AccountSettings orgId={orgId} />}
-
-      <ThemeSwitcher />
-      <GitHubConnection />
-    </div>
-  );
+export default function ProfilePage() {
+  redirect("/profile/account");
 }

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -237,7 +237,7 @@ export function CommandPalette({ orgId }: CommandPaletteProps) {
               </CommandItem>
               <CommandItem
                 value="Profile Account"
-                onSelect={() => runCommand(() => router.push("/profile"))}
+                onSelect={() => runCommand(() => router.push("/profile/account"))}
                 className="gap-2"
               >
                 <UserCircle className="size-4" />

--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -102,7 +102,7 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
-          onClick={() => router.push("/profile")}
+          onClick={() => router.push("/profile/account")}
         >
           <User className="size-4" />
           Profile

--- a/components/settings-nav.tsx
+++ b/components/settings-nav.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+type NavItem = {
+  label: string;
+  href: string;
+};
+
+type SettingsNavProps = {
+  items: NavItem[];
+  basePath: string;
+};
+
+export function SettingsNav({ items, basePath }: SettingsNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="inline-flex w-fit items-center justify-center gap-1 rounded-none p-[3px] text-muted-foreground"
+      role="tablist"
+    >
+      {items.map((item) => {
+        const isActive =
+          pathname === item.href ||
+          (item.href === `${basePath}/account` && pathname === basePath);
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            role="tab"
+            aria-selected={isActive}
+            className={cn(
+              "relative inline-flex h-[calc(100%-1px)] items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all",
+              "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring focus-visible:ring-[3px] focus-visible:outline-1",
+              isActive
+                ? "text-foreground"
+                : "text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground",
+              "after:bg-foreground after:absolute after:inset-x-0 after:bottom-[-5px] after:h-0.5 after:opacity-0 after:transition-opacity",
+              isActive && "after:opacity-100"
+            )}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Restructures `/profile` from a single scrolling page into `/profile/[tab]` with five URL-driven tabs: account, security, tokens, connections, and appearance
- Adds a reusable `SettingsNav` component that mirrors the `TabsList variant="line"` visual style using Next.js `Link` components and `usePathname()` for active state
- Follows the same routing pattern established by `/projects/[...slug]` and `/apps/[...slug]` with `VALID_TABS` validation and `notFound()` for invalid tabs

## Test plan
- [ ] Navigate to `/profile` and verify it redirects to `/profile/account`
- [ ] Verify each tab renders the correct content: account (name/email + password), security (2FA + sessions), tokens (API tokens), connections (GitHub), appearance (theme)
- [ ] Verify invalid tab slugs like `/profile/foo` return 404
- [ ] Verify the active tab underline indicator follows the current URL
- [ ] Check user menu dropdown "Profile" link navigates to `/profile/account`
- [ ] Check command palette "Profile" entry navigates to `/profile/account`
- [ ] Verify unauthenticated users are redirected to `/login`