### PR TITLE
fix(ui): shorten Admin settings label

### DIFF
--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -154,7 +154,7 @@ export function UserMenu({ collapsed, compact, currentOrgId, organizations }: Us
               onClick={() => router.push("/admin/settings")}
             >
               <Shield className="size-4" />
-              Admin settings
+              Admin
             </DropdownMenuItem>
           </>
         )}


### PR DESCRIPTION
Rename 'Admin settings' to 'Admin' — the context is clear from the shield icon and section placement.