### PR TITLE
fix: human-readable retention text in backup banner

### DIFF
--- a/components/backups/auto-backup-banner.tsx
+++ b/components/backups/auto-backup-banner.tsx
@@ -2,7 +2,7 @@
 
 import { ShieldCheck, Check, Info, CloudUpload } from "lucide-react";
 import { scheduleLabel } from "./constants";
-import { retentionText } from "./retention-summary";
+import { retentionDescription } from "./retention-summary";
 import type { BackupJob, BackupTarget } from "./types";
 
 export function AutoBackupBanner({
@@ -14,7 +14,7 @@ export function AutoBackupBanner({
   jobs: BackupJob[];
   scope: "admin" | "org";
 }) {
-  const retention = jobs.length > 0 ? retentionText(jobs[0]) : "Default";
+  const retention = jobs.length > 0 ? retentionDescription(jobs[0]) : "Default retention";
   const schedule = jobs.length > 0 ? scheduleLabel(jobs[0].schedule) : "Daily";
 
   return (
@@ -40,7 +40,7 @@ export function AutoBackupBanner({
         </span>
         <span className="flex items-center gap-1.5">
           <Info className="size-3" aria-hidden="true" />
-          Retention: {retention}
+          {retention}
         </span>
       </div>
     </div>

--- a/components/backups/retention-summary.tsx
+++ b/components/backups/retention-summary.tsx
@@ -2,6 +2,7 @@ import type { BackupJob } from "./types";
 
 type RetentionFields = Pick<BackupJob, "keepLast" | "keepDaily" | "keepWeekly" | "keepMonthly">;
 
+/** Compact format for job cards: "1 last, 7 daily, 1 weekly, 1 monthly" */
 export function retentionText(job: RetentionFields): string {
   const parts: string[] = [];
   if (job.keepLast) parts.push(`${job.keepLast} last`);
@@ -10,6 +11,20 @@ export function retentionText(job: RetentionFields): string {
   if (job.keepMonthly) parts.push(`${job.keepMonthly} monthly`);
   if (parts.length === 0) return "No retention policy";
   return parts.join(", ");
+}
+
+/** Human-readable format for banners: "Keeps 7 days of snapshots, plus weekly and monthly archives" */
+export function retentionDescription(job: RetentionFields): string {
+  const parts: string[] = [];
+  if (job.keepDaily) parts.push(`${job.keepDaily} days of snapshots`);
+  if (job.keepWeekly) parts.push("weekly");
+  if (job.keepMonthly) parts.push("monthly");
+
+  if (parts.length === 0) return "No retention policy";
+  if (parts.length === 1) return `Keeps ${parts[0]}`;
+
+  const daily = parts.shift()!;
+  return `Keeps ${daily}, plus ${parts.join(" and ")} archives`;
 }
 
 export function RetentionSummary({ job }: { job: RetentionFields }) {


### PR DESCRIPTION
Banner now shows 'Keeps 7 days of snapshots, plus weekly and monthly archives' instead of '1 last, 7 daily, 1 weekly, 1 monthly'. Job cards keep the compact format.