### PR TITLE
Rename host-network to vardo-network, mark as external

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,7 +3,7 @@
 # - Removes the host service (run `pnpm dev` instead)
 # - Exposes service ports to localhost for direct access
 # - Disables TLS / ACME (uses insecure Traefik dashboard)
-# - Attaches all services to host-network so localhost can reach them
+# - Attaches all services to vardo-network so localhost can reach them
 #
 # All optional profiles (logs, metrics) are activated in .env via COMPOSE_PROFILES
 # so that `docker compose up` in dev starts everything by default.
@@ -22,40 +22,40 @@ services:
       - "5433:5432"
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   redis:
     ports:
       - "6379:6379"
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   cadvisor:
     ports:
       - "8081:8080"
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   loki:
     ports:
       - "3100:3100"
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   promtail:
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   traefik:
     command:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=host-network"
+      - "--providers.docker.network=vardo-network"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.websecure.http.tls=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - "traefik.http.services.host.loadbalancer.server.port=3000"
     networks:
       - internal
-      - host-network
+      - vardo-network
 
   postgres:
     image: postgres:17
@@ -133,7 +133,7 @@ services:
       - "--api.dashboard=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--providers.docker.network=host-network"
+      - "--providers.docker.network=vardo-network"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
@@ -159,7 +159,7 @@ services:
       - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_DASHBOARD_AUTH}"
       - "traefik.http.routers.traefik.middlewares=traefik-auth"
     networks:
-      - host-network
+      - vardo-network
 
 volumes:
   postgres_data:
@@ -170,6 +170,5 @@ volumes:
 
 networks:
   internal:
-  host-network:
-    name: host-network
-    driver: bridge
+  vardo-network:
+    external: true

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -141,7 +141,7 @@ Every deployment in Host uses a blue-green strategy to minimize downtime:
 2. **Prepare** -- The compose file and resolved `.env` file are written to the new slot's directory.
 3. **Start new slot** -- `docker compose up` starts the new containers. Traefik labels are applied so Traefik discovers the service on the Docker network.
 4. **Health check** -- Host waits for the new containers to become healthy. If the health check fails, the new slot is torn down and the deployment is marked as failed. Container logs from the failed slot are captured for debugging.
-5. **Route traffic** -- Traefik automatically routes traffic to the new containers once they are healthy and connected to the `host-network` Docker network.
+5. **Route traffic** -- Traefik automatically routes traffic to the new containers once they are healthy and connected to the `vardo-network` Docker network.
 6. **Tear down old slot** -- The previous slot's containers are stopped and removed.
 7. **Record active slot** -- The `.active-slot` file is updated to reflect the new active slot.
 8. **Domain health checks** -- HTTP health checks run against all configured domains to verify external reachability.

--- a/install.sh
+++ b/install.sh
@@ -343,10 +343,13 @@ fi
 
 # ── Start ──────────────────────────────────────────────────────────────────────
 
+log "Ensuring shared Docker network exists..."
+docker network create vardo-network 2>/dev/null || true
+
 log "Building Vardo (this may take a few minutes)..."
 docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" build
 
-log "Starting Host..."
+log "Starting Vardo..."
 docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
 
 # ── Wait for healthy ───────────────────────────────────────────────────────────

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -189,7 +189,7 @@ export function injectTraefikLabels(
  */
 export function injectNetwork(
   compose: ComposeFile,
-  networkName: string = "host-network",
+  networkName: string = "vardo-network",
 ): ComposeFile {
   const updatedServices: Record<string, ComposeService> = {};
   for (const [key, svc] of Object.entries(compose.services)) {

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -39,7 +39,7 @@ import {
 const execFileAsync = promisify(execFile);
 
 const PROJECTS_DIR = resolve(process.env.HOST_PROJECTS_DIR || "./.host/projects");
-const NETWORK_NAME = "host-network";
+const NETWORK_NAME = "vardo-network";
 
 const HEALTH_CHECK_TIMEOUT_MS = 60000;
 const HEALTH_CHECK_INTERVAL_MS = 2000;


### PR DESCRIPTION
## Summary

- Rename `host-network` → `vardo-network` across compose files, deploy engine, and docs
- Mark network as `external: true` in docker-compose.yml — the deploy engine creates it via Docker API, not compose
- Add `docker network create vardo-network` to install.sh before compose up
- Fix "Starting Host" → "Starting Vardo" in install script

## Test plan

- [ ] `docker network create vardo-network && docker compose up -d` — no more label warning
- [ ] Deploy an app — verify it joins `vardo-network` and Traefik routes to it
- [ ] Fresh install with install.sh — verify network is created automatically