### PR TITLE
Unified DB > env var > default settings fallback chain

### DIFF
--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -78,12 +78,6 @@ function parseJson<T>(raw: string, label: string): T | null {
 }
 
 // ---------------------------------------------------------------------------
-// Setting source helper (for debugging / admin UI)
-// ---------------------------------------------------------------------------
-
-export type SettingSource = "db" | "env" | "default";
-
-// ---------------------------------------------------------------------------
 // Instance config (general settings)
 // ---------------------------------------------------------------------------
 
@@ -97,10 +91,13 @@ export async function getInstanceConfig(): Promise<InstanceConfig> {
   const dbConfig = await getSystemSettingRaw("instance_config")
     .then((raw) => raw ? parseJson<InstanceConfig>(raw, "instance_config") : null);
 
+  if (dbConfig) return dbConfig;
+
+  // Env var fallback
   return {
-    instanceName: dbConfig?.instanceName ?? process.env.NEXT_PUBLIC_APP_NAME ?? "Vardo",
-    baseDomain: dbConfig?.baseDomain ?? process.env.HOST_BASE_DOMAIN ?? "",
-    serverIp: dbConfig?.serverIp ?? process.env.HOST_SERVER_IP ?? "",
+    instanceName: process.env.NEXT_PUBLIC_APP_NAME ?? "Vardo",
+    baseDomain: process.env.HOST_BASE_DOMAIN ?? "",
+    serverIp: process.env.HOST_SERVER_IP ?? "",
   };
 }
 
@@ -269,6 +266,8 @@ export type AuthConfig = {
   sessionDurationDays: number;
 };
 
+// No env var fallback — auth config is security-sensitive (registration mode,
+// session duration) and should only be set explicitly via the admin UI.
 export async function getAuthConfig(): Promise<AuthConfig> {
   const dbConfig = await getSystemSettingRaw("auth_config")
     .then((raw) => raw ? parseJson<Partial<AuthConfig>>(raw, "auth_config") : null);


### PR DESCRIPTION
## Summary

- Refactor all config readers to consistent read order: DB → env var → default
- Previously some checked env vars first, others had no env var support
- All settings now seedable via env vars but DB takes precedence once saved via UI
- New env var fallbacks: `BACKUP_STORAGE_*`, `FEATURE_METRICS/LOGS`, `SMTP_*`, `RESEND_API_KEY`
- Deduplicated JSON parsing via `parseJson` helper

## Test plan

- [ ] Set env vars only (no DB rows) — verify settings resolve from env
- [ ] Save via admin UI — verify DB value takes precedence over env
- [ ] No env vars, no DB rows — verify hardcoded defaults work
- [ ] Verify email provider detection: Resend → Mailpace → SMTP priority

Fixes #194