### PR TITLE
fix(infra): pin Redis, dedup schedulers, compose restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
 
   redis:
     container_name: vardo-redis
-    image: redis/redis-stack-server:latest
+    image: redis/redis-stack-server:7.4.0-v3
     restart: unless-stopped
     ports:
       - "${REDIS_PORT:-7200}:6379"

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,11 @@
+const globalForInit = globalThis as unknown as { __vardo_initialized?: boolean };
+
 export async function register() {
   // Only run on the server, not during build
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Dedup guard — prevents duplicate schedulers on hot reload
+    if (globalForInit.__vardo_initialized) return;
+    globalForInit.__vardo_initialized = true;
     // Check encryption key — must run first, before any other initialization
     const { checkEncryptionKey } = await import("./lib/crypto/encrypt");
     const keyCheck = checkEncryptionKey();

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -19,6 +19,7 @@ export type ComposeService = {
   name: string;
   image?: string;
   build?: string | { context: string; dockerfile?: string };
+  restart?: string;
   ports?: string[];
   environment?: Record<string, string>;
   env_file?: string[];
@@ -60,6 +61,7 @@ export function generateComposeForImage(opts: {
   const service: ComposeService = {
     name: projectName,
     image: imageName,
+    restart: "unless-stopped",
   };
 
   // Map exposed ports to host (for non-HTTP services like databases)


### PR DESCRIPTION
## Summary

- **#73**: Redis pinned to `7.4.0-v3` (was `:latest`)
- **#85**: globalThis dedup guard prevents duplicate schedulers on hot reload
- **#90**: Generated compose files include `restart: unless-stopped`, ComposeService type updated

Closes #73, #85, #90.