### PR TITLE
fix(security): CSP header, SSH host key persistence, terminal session scoping

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/terminal/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/terminal/route.ts
@@ -17,6 +17,8 @@ type ExecSession = {
   socket: net.Socket;
   execId: string;
   containerId: string;
+  orgId: string;
+  appId: string;
   createdAt: number;
 };
 
@@ -108,6 +110,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       socket,
       execId,
       containerId,
+      orgId,
+      appId,
       createdAt: Date.now(),
     });
 
@@ -203,7 +207,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Feature not enabled" }, { status: 404 });
     }
 
-    const { orgId } = await params;
+    const { orgId, appId } = await params;
     const { organization } = await requireOrg();
 
     if (organization.id !== orgId) {
@@ -225,6 +229,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { error: "Session not found or expired" },
         { status: 404 },
       );
+    }
+
+    // Verify session belongs to this org and app
+    if (session.orgId !== orgId || session.appId !== appId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (session.socket.destroyed) {

--- a/lib/crypto/deploy-key.ts
+++ b/lib/crypto/deploy-key.ts
@@ -58,8 +58,9 @@ export async function cleanupKeyFile(filepath: string): Promise<void> {
 
 /**
  * Build the GIT_SSH_COMMAND for use with a deploy key.
- * Disables host key checking for automated clones.
+ * Uses accept-new with a persistent known_hosts so host keys are
+ * trusted on first connection and verified on subsequent ones.
  */
 export function buildGitSshCommand(keyFilePath: string): string {
-  return `ssh -i "${keyFilePath}" -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null`;
+  return `ssh -i "${keyFilePath}" -o StrictHostKeyChecking=accept-new`;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,18 @@ const nextConfig: NextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
           { key: "X-XSS-Protection", value: "0" },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: https:",
+              "font-src 'self' data:",
+              "connect-src 'self' https:",
+              "frame-ancestors 'none'",
+            ].join("; "),
+          },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Three security fixes:

### Content-Security-Policy header (#92)
Added CSP to all routes: `default-src 'self'`, script/style `unsafe-inline` for Next.js, `frame-ancestors 'none'`. XSS mitigation baseline.

### SSH host key persistence (#108)
Removed `UserKnownHostsFile=/dev/null` from deploy key SSH command. Host keys now persist in the system known_hosts file — trusted on first connection, verified on subsequent ones. Prevents MITM on repeat deployments.

### Terminal session org+app scoping (#84)
Sessions now store `orgId` and `appId`. POST handler verifies the session belongs to the requesting org and app before processing input. Prevents cross-org terminal session hijacking.

## Also closed (already safe)
- #79 — git URLs use `execFile` with array args, no shell injection
- #100 — mount paths validated with Zod (absolute, no `..`)
- #104 — cron commands use `execFile` to Docker, admin-configured not user input

Closes #92, #108, #84.