### PR TITLE
Fix instrumentation cold start blocking (#134)

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,7 +1,7 @@
 export async function register() {
   // Only run on the server, not during build
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    // Check encryption key
+    // Check encryption key — must run first, before any other initialization
     const { checkEncryptionKey } = await import("./lib/crypto/encrypt");
     const keyCheck = checkEncryptionKey();
     if (!keyCheck.ok) {
@@ -10,77 +10,81 @@ export async function register() {
       console.log("[instrumentation] Encryption key configured");
     }
 
-    console.log("[instrumentation] Starting metrics collector...");
-    try {
-      const { startCollector } = await import("./lib/metrics/collector");
-      startCollector();
-      console.log("[instrumentation] Metrics collector started");
-    } catch (err) {
-      console.error("[instrumentation] Failed to start collector:", err);
-    }
-
-    console.log("[instrumentation] Starting cron scheduler...");
-    try {
-      const { startCronScheduler } = await import("./lib/cron/scheduler");
-      startCronScheduler();
-      console.log("[instrumentation] Cron scheduler started");
-    } catch (err) {
-      console.error("[instrumentation] Failed to start cron scheduler:", err);
-    }
-
-    console.log("[instrumentation] Ensuring Host-level backup target...");
+    // Ensure backup target exists first (sequential dependency for scheduler)
+    let backupTargetReady: Promise<void> | undefined;
     try {
       const { ensureHostBackupTarget } = await import("./lib/backup/auto-backup");
-      const target = await ensureHostBackupTarget();
-      if (target) {
-        console.log(`[instrumentation] Host backup target ready: ${target.name} (${target.type})`);
-      } else {
-        console.log("[instrumentation] No backup storage configured (set BACKUP_STORAGE_* env vars or configure in settings)");
-      }
-    } catch (err) {
-      console.error("[instrumentation] Failed to ensure backup target:", err);
-    }
-
-    console.log("[instrumentation] Starting backup scheduler...");
-    try {
       const { startBackupScheduler } = await import("./lib/backup/scheduler");
-      startBackupScheduler();
-      console.log("[instrumentation] Backup scheduler started");
+      backupTargetReady = ensureHostBackupTarget()
+        .then((target) => {
+          if (target) {
+            console.log(`[instrumentation] Host backup target ready: ${target.name} (${target.type})`);
+          } else {
+            console.log("[instrumentation] No backup storage configured (set BACKUP_STORAGE_* env vars or configure in settings)");
+          }
+          startBackupScheduler();
+          console.log("[instrumentation] Backup scheduler started");
+        })
+        .catch((err) => {
+          console.error("[instrumentation] Backup setup failed:", err);
+        });
     } catch (err) {
-      console.error("[instrumentation] Failed to start backup scheduler:", err);
+      console.error("[instrumentation] Failed to import backup modules:", err);
     }
 
-    console.log("[instrumentation] Starting system health monitor...");
-    try {
-      const { startSystemAlertMonitor } = await import("./lib/system-alerts/monitor");
-      startSystemAlertMonitor();
-      console.log("[instrumentation] System health monitor started");
-    } catch (err) {
-      console.error("[instrumentation] Failed to start system health monitor:", err);
+    // Fire all independent startup tasks in parallel
+    const tasks: Promise<unknown>[] = [];
+
+    if (backupTargetReady) {
+      tasks.push(backupTargetReady);
     }
 
-    console.log("[instrumentation] Starting digest scheduler...");
-    try {
-      const { startDigestScheduler } = await import("./lib/digest/scheduler");
-      startDigestScheduler();
-      console.log("[instrumentation] Digest scheduler started");
-    } catch (err) {
-      console.error("[instrumentation] Failed to start digest scheduler:", err);
-    }
+    tasks.push(
+      import("./lib/metrics/collector")
+        .then(({ startCollector }) => {
+          startCollector();
+          console.log("[instrumentation] Metrics collector started");
+        })
+        .catch((err) => console.error("[instrumentation] Failed to start collector:", err)),
 
-    console.log("[instrumentation] Starting domain monitor...");
-    try {
-      setInterval(async () => {
-        try {
-          const { checkAllDomains } = await import("./lib/domains/monitor");
-          await checkAllDomains();
-        } catch (err) {
-          console.error("[domain-monitor] Error:", err);
-        }
-      }, 5 * 60 * 1000);
-      console.log("[instrumentation] Domain monitor started (every 5 minutes)");
-    } catch (err) {
-      console.error("[instrumentation] Failed to start domain monitor:", err);
+      import("./lib/cron/scheduler")
+        .then(({ startCronScheduler }) => {
+          startCronScheduler();
+          console.log("[instrumentation] Cron scheduler started");
+        })
+        .catch((err) => console.error("[instrumentation] Failed to start cron scheduler:", err)),
+
+      import("./lib/system-alerts/monitor")
+        .then(({ startSystemAlertMonitor }) => {
+          startSystemAlertMonitor();
+          console.log("[instrumentation] System health monitor started");
+        })
+        .catch((err) => console.error("[instrumentation] Failed to start system health monitor:", err)),
+
+      import("./lib/digest/scheduler")
+        .then(({ startDigestScheduler }) => {
+          startDigestScheduler();
+          console.log("[instrumentation] Digest scheduler started");
+        })
+        .catch((err) => console.error("[instrumentation] Failed to start digest scheduler:", err)),
+
+      Promise.resolve().then(() => {
+        setInterval(async () => {
+          try {
+            const { checkAllDomains } = await import("./lib/domains/monitor");
+            await checkAllDomains();
+          } catch (err) {
+            console.error("[domain-monitor] Error:", err);
+          }
+        }, 5 * 60 * 1000);
+        console.log("[instrumentation] Domain monitor started (every 5 minutes)");
+      }),
+    );
+
+    const results = await Promise.allSettled(tasks);
+    const failed = results.filter((r) => r.status === "rejected").length;
+    if (failed > 0) {
+      console.error(`[instrumentation] ${failed} startup task(s) failed`);
     }
   }
 }

--- a/lib/metrics/collector.ts
+++ b/lib/metrics/collector.ts
@@ -157,9 +157,6 @@ async function collect() {
   }
 }
 
-// Collect immediately on start
-collect();
-
 export function stopCollector() {
   if (timeout) {
     clearTimeout(timeout);

--- a/lib/system-alerts/monitor.ts
+++ b/lib/system-alerts/monitor.ts
@@ -322,11 +322,18 @@ export function startSystemAlertMonitor(): void {
   if (interval) return;
 
   // Load persisted alert state from DB before the first tick so rate-limit
-  // windows survive process restarts.
+  // windows survive process restarts. Defer the initial tick by 10s to let
+  // the process stabilize before firing network calls (git ls-remote, etc.).
   loadAlertState()
-    .then(() => tickSystemAlerts())
+    .then(() => {
+      setTimeout(() => {
+        tickSystemAlerts().catch((err) => {
+          console.error("[system-alerts] Initial tick error:", err);
+        });
+      }, 10_000);
+    })
     .catch((err) => {
-      console.error("[system-alerts] Initial tick error:", err);
+      console.error("[system-alerts] Failed to load alert state:", err);
     });
 
   console.log("[system-alerts] Monitor started (60s interval)");


### PR DESCRIPTION
## Summary

- Parallelized 6 independent startup tasks in `instrumentation.ts` using `Promise.allSettled` instead of sequential awaits — the encryption key check stays synchronous and first
- Removed the bare `collect()` call at module scope in `collector.ts` that fired before the process was ready
- Deferred the initial `tickSystemAlerts()` call by 10 seconds so `git ls-remote` and other network calls don't block cold start

The backup target setup and backup scheduler remain sequential since the scheduler depends on the target being ready. Everything else runs in parallel.

## Test plan

- [ ] Deploy to staging and verify all services initialize (metrics, cron, backups, system alerts, digest, domain monitor)
- [ ] Check logs for correct startup ordering — encryption key check should appear first, then parallel tasks in any order
- [ ] Confirm no bare `collect()` runs at import time — metrics should only start when `startCollector()` is called
- [ ] Verify system alerts initial tick fires ~10s after startup, not immediately
- [ ] Confirm `git ls-remote` network call doesn't block other initialization tasks