### PR TITLE
Drop env vars from search index and add cache header

### DIFF
--- a/app/api/v1/organizations/[orgId]/search/route.ts
+++ b/app/api/v1/organizations/[orgId]/search/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { apps, projects, envVars, orgEnvVars } from "@/lib/db/schema";
+import { apps, projects, orgEnvVars } from "@/lib/db/schema";
 import { requireOrg } from "@/lib/auth/session";
 import { eq, asc, desc } from "drizzle-orm";
 
@@ -10,7 +10,8 @@ type RouteParams = {
 };
 
 // GET /api/v1/organizations/[orgId]/search
-// Returns a lightweight index of all searchable entities for the command palette
+// Returns a lightweight index of all searchable entities for the command palette.
+// Cached for 30s to avoid re-querying on every Cmd+K open.
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { orgId } = await params;
@@ -36,7 +37,6 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
         with: {
           project: { columns: { name: true, displayName: true } },
           domains: { columns: { domain: true } },
-          envVars: { columns: { key: true } },
         },
       }),
       db.query.projects.findMany({
@@ -49,7 +49,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       }),
     ]);
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       apps: orgApps.map((app) => ({
         id: app.id,
         name: app.name,
@@ -60,11 +60,13 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
         imageName: app.imageName,
         projectName: app.project?.displayName || null,
         domains: app.domains?.map((d) => d.domain) || [],
-        envKeys: app.envVars?.map((e) => e.key) || [],
       })),
       projects: orgProjects,
       orgEnvKeys: sharedEnvVars.map((e) => e.key),
     });
+
+    response.headers.set("Cache-Control", "private, max-age=30");
+    return response;
   } catch (error) {
     return handleRouteError(error, "Error fetching search index");
   }

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -51,7 +51,6 @@ type SearchableApp = {
   imageName: string | null;
   projectName: string | null;
   domains: string[];
-  envKeys: string[];
 };
 
 type SearchableProject = {
@@ -139,7 +138,7 @@ export function CommandPalette({ orgId }: CommandPaletteProps) {
                 {apps.map((app) => (
                   <CommandItem
                     key={app.id}
-                    value={`${app.displayName} ${app.name} ${app.projectName || ""} ${app.imageName || ""} ${app.domains.join(" ")} ${app.envKeys.join(" ")}`}
+                    value={`${app.displayName} ${app.name} ${app.projectName || ""} ${app.imageName || ""} ${app.domains.join(" ")}`}
                     onSelect={() => runCommand(() => router.push(`/apps/${app.name}`))}
                     className="gap-2"
                   >


### PR DESCRIPTION
## Summary

- Remove per-app `envVars` relation from search index query — eliminates N+1 joins (50 apps × 20 vars = 1000 rows per request)
- Add `Cache-Control: private, max-age=30` header so the browser caches the response
- Update command palette to remove `envKeys` from search matching

Org-level env keys (`orgEnvKeys`) are preserved since they're a single flat query.

## Test plan

- [ ] Open command palette — verify apps still searchable by name, project, domain
- [ ] Check network tab — verify 30s cache on search endpoint
- [ ] Search by env var key name — should no longer match (acceptable trade-off)

Fixes #133