### PR TITLE
feat(ui): consistent card layout across settings and new project pages

### DIFF
--- a/app/(app)/projects/new/new-project-form.tsx
+++ b/app/(app)/projects/new/new-project-form.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent } from "@/components/ui/card";
 import { slugify } from "@/lib/ui/slugify";
 
 export function NewProjectForm({ orgId }: { orgId: string }) {
@@ -72,7 +73,8 @@ export function NewProjectForm({ orgId }: { orgId: string }) {
 
   return (
     <form onSubmit={handleSubmit} className="max-w-lg space-y-6">
-      <div className="squircle rounded-lg border bg-card p-6 space-y-5">
+      <Card className="squircle rounded-lg">
+        <CardContent className="space-y-5">
         <div className="space-y-2">
           <Label htmlFor="displayName">Name</Label>
           <Input
@@ -114,7 +116,8 @@ export function NewProjectForm({ orgId }: { orgId: string }) {
             className="squircle"
           />
         </div>
-      </div>
+        </CardContent>
+      </Card>
 
       <div className="flex items-center gap-3">
         <Button type="submit" disabled={submitting || !slug.trim()} className="squircle">

--- a/app/(app)/settings/[tab]/page.tsx
+++ b/app/(app)/settings/[tab]/page.tsx
@@ -49,11 +49,9 @@ export default async function OrgSettingsTabPage({
 
     case "notifications":
       return (
-        <div className="space-y-8">
+        <div className="space-y-4">
           <NotificationChannelsEditor orgId={orgId} />
-          <div className="border-t border-border pt-6">
-            <DigestSettingsEditor orgId={orgId} />
-          </div>
+          <DigestSettingsEditor orgId={orgId} />
         </div>
       );
 

--- a/app/(app)/settings/digest-settings.tsx
+++ b/app/(app)/settings/digest-settings.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "sonner";
+import { Card, CardContent } from "@/components/ui/card";
 import { Loader2, Mail } from "lucide-react";
 
 type DigestSettingsData = {
@@ -120,7 +121,8 @@ export function DigestSettingsEditor({ orgId }: { orgId: string }) {
   }
 
   return (
-    <div className="space-y-6">
+    <Card className="squircle rounded-lg">
+      <CardContent className="space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
@@ -203,6 +205,7 @@ export function DigestSettingsEditor({ orgId }: { orgId: string }) {
           })}
         </p>
       )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/app/(app)/settings/invitations.tsx
+++ b/app/(app)/settings/invitations.tsx
@@ -23,6 +23,7 @@ import {
   BottomSheetTitle,
 } from "@/components/ui/bottom-sheet";
 import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
+import { Card, CardContent } from "@/components/ui/card";
 import { isAdmin } from "@/lib/auth/permissions";
 import { formatDistanceToNow } from "date-fns";
 
@@ -182,7 +183,8 @@ export function InvitationsPanel({
         confirmLabel="Revoke"
       />
 
-      <div className="space-y-4">
+      <Card className="squircle rounded-lg">
+        <CardContent className="space-y-4">
         <div className="flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
             {invitations.filter((i) => i.status === "pending").length} pending
@@ -296,7 +298,8 @@ export function InvitationsPanel({
             })}
           </div>
         )}
-      </div>
+        </CardContent>
+      </Card>
 
       {/* Invite sheet */}
       <BottomSheet open={inviteOpen} onOpenChange={setInviteOpen}>

--- a/app/(app)/settings/notification-channels.tsx
+++ b/app/(app)/settings/notification-channels.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
 import { Loader2, Plus, Trash2, Bell } from "lucide-react";
 
@@ -55,7 +56,8 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
   if (loading) return <div className="flex items-center gap-2 text-muted-foreground py-8"><Loader2 className="h-4 w-4 animate-spin" />Loading...</div>;
 
   return (
-    <div className="space-y-4">
+    <Card className="squircle rounded-lg">
+      <CardContent className="space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">Configure where notifications are sent for deploy, backup, and cron failures.</p>
         {!showForm && <Button size="sm" onClick={() => setShowForm(true)} className="squircle"><Plus className="h-4 w-4 mr-1" />Add channel</Button>}
@@ -89,6 +91,7 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
           </div>
         ))}</div>
       )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/app/(app)/settings/org-domain-editor.tsx
+++ b/app/(app)/settings/org-domain-editor.tsx
@@ -17,6 +17,7 @@ import {
   BottomSheetClose,
 } from "@/components/ui/bottom-sheet";
 import { toast } from "sonner";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   Globe,
   Plus,
@@ -203,7 +204,8 @@ export function OrgDomainEditor({
   const customDomains = domains.filter((d) => !d.isDefault);
 
   return (
-    <div className="space-y-4">
+    <Card className="squircle rounded-lg">
+      <CardContent className="space-y-4">
       <div>
         <p className="text-sm text-muted-foreground">
           Manage domains for auto-generated project URLs. Projects can use any
@@ -326,6 +328,8 @@ export function OrgDomainEditor({
         Add Domain
       </Button>
 
+      </CardContent>
+
       {/* Add domain bottom sheet */}
       <BottomSheet open={addOpen} onOpenChange={setAddOpen}>
         <BottomSheetContent>
@@ -403,6 +407,6 @@ export function OrgDomainEditor({
           </BottomSheetFooter>
         </BottomSheetContent>
       </BottomSheet>
-    </div>
+    </Card>
   );
 }

--- a/app/(app)/settings/org-env-vars.tsx
+++ b/app/(app)/settings/org-env-vars.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
 
 type Props = {
@@ -168,7 +169,8 @@ export function OrgEnvVarsEditor({ orgId }: Props) {
   }
 
   return (
-    <div className="space-y-3">
+    <Card className="squircle rounded-lg">
+      <CardContent className="space-y-3">
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted-foreground">
           Shared across all projects. Reference with{" "}
@@ -225,7 +227,8 @@ export function OrgEnvVarsEditor({ orgId }: Props) {
           </div>
         )}
       </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/app/(app)/team/team-members.tsx
+++ b/app/(app)/team/team-members.tsx
@@ -25,6 +25,7 @@ import {
   BottomSheetTitle,
 } from "@/components/ui/bottom-sheet";
 import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
+import { Card, CardContent } from "@/components/ui/card";
 import { isAdmin } from "@/lib/auth/permissions";
 import { OrgSwitcher } from "@/components/layout/org-switcher";
 import { getInitials } from "@/lib/utils";
@@ -208,7 +209,8 @@ export function TeamMembers({ members: initialMembers, orgId, orgName, currentRo
           </PageToolbar>
         )}
 
-        <div className="divide-y rounded-lg border">
+        <Card className="squircle rounded-lg">
+          <div className="divide-y">
           {sortedMembers.map((member) => {
             const isSelf = member.id === currentUserId;
             const isOwner = member.role === "owner";
@@ -288,7 +290,8 @@ export function TeamMembers({ members: initialMembers, orgId, orgName, currentRo
               </div>
             );
           })}
-        </div>
+          </div>
+        </Card>
       </div>
 
       <ConfirmDeleteDialog


### PR DESCRIPTION
## Summary
- Wraps all org settings tab content (Variables, Domains, Notifications, Digest, Team, Invitations) in `<Card className="squircle rounded-lg"><CardContent>` to match the admin settings pattern
- Converts the new project form from raw `div` with manual card classes to the `Card`/`CardContent` component
- Removes the manual `border-t` divider between notification channels and digest settings — both are now visually separated as distinct cards
- Team members list (`team-members.tsx`) uses `Card` instead of `divide-y rounded-lg border` when rendered in embedded/settings mode

## Test plan
- [ ] Visit /settings/variables — env vars editor should appear inside a card
- [ ] Visit /settings/domains — domain list and add button inside a card
- [ ] Visit /settings/notifications — notification channels and digest settings each in their own card
- [ ] Visit /settings/team — member list inside a card
- [ ] Visit /settings/invitations — invitations list inside a card
- [ ] Visit /projects/new — new project form inside a card
- [ ] Verify no double borders or visual regressions vs admin settings pages
- [ ] Confirm team page (/team) still renders correctly with its own full-page header (non-embedded mode unchanged)

Closes #247