### PR TITLE
Add short-TTL cache to system settings reads

### DIFF
--- a/app/api/setup/auth/route.ts
+++ b/app/api/setup/auth/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getAuthConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getAuthConfig, setSystemSetting } from "@/lib/system-settings";
 
 const authSchema = z.object({
   registrationMode: z.enum(["closed", "open", "approval"]),
@@ -39,17 +36,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const config = encryptSystem(JSON.stringify(parsed.data));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "auth_config", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
+  await setSystemSetting("auth_config", JSON.stringify(parsed.data));
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/backup/route.ts
+++ b/app/api/setup/backup/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getBackupStorageConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getBackupStorageConfig, setSystemSetting } from "@/lib/system-settings";
 import { maskSecret, isMasked } from "@/lib/mask-secrets";
 
 const backupSchema = z.object({
@@ -60,7 +57,7 @@ export async function POST(request: NextRequest) {
     return incoming ?? undefined;
   }
 
-  const config = encryptSystem(JSON.stringify({
+  await setSystemSetting("backup_storage", JSON.stringify({
     type,
     bucket,
     region,
@@ -68,16 +65,6 @@ export async function POST(request: NextRequest) {
     accessKey: resolveSecret(accessKey, existing?.accessKey),
     secretKey: resolveSecret(secretKey, existing?.secretKey),
   }));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "backup_storage", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/email/route.ts
+++ b/app/api/setup/email/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getEmailProviderConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getEmailProviderConfig, setSystemSetting } from "@/lib/system-settings";
 import { maskSecret, isMasked } from "@/lib/mask-secrets";
 
 const emailSchema = z.object({
@@ -66,7 +63,7 @@ export async function POST(request: NextRequest) {
     return incoming ?? undefined;
   }
 
-  const config = encryptSystem(JSON.stringify({
+  await setSystemSetting("email_provider", JSON.stringify({
     provider,
     smtpHost,
     smtpPort,
@@ -76,16 +73,6 @@ export async function POST(request: NextRequest) {
     fromEmail,
     fromName,
   }));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "email_provider", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/feature-flags/route.ts
+++ b/app/api/setup/feature-flags/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getFeatureFlagsConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getFeatureFlagsConfig, setSystemSetting } from "@/lib/system-settings";
 import {
   type FeatureFlag,
   isFeatureEnabled,
@@ -75,17 +72,7 @@ export async function POST(request: NextRequest) {
   const existing = (await getFeatureFlagsConfig()) ?? {};
   const merged = { ...existing, ...parsed.data };
 
-  const config = encryptSystem(JSON.stringify(merged));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "feature_flags", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
+  await setSystemSetting("feature_flags", JSON.stringify(merged));
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/general/route.ts
+++ b/app/api/setup/general/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getInstanceConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getInstanceConfig, setSystemSetting } from "@/lib/system-settings";
 
 const generalSchema = z.object({
   instanceName: z.string().min(1).max(100),
@@ -44,21 +41,11 @@ export async function POST(request: NextRequest) {
   // Only instanceName is editable; preserve baseDomain and serverIp from existing config
   const existing = await getInstanceConfig();
 
-  const config = encryptSystem(JSON.stringify({
+  await setSystemSetting("instance_config", JSON.stringify({
     instanceName: parsed.data.instanceName,
     baseDomain: existing.baseDomain,
     serverIp: existing.serverIp,
   }));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "instance_config", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/github/route.ts
+++ b/app/api/setup/github/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { encryptSystem } from "@/lib/crypto/encrypt";
-import { getGitHubAppConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getGitHubAppConfig, setSystemSetting } from "@/lib/system-settings";
 import { maskSecret, isMasked } from "@/lib/mask-secrets";
 
 const githubSchema = z.object({
@@ -60,7 +57,7 @@ export async function POST(request: NextRequest) {
     return incoming ?? undefined;
   }
 
-  const config = encryptSystem(JSON.stringify({
+  await setSystemSetting("github_app", JSON.stringify({
     appId,
     appSlug,
     clientId,
@@ -68,16 +65,6 @@ export async function POST(request: NextRequest) {
     privateKey: resolveSecret(privateKey, existing?.privateKey),
     webhookSecret: resolveSecret(webhookSecret, existing?.webhookSecret),
   }));
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "github_app", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/setup/services/route.ts
+++ b/app/api/setup/services/route.ts
@@ -2,9 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { needsSetup } from "@/lib/setup";
-import { db } from "@/lib/db";
-import { systemSettings } from "@/lib/db/schema";
-import { getOptionalServicesConfig, invalidateSettingsCache } from "@/lib/system-settings";
+import { getOptionalServicesConfig, setSystemSetting } from "@/lib/system-settings";
 
 const servicesSchema = z.object({
   metrics: z.boolean(),
@@ -39,17 +37,7 @@ export async function POST(request: NextRequest) {
 
   const { metrics, logs } = parsed.data;
 
-  const config = JSON.stringify({ metrics, logs });
-
-  await db
-    .insert(systemSettings)
-    .values({ key: "optional_services", value: config })
-    .onConflictDoUpdate({
-      target: systemSettings.key,
-      set: { value: config, updatedAt: new Date() },
-    });
-
-  invalidateSettingsCache();
+  await setSystemSetting("optional_services", JSON.stringify({ metrics, logs }));
 
   return NextResponse.json({ ok: true });
 }

--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -9,7 +9,7 @@
 
 import { db } from "@/lib/db";
 import { systemSettings } from "@/lib/db/schema";
-import { decryptSystemOrFallback } from "@/lib/crypto/encrypt";
+import { decryptSystemOrFallback, encryptSystem } from "@/lib/crypto/encrypt";
 import { eq } from "drizzle-orm";
 
 // Short-TTL in-memory cache for system settings. These change rarely (admin
@@ -54,7 +54,6 @@ export function invalidateSettingsCache(key?: string) {
  * Encrypts the value before writing.
  */
 export async function setSystemSetting(key: string, value: string) {
-  const { encryptSystem } = await import("@/lib/crypto/encrypt");
   const encrypted = encryptSystem(value);
   await db
     .insert(systemSettings)


### PR DESCRIPTION
## Summary

- 30s in-memory cache on `getSystemSettingRaw` — eliminates repeated DB + decrypt calls when multiple config readers fan out within the same request
- `invalidateSettingsCache()` wired into all 7 setup routes so writes take effect immediately
- `setSystemSetting()` helper for future callers that handles upsert + encrypt + invalidate

## Test plan

- [ ] Change a system setting via admin panel — verify it takes effect within seconds (not stale for 30s)
- [ ] Verify admin overview page loads faster (fewer DB round-trips for config reads)
- [ ] Check that feature flags, email, GitHub, backup configs all still read correctly

Fixes #186