### PR TITLE
fix: backup page copy polish

### DIFF
--- a/components/backups/auto-backup-banner.tsx
+++ b/components/backups/auto-backup-banner.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Archive, Check, Info } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { scheduleLabel, TargetIcon } from "./constants";
+import { scheduleLabel } from "./constants";
 import { retentionText } from "./retention-summary";
 import type { BackupJob, BackupTarget } from "./types";
 
@@ -23,21 +22,14 @@ export function AutoBackupBanner({
       <div className="flex items-start gap-3">
         <Archive className="size-5 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
         <div className="space-y-1">
-          <h3 className="text-sm font-medium">Automatic backups are enabled</h3>
+          <h3 className="text-sm font-medium">We&apos;ve got you covered</h3>
           <p className="text-sm text-muted-foreground">
-            {scope === "org"
-              ? "Your data is automatically backed up by the host. You can download or restore these backups anytime."
-              : "All apps with persistent volumes are backed up automatically."}
+            Your data is backed up automatically. You can download or restore any snapshot, or add your own backup targets for additional redundancy.
           </p>
         </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground pl-8">
-        <span className="flex items-center gap-1.5">
-          <TargetIcon type={target.type} />
-          {target.name}
-          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">{target.type}</Badge>
-        </span>
         <span className="flex items-center gap-1.5">
           <Check className="size-3 text-status-success" aria-hidden="true" />
           {schedule}

--- a/components/backups/backup-page.tsx
+++ b/components/backups/backup-page.tsx
@@ -82,19 +82,18 @@ export function BackupPage({
 
   return (
     <div className="space-y-8">
-      {/* Header */}
-      <div className="space-y-1">
-        <h2 className="text-lg font-medium">Backups</h2>
-        <p className="text-sm text-muted-foreground">
-          {scope === "admin"
-            ? "Manage system-wide backup targets, retention policies, and view backup history across all organizations."
-            : "Manage backup targets and view backup history for this organization."}
-        </p>
-      </div>
-
-      {/* Auto-backup banner — only shown to org users, admin is configuring this */}
-      {scope === "org" && autoTarget && (
+      {/* Auto-backup banner — only shown to org users when system backups exist */}
+      {scope === "org" && autoTarget ? (
         <AutoBackupBanner target={autoTarget} jobs={autoJobs} scope={scope} />
+      ) : (
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium">Backups</h2>
+          <p className="text-sm text-muted-foreground">
+            {scope === "admin"
+              ? "Manage system-wide backup targets, retention policies, and view backup history across all organizations."
+              : "Configure backup targets and schedules for this organization."}
+          </p>
+        </div>
       )}
 
       {/* Two-column: Storage targets + Backup jobs */}


### PR DESCRIPTION
## Summary

- Banner copy: "We've got you covered" + friendlier description encouraging users to add their own targets
- Remove system target name/type from org banner — users don't need those details
- Show section header only when auto-backup banner isn't present (admin, or no system backups)