### PR TITLE
fix: deduplicate backup info line

### DIFF
--- a/components/backups/backup-page.tsx
+++ b/components/backups/backup-page.tsx
@@ -198,11 +198,7 @@ export function BackupPage({
           <ul className="text-sm space-y-2">
             <li className="flex items-start gap-2.5">
               <Check className="size-4 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
-              <span className="text-muted-foreground">Databases — PostgreSQL, MySQL, SQLite, Redis dumps</span>
-            </li>
-            <li className="flex items-start gap-2.5">
-              <Check className="size-4 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
-              <span className="text-muted-foreground">Uploads and file storage — anything in persistent volumes</span>
+              <span className="text-muted-foreground">Everything in persistent volumes — databases, uploads, file storage</span>
             </li>
             <li className="flex items-start gap-2.5">
               <Info className="size-4 text-muted-foreground/50 shrink-0 mt-0.5" aria-hidden="true" />


### PR DESCRIPTION
Merge two redundant lines into one: 'Everything in persistent volumes — databases, uploads, file storage'