### PR TITLE
Fix client build error — move DEFAULT_APP_NAME to lib/constants

### DIFF
--- a/app/(app)/admin/settings/email-settings.tsx
+++ b/app/(app)/admin/settings/email-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import { DEFAULT_APP_NAME } from "@/lib/system-settings";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/app/(app)/admin/settings/general-settings.tsx
+++ b/app/(app)/admin/settings/general-settings.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useSystemSetting } from "./use-system-setting";
-import { DEFAULT_APP_NAME } from "@/lib/system-settings";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
 
 export function GeneralSettings() {
   const [instanceName, setInstanceName] = useState(DEFAULT_APP_NAME);

--- a/app/(public)/invite/[token]/invite-accept-client.tsx
+++ b/app/(public)/invite/[token]/invite-accept-client.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Loader2, Mail, KeyRound } from "lucide-react";
-import { DEFAULT_APP_NAME } from "@/lib/system-settings";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
 import {
   Card,
   CardContent,

--- a/app/(public)/setup/setup-wizard.tsx
+++ b/app/(public)/setup/setup-wizard.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { signUp } from "@/lib/auth/client";
-import { DEFAULT_APP_NAME } from "@/lib/system-settings";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/components/brand.tsx
+++ b/components/brand.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Container } from "lucide-react";
-import { DEFAULT_APP_NAME } from "@/lib/system-settings";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
 
 const appName = process.env.NEXT_PUBLIC_APP_NAME || DEFAULT_APP_NAME;
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Default app name used across the UI, emails, and metadata when not configured. */
+export const DEFAULT_APP_NAME = "Vardo";

--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -11,8 +11,8 @@ import { systemSettings } from "@/lib/db/schema";
 import { decryptSystemOrFallback, encryptSystem } from "@/lib/crypto/encrypt";
 import { eq } from "drizzle-orm";
 
-/** Default app name used across the UI, emails, and metadata when not configured. */
-export const DEFAULT_APP_NAME = "Vardo";
+import { DEFAULT_APP_NAME } from "@/lib/constants";
+export { DEFAULT_APP_NAME };
 
 // Short-TTL in-memory cache for system settings. These change rarely (admin
 // panel only), so a 30s cache eliminates repeated DB + decrypt calls when


### PR DESCRIPTION
## Summary

Client components importing `DEFAULT_APP_NAME` from `lib/system-settings` pulled in `lib/db` → `postgres` → `fs`, breaking the browser bundle. Move the constant to `lib/constants.ts` (zero dependencies) and update client component imports.

## Test plan

- [ ] `pnpm dev` — no build errors