### PR TITLE
fix: backup info — include project config and env vars

### DIFF
--- a/components/backups/backup-page.tsx
+++ b/components/backups/backup-page.tsx
@@ -198,11 +198,15 @@ export function BackupPage({
           <ul className="text-sm space-y-2">
             <li className="flex items-start gap-2.5">
               <Check className="size-4 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
-              <span className="text-muted-foreground">Everything in persistent volumes — databases, uploads, file storage</span>
+              <span className="text-muted-foreground">Persistent volumes — databases, uploads, file storage</span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <Check className="size-4 text-status-success shrink-0 mt-0.5" aria-hidden="true" />
+              <span className="text-muted-foreground">Project config and environment variables (via database backup)</span>
             </li>
             <li className="flex items-start gap-2.5">
               <Info className="size-4 text-muted-foreground/50 shrink-0 mt-0.5" aria-hidden="true" />
-              <span className="text-muted-foreground">Does not include container images, source code or environment variables</span>
+              <span className="text-muted-foreground">Container images are not included — they&apos;re pulled from your registry on deploy</span>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Project config and env vars are in the database, which is a persistent volume that gets backed up. Updated info section to reflect this. Only container images are excluded (pulled from registry on deploy).