### PR TITLE
fix(infra): standalone Dockerfile + .env.example cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # =============================================================================
 # Vardo — Environment Variables
 # =============================================================================
-# Copy to .env and fill in values. One file for everything — no .env.local.
-# .env is gitignored. install.sh generates it automatically in production.
+# These are infrastructure connection strings and build-time settings only.
+# Application configuration (email, backups, GitHub, feature flags) is managed
+# via vardo.yml / vardo.secrets.yml or the admin UI.
+#
+# Copy to .env and fill in values. install.sh generates this automatically.
 # =============================================================================
 
 # ---------------------
@@ -33,40 +36,11 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 ENCRYPTION_MASTER_KEY=
 
 # ---------------------
-# Email
+# Instance Identity
 # ---------------------
-# Set one of: MAILPACE_API_TOKEN, RESEND_API_KEY, or SMTP_HOST
-MAILPACE_API_TOKEN=
-EMAIL_FROM=Vardo <deploy@example.com>
-EMAIL_REPLY_TO=you@example.com
-
-# ---------------------
-# GitHub App (optional)
-# ---------------------
-GITHUB_APP_ID=
-GITHUB_APP_SLUG=
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-GITHUB_WEBHOOK_SECRET=
-GITHUB_PRIVATE_KEY=
-
-# ---------------------
-# Vardo
-# ---------------------
+VARDO_INSTANCE_ID=
 VARDO_DOMAIN=localhost
-VARDO_BASE_DOMAIN=localhost
-VARDO_SERVER_IP=
 # VARDO_PROJECTS_DIR=     # Default: ./.host/projects (dev), /var/lib/host/projects (prod)
-
-# ---------------------
-# Instance Mesh
-# ---------------------
-# Stable identity for this instance. Generated automatically by install.sh.
-# Do not change after initial setup — mesh peers reference this ID.
-# Generate manually with: uuidgen | tr '[:upper:]' '[:lower:]'
-# VARDO_INSTANCE_ID=
-# WIREGUARD_PORT=51820
-# Enable mesh: add "mesh" to COMPOSE_PROFILES (e.g. COMPOSE_PROFILES=production,mesh)
 
 # ---------------------
 # TLS (production only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV NEXT_PUBLIC_PLAUSIBLE_SRC=$NEXT_PUBLIC_PLAUSIBLE_SRC
 
 RUN pnpm build
 
-# Production — plain node, no pnpm/corepack needed
+# Production — standalone output, no node_modules needed
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
@@ -42,9 +42,10 @@ RUN addgroup --system --gid 1001 nodejs && \
     mkdir -p /var/lib/host/projects && \
     chown nextjs:nodejs /var/lib/host/projects
 
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+# Copy standalone output (includes only needed node_modules)
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/migrate.mjs ./scripts/migrate.mjs
 
@@ -54,4 +55,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "node scripts/migrate.mjs && node_modules/.bin/next start"]
+CMD ["sh", "-c", "node scripts/migrate.mjs && node server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ try {
 }
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,
   },


### PR DESCRIPTION
## Summary

- **Dockerfile standalone (#68)**: copies `.next/standalone` instead of full `node_modules`. ~200MB image vs ~1GB.
- **next.config.ts**: `output: "standalone"` enabled
- **.env.example (#98)**: simplified to infrastructure-only vars (DATABASE_URL, REDIS_URL, auth secrets). App config managed via vardo.yml or admin UI.

Closes #68, #98.