### PR TITLE
fix: tighten CSP — drop unsafe-eval, restrict connect-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,11 +35,11 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "script-src 'self' 'unsafe-inline'",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self' data:",
-              "connect-src 'self' https:",
+              "connect-src 'self'",
               "frame-ancestors 'none'",
             ].join("; "),
           },


### PR DESCRIPTION
Drop `unsafe-eval` (not needed in production Next.js) and narrow `connect-src` from `https:` to `'self'`.