### PR TITLE
refactor(ui): restructure user dropdown menu

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -3,7 +3,11 @@ import { redirect } from "next/navigation";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { TopNav } from "@/components/layout/top-nav";
 import { CommandPalette } from "@/components/command-palette";
-import { getCurrentOrg, getUserOrganizations } from "@/lib/auth/session";
+import { AdminProvider } from "@/lib/hooks/use-admin";
+import { getSession, getCurrentOrg, getUserOrganizations } from "@/lib/auth/session";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
 import { isFeatureEnabled } from "@/lib/config/features";
 
 export const metadata: Metadata = {
@@ -31,7 +35,7 @@ export default async function AppLayout({
     );
   }
 
-  const orgData = await getCurrentOrg();
+  const [session, orgData] = await Promise.all([getSession(), getCurrentOrg()]);
 
   if (!orgData) {
     redirect("/create-org");
@@ -40,24 +44,33 @@ export default async function AppLayout({
   const { organization } = orgData;
   const organizations = await getUserOrganizations();
 
+  let isAdmin = false;
+  if (session?.user?.id) {
+    const dbUser = await db.query.user.findFirst({
+      where: eq(user.id, session.user.id),
+      columns: { isAppAdmin: true },
+    });
+    isAdmin = !!dbUser?.isAppAdmin;
+  }
+
   return (
-    <TooltipProvider>
-      <div className="flex flex-col h-dvh bg-sidebar">
-        {/* Top Navigation */}
-        <TopNav
-          currentOrgId={organization.id}
-          organizations={organizations}
-        />
+    <AdminProvider isAdmin={isAdmin}>
+      <TooltipProvider>
+        <div className="flex flex-col h-dvh bg-sidebar">
+          <TopNav
+            currentOrgId={organization.id}
+            organizations={organizations}
+          />
 
-        {/* Main Content */}
-        <div className="flex-1 overflow-y-auto bg-background rounded-t-2xl min-h-0">
-          <main className="mx-auto max-w-screen-xl px-5 py-8 lg:px-10 min-h-full">
-            {children}
-          </main>
+          <div className="flex-1 overflow-y-auto bg-background rounded-t-2xl min-h-0">
+            <main className="mx-auto max-w-screen-xl px-5 py-8 lg:px-10 min-h-full">
+              {children}
+            </main>
+          </div>
         </div>
-      </div>
 
-      <CommandPalette orgId={organization.id} />
-    </TooltipProvider>
+        <CommandPalette orgId={organization.id} />
+      </TooltipProvider>
+    </AdminProvider>
   );
 }

--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
-import { LogOut, User, Users, ChevronsUpDown, Loader2, Settings, Shield, Building2, Check, Plus, Sun, Moon, Monitor } from "lucide-react";
+import { LogOut, User, ChevronsUpDown, Loader2, Settings, Shield, Building2, Check, Plus, Sun, Moon, Monitor } from "lucide-react";
+import { useAdmin } from "@/lib/hooks/use-admin";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -25,6 +26,7 @@ type UserMenuProps = {
 };
 
 export function UserMenu({ collapsed, compact, currentOrgId, organizations }: UserMenuProps) {
+  const isAdmin = useAdmin();
   const router = useRouter();
   const { theme, setTheme } = useTheme();
   const { data: session, isPending } = useSession();
@@ -93,6 +95,7 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
         align="end"
         className="min-w-56"
       >
+        {/* Profile info */}
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
             <p className="text-sm font-medium">{displayName}</p>
@@ -100,6 +103,8 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+
+        {/* Settings links */}
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
           onClick={() => router.push("/user/settings/profile")}
@@ -109,11 +114,20 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
         </DropdownMenuItem>
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
-          onClick={() => router.push("/admin")}
+          onClick={() => router.push("/settings")}
         >
-          <Shield className="size-4" />
-          Admin
+          <Settings className="size-4" />
+          Org settings
         </DropdownMenuItem>
+        {isAdmin && (
+          <DropdownMenuItem
+            className="gap-2 cursor-pointer"
+            onClick={() => router.push("/admin/settings")}
+          >
+            <Shield className="size-4" />
+            Admin settings
+          </DropdownMenuItem>
+        )}
 
         {/* Org switcher */}
         <DropdownMenuSeparator />
@@ -135,26 +149,13 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
         ))}
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
-          onClick={() => router.push("/settings")}
-        >
-          <Settings className="size-4" />
-          Settings
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="gap-2 cursor-pointer"
-          onClick={() => router.push("/settings/team")}
-        >
-          <Users className="size-4" />
-          Team
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="gap-2 cursor-pointer"
           onClick={() => router.push("/onboarding")}
         >
           <Plus className="size-4" />
           New organization
         </DropdownMenuItem>
 
+        {/* Theme switcher */}
         <DropdownMenuSeparator />
         <div className="px-2 py-1.5">
           <div className="inline-flex items-center gap-0.5 rounded-md bg-muted p-0.5 w-full">
@@ -181,6 +182,8 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
             ))}
           </div>
         </div>
+
+        {/* Sign out */}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="gap-2 cursor-pointer"

--- a/lib/hooks/use-admin.tsx
+++ b/lib/hooks/use-admin.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const AdminContext = createContext(false);
+
+export function AdminProvider({ isAdmin, children }: { isAdmin: boolean; children: React.ReactNode }) {
+  return <AdminContext.Provider value={isAdmin}>{children}</AdminContext.Provider>;
+}
+
+export function useAdmin() {
+  return useContext(AdminContext);
+}


### PR DESCRIPTION
## Summary

- Reorder dropdown: profile info → account settings → org settings → admin settings → org switcher → theme → sign out
- Admin settings only visible to app admins (via `useAdmin` hook + `AdminProvider` context)
- Remove separate Team link (now a tab under /settings/team)
- Admin settings points to `/admin/settings` instead of `/admin`

## Test plan

- [ ] Non-admin user: dropdown shows Account settings, Org settings — no Admin settings
- [ ] Admin user: dropdown shows all three settings links
- [ ] Account settings navigates to `/user/settings/profile`
- [ ] Org settings navigates to `/settings`
- [ ] Admin settings navigates to `/admin/settings`
- [ ] Org switcher still works
- [ ] Theme switcher still works
- [ ] Sign out still works