### PR TITLE
fix(ui): move org settings under organizations section in user menu

### DIFF
--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -104,20 +104,12 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
 
-        {/* Settings links */}
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
           onClick={() => router.push("/user/settings/profile")}
         >
           <User className="size-4" />
           Account settings
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="gap-2 cursor-pointer"
-          onClick={() => router.push("/settings")}
-        >
-          <Settings className="size-4" />
-          Org settings
         </DropdownMenuItem>
         {isAdmin && (
           <DropdownMenuItem
@@ -129,7 +121,7 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
           </DropdownMenuItem>
         )}
 
-        {/* Org switcher */}
+        {/* Organizations */}
         <DropdownMenuSeparator />
         <DropdownMenuLabel className="text-xs text-muted-foreground">
           Organizations
@@ -147,6 +139,13 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
             )}
           </DropdownMenuItem>
         ))}
+        <DropdownMenuItem
+          className="gap-2 cursor-pointer"
+          onClick={() => router.push("/settings")}
+        >
+          <Settings className="size-4" />
+          Settings
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="gap-2 cursor-pointer"
           onClick={() => router.push("/onboarding")}


### PR DESCRIPTION
## Summary

- Moved org settings link from top-level settings group into the organizations section
- Renamed "Org settings" to "Settings" since it's contextual to the selected org
- Order is now: account settings → admin settings → organizations (switcher, settings, new org) → theme → sign out

## Test plan

- [ ] Dropdown shows org settings under the org switcher, not at the top
- [ ] All links still navigate correctly