### PR TITLE
Wrap migration scripts in transactions

### DIFF
--- a/scripts/migrate-org-env-vars.ts
+++ b/scripts/migrate-org-env-vars.ts
@@ -28,27 +28,29 @@ async function migrate() {
   let migrated = 0;
   let skipped = 0;
 
-  for (const v of allVars) {
-    if (!v.isSecret) {
-      skipped++;
-      continue;
+  await db.transaction(async (tx) => {
+    for (const v of allVars) {
+      if (!v.isSecret) {
+        skipped++;
+        continue;
+      }
+
+      if (isEncrypted(v.value)) {
+        console.log(`  [skip] ${v.key} (org: ${v.organizationId}) — already encrypted`);
+        skipped++;
+        continue;
+      }
+
+      const encrypted = encrypt(v.value, v.organizationId);
+      await tx
+        .update(orgEnvVars)
+        .set({ value: encrypted, updatedAt: new Date() })
+        .where(eq(orgEnvVars.id, v.id));
+
+      console.log(`  [migrated] ${v.key} (org: ${v.organizationId})`);
+      migrated++;
     }
-
-    if (isEncrypted(v.value)) {
-      console.log(`  [skip] ${v.key} (org: ${v.organizationId}) — already encrypted`);
-      skipped++;
-      continue;
-    }
-
-    const encrypted = encrypt(v.value, v.organizationId);
-    await db
-      .update(orgEnvVars)
-      .set({ value: encrypted, updatedAt: new Date() })
-      .where(eq(orgEnvVars.id, v.id));
-
-    console.log(`  [migrated] ${v.key} (org: ${v.organizationId})`);
-    migrated++;
-  }
+  });
 
   console.log(`\nDone: ${migrated} migrated, ${skipped} skipped`);
 }

--- a/scripts/migrate-system-settings.ts
+++ b/scripts/migrate-system-settings.ts
@@ -37,22 +37,24 @@ async function migrate() {
   let migrated = 0;
   let skipped = 0;
 
-  for (const row of rows) {
-    if (isEncrypted(row.value)) {
-      console.log(`  [skip] ${row.key} — already encrypted`);
-      skipped++;
-      continue;
+  await db.transaction(async (tx) => {
+    for (const row of rows) {
+      if (isEncrypted(row.value)) {
+        console.log(`  [skip] ${row.key} — already encrypted`);
+        skipped++;
+        continue;
+      }
+
+      const encrypted = encryptSystem(row.value);
+      await tx
+        .update(systemSettings)
+        .set({ value: encrypted, updatedAt: new Date() })
+        .where(eq(systemSettings.key, row.key));
+
+      console.log(`  [migrated] ${row.key}`);
+      migrated++;
     }
-
-    const encrypted = encryptSystem(row.value);
-    await db
-      .update(systemSettings)
-      .set({ value: encrypted, updatedAt: new Date() })
-      .where(eq(systemSettings.key, row.key));
-
-    console.log(`  [migrated] ${row.key}`);
-    migrated++;
-  }
+  });
 
   console.log(`\nDone: ${migrated} migrated, ${skipped} skipped`);
 }


### PR DESCRIPTION
## Summary

- Wrap per-row encryption updates in `db.transaction()` in both migration scripts
- A crash mid-flight no longer leaves a mixed encrypted/plaintext table
- Idempotency guards still prevent double-encryption on re-run

## Test plan

- [ ] Run `npx tsx scripts/migrate-system-settings.ts` — verify it completes or rolls back cleanly
- [ ] Run `npx tsx scripts/migrate-org-env-vars.ts` — same
- [ ] Re-run both — verify all rows show as `[skip]`

Fixes #187