### PR TITLE
Merge .env and .env.local into single .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,16 @@
 # =============================================================================
 # Vardo — Environment Variables
 # =============================================================================
-# Copy this file to .env and fill in the values for your environment.
-# .env is gitignored — never committed to the repo.
+# Copy to .env and fill in values. One file for everything — no .env.local.
+# .env is gitignored. install.sh generates it automatically in production.
 # =============================================================================
+
+# ---------------------
+# Environment
+# ---------------------
+# dev:        skips app container (use pnpm dev), no ACME
+# production: full stack (default, set by install.sh)
+ENV=dev
 
 # ---------------------
 # Database & Cache
@@ -35,8 +42,6 @@ EMAIL_REPLY_TO=you@example.com
 # ---------------------
 # GitHub App (optional)
 # ---------------------
-# Create a GitHub App and fill in these values.
-# GITHUB_PRIVATE_KEY is the base64-encoded PEM private key.
 GITHUB_APP_ID=
 GITHUB_APP_SLUG=
 GITHUB_CLIENT_ID=
@@ -45,27 +50,20 @@ GITHUB_WEBHOOK_SECRET=
 GITHUB_PRIVATE_KEY=
 
 # ---------------------
-# Docker Compose Profiles
-# ---------------------
-# Controls which services start. Comma-separated.
-#   production — app container + Traefik TLS (install.sh sets this)
-#   logs       — Loki + Promtail for persistent log collection
-#   metrics    — cAdvisor for container CPU/memory/network monitoring
-#
-# Dev:  leave empty or set logs,metrics (no production — run pnpm dev)
-# Prod: production,logs,metrics (install.sh sets this automatically)
-COMPOSE_PROFILES=logs,metrics
-FEATURE_METRICS=true
-FEATURE_LOGS=true
-
-# ---------------------
 # Vardo
 # ---------------------
 VARDO_DOMAIN=localhost
 VARDO_BASE_DOMAIN=localhost
 VARDO_SERVER_IP=
-# VARDO_PROJECTS_DIR=       # Default: ./.host/projects (dev), /var/lib/host/projects (prod)
-# VARDO_EXPOSE_PORTS=true
-# NEXT_PUBLIC_VARDO_EXPOSE_PORTS=true
+# VARDO_PROJECTS_DIR=     # Default: ./.host/projects (dev), /var/lib/host/projects (prod)
+
+# ---------------------
+# TLS (production only)
+# ---------------------
+# ACME_EMAIL=you@example.com
+
+# ---------------------
+# Analytics (optional)
+# ---------------------
 # NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
 # NEXT_PUBLIC_PLAUSIBLE_SRC=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,10 +2,9 @@
 
 ## Environment Variables
 
-Vardo uses two environment files:
+Vardo uses one environment file:
 
-- **`.env`** -- Non-secret development defaults, committed to the repository.
-- **`.env.prod`** (production) or **`.env.local`** (development) -- Secret overrides, never committed.
+- **`.env`** -- All config for your environment. Gitignored, never committed. Copy from `.env.example`.
 
 ### Core Variables
 


### PR DESCRIPTION
## Summary

- Single `.env` for everything — no `.env.local`, no `.env.prod`
- Add `ENV=dev` to `.env.example` for environment mode control
- Update docs/configuration.md to reflect single-file convention

After merging: delete `.env`, rename `.env.local` to `.env`, add `ENV=dev` to the top.

Fixes part of #241