### PR TITLE
Fix org metrics showing system-wide stats instead of org-scoped data

### DIFF
--- a/app/(app)/metrics/org-metrics.tsx
+++ b/app/(app)/metrics/org-metrics.tsx
@@ -12,7 +12,6 @@ import { CHART_COLORS, chartTickStyle, type TimeRange } from "@/lib/metrics/cons
 import { useMetricsStream } from "@/lib/hooks/use-metrics-stream";
 import { Sparkline } from "@/components/app-metrics-card";
 import { MetricsTooltip } from "@/components/metrics-chart";
-import type { SystemInfo, DiskUsage } from "@/lib/docker/client";
 
 type AppSummary = {
   id: string;
@@ -95,10 +94,9 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
     timeRange,
   });
 
-  const disk = meta?.disk as DiskUsage | null | undefined;
-  const system = meta?.system as SystemInfo | null | undefined;
   const metaApps = meta?.apps as AppMeta[] | undefined;
   const streamProjectCount = meta?.projectCount as number | undefined;
+  const orgDiskTotal = meta?.orgDiskTotal as number | undefined;
 
   // Derive display apps from SSE meta when available, fall back to props
   const displayApps = useMemo(() => {
@@ -222,17 +220,6 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
         </div>
       </div>
 
-      {/* System info */}
-      {system && (
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-1 text-xs text-muted-foreground">
-          <span>{system.cpus} CPUs</span>
-          <span>{formatBytes(system.memoryTotal)} RAM</span>
-          <span>{system.os}</span>
-          <span>Docker {system.dockerVersion}</span>
-          <span>{system.images} images</span>
-        </div>
-      )}
-
       {/* Summary cards with sparklines */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
         <div className="squircle relative rounded-lg border bg-card px-4 py-3 overflow-hidden">
@@ -268,11 +255,11 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             <p className="text-xs text-muted-foreground">Disk</p>
           </div>
           <p className="relative text-2xl font-semibold tabular-nums mt-1">
-            {disk ? formatBytes(disk.total) : <Loader2 className="size-5 animate-spin text-muted-foreground" />}
+            {loading ? <Loader2 className="size-5 animate-spin text-muted-foreground" /> : formatBytes(orgDiskTotal ?? 0)}
           </p>
-          {disk && (
+          {!loading && displayApps.length > 0 && (
             <p className="relative text-[10px] text-muted-foreground mt-0.5">
-              {formatBytes(disk.images.totalSize)} images · {formatBytes(disk.volumes.totalSize)} volumes
+              across {displayApps.length} app{displayApps.length !== 1 ? "s" : ""}
             </p>
           )}
         </div>

--- a/app/api/v1/organizations/[orgId]/stats/route.ts
+++ b/app/api/v1/organizations/[orgId]/stats/route.ts
@@ -5,7 +5,7 @@ import { apps } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq } from "drizzle-orm";
 import { fetchAllContainerMetrics } from "@/lib/metrics/cadvisor";
-import { queryMetrics, queryDiskHistory, queryMetricsPoints } from "@/lib/metrics/store";
+import { queryMetrics, queryMetricsPoints } from "@/lib/metrics/store";
 import type { MetricsPoint } from "@/lib/metrics/types";
 import { isFeatureEnabled } from "@/lib/config/features";
 
@@ -78,8 +78,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       const perAppPoints = await Promise.all(
         activeAppNames.map((name) => queryMetricsPoints(name, fromMs, toMs, bucketMs))
       );
-      const diskHistory = await queryDiskHistory(fromMs, toMs, bucketMs);
-
       // Merge all apps' points by timestamp
       const pointMap = new Map<number, MetricsPoint>();
       for (const appPoints of perAppPoints) {
@@ -91,16 +89,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
             existing.memoryLimit = Math.max(existing.memoryLimit, p.memoryLimit);
             existing.networkRx += p.networkRx;
             existing.networkTx += p.networkTx;
+            existing.diskTotal += p.diskTotal;
           } else {
             pointMap.set(p.timestamp, { ...p });
           }
         }
-      }
-      // Add disk data
-      const diskMap = new Map(diskHistory);
-      for (const [ts, val] of diskMap) {
-        const existing = pointMap.get(ts);
-        if (existing) existing.diskTotal = val;
       }
 
       const points = Array.from(pointMap.values()).sort((a, b) => a.timestamp - b.timestamp);

--- a/app/api/v1/organizations/[orgId]/stats/stream/route.ts
+++ b/app/api/v1/organizations/[orgId]/stats/stream/route.ts
@@ -4,9 +4,8 @@ import { db } from "@/lib/db";
 import { apps } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq } from "drizzle-orm";
-import { getSystemInfo, type DiskUsage, type SystemInfo } from "@/lib/docker/client";
 import { isCollectorRunning, startCollector } from "@/lib/metrics/collector";
-import { getLatestProjectDiskUsage, getLatestDiskUsage } from "@/lib/metrics/store";
+import { getLatestProjectDiskUsage } from "@/lib/metrics/store";
 import { createSSEResponse } from "@/lib/api/sse";
 import { isMetricsEnabled } from "@/lib/metrics/config";
 import { isFeatureEnabled } from "@/lib/config/features";
@@ -51,9 +50,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return createSSEResponse(request, async (sendEvent) => {
       let tickCount = 0;
 
-      // Slow data cache
-      let cachedDisk: DiskUsage | null = null;
-      let cachedSystem: SystemInfo | null = null;
+      // Slow data cache — org-scoped (per-app disk only, no system-wide stats)
       let cachedAppDisk: Record<string, number> = {};
 
       async function refreshAppDisk() {
@@ -72,25 +69,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         } catch { /* skip */ }
       }
 
-      async function refreshSlowData() {
-        try {
-          const d = await getLatestDiskUsage();
-          if (d) {
-            cachedDisk = {
-              images: { count: 0, totalSize: d.images, reclaimable: 0 },
-              containers: { count: 0, totalSize: 0 },
-              volumes: { count: 0, totalSize: d.volumes },
-              buildCache: { count: 0, totalSize: d.buildCache, reclaimable: 0 },
-              total: d.total,
-            };
-          }
-        } catch { /* skip */ }
-        try { cachedSystem = await getSystemInfo(); } catch { /* skip */ }
-        await refreshAppDisk();
-      }
-
-      // Start slow data fetch in background
-      refreshSlowData();
+      // Start app disk fetch in background
+      refreshAppDisk();
 
       const unsubscribe = subscribe((allMetrics) => {
         const byApp: Record<string, typeof allMetrics> = {};
@@ -104,24 +84,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         }
 
         const allOrgContainers = Object.values(byApp).flat();
-        const diskTotal = cachedDisk?.total ?? 0;
-        const point = aggregateContainers(allOrgContainers, diskTotal);
+        const orgDiskTotal = Object.values(cachedAppDisk).reduce((s, v) => s + v, 0);
+        const point = aggregateContainers(allOrgContainers, orgDiskTotal);
 
         sendEvent("point", {
           ...point,
           projectCount,
+          orgDiskTotal,
           apps: orgApps.map((p) => ({
             ...p,
             diskUsage: cachedAppDisk[p.id] || 0,
             containers: (byApp[p.id] || []).map(containerToPoint),
           })),
-          disk: cachedDisk,
-          system: cachedSystem,
         });
 
         tickCount++;
         if (tickCount % 60 === 0) {
-          refreshSlowData();
+          refreshAppDisk();
         }
       });
 

--- a/lib/hooks/use-metrics-stream.ts
+++ b/lib/hooks/use-metrics-stream.ts
@@ -14,6 +14,7 @@ type MetricsMeta = {
   system: unknown;
   apps: unknown[];
   projectCount?: number;
+  orgDiskTotal?: number;
   [key: string]: unknown;
 };
 
@@ -136,12 +137,13 @@ export function useMetricsStream(
         }
 
         // Auxiliary metadata — merge incrementally
-        if (data.disk || data.system || data.apps || data.projectCount !== undefined) {
+        if (data.disk || data.system || data.apps || data.projectCount !== undefined || data.orgDiskTotal !== undefined) {
           setMeta((prev) => ({
             disk: data.disk ?? prev?.disk ?? null,
             system: data.system ?? prev?.system ?? null,
             apps: data.apps ?? prev?.apps ?? [],
             projectCount: data.projectCount ?? prev?.projectCount,
+            orgDiskTotal: data.orgDiskTotal ?? prev?.orgDiskTotal,
           }));
         }
 


### PR DESCRIPTION
## Summary

- Removed system-wide disk usage and system info (CPUs, RAM, Docker version, image count) from the org metrics page — these are host-level stats that don't belong at the org scope
- Replaced with `orgDiskTotal`, the sum of per-app disk usage for the org's apps
- Removed `queryDiskHistory` (system-wide) from the org stats history endpoint; aggregate per-app `diskTotal` instead
- Admin stats endpoints unchanged — system-wide data stays on the admin panel where it belongs

## Test plan

- [ ] Load `/metrics` with zero apps — should show empty state, disk card shows 0 B
- [ ] Load `/metrics` with apps deployed — disk card shows sum of per-app disk, no host stats
- [ ] System info row (CPUs, RAM, Docker version) no longer appears on org metrics
- [ ] Admin `/admin/metrics` still shows system-wide disk, system info as before
- [ ] Historical chart data aggregates per-app disk instead of system-wide disk
- [ ] SSE stream reconnects cleanly and shows `orgDiskTotal` on each tick

Closes #207