### PR TITLE
feat(auth): passkey manager, linked accounts, setup welcome page

### DIFF
--- a/apps/console/app/(app)/user/settings/[tab]/page.tsx
+++ b/apps/console/app/(app)/user/settings/[tab]/page.tsx
@@ -4,6 +4,8 @@ import {
   AccountInfo,
   PasswordManagement,
   TwoFactorAuth,
+  PasskeyManager,
+  LinkedAccounts,
   ActiveSessions,
   ApiTokens,
 } from "../account-settings";
@@ -62,6 +64,10 @@ function TabContent({ tab, orgId }: { tab: ValidTab; orgId: string | null }) {
             <p className="text-sm text-muted-foreground">
               Manage how you sign in and protect your account.
             </p>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <PasskeyManager />
+            <LinkedAccounts />
           </div>
           <PasswordManagement />
           <TwoFactorAuth />

--- a/apps/console/app/(app)/user/settings/account-settings.tsx
+++ b/apps/console/app/(app)/user/settings/account-settings.tsx
@@ -12,6 +12,8 @@ import {
   Copy,
   Plus,
   Key,
+  KeyRound,
+  Github,
 } from "lucide-react";
 import { toast } from "@/lib/messenger";
 import { Button } from "@/components/ui/button";
@@ -19,7 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { authClient, useSession } from "@/lib/auth/client";
+import { authClient, useSession, passkey as passkeyMethods } from "@/lib/auth/client";
 
 // ---------------------------------------------------------------------------
 // Account Info
@@ -435,6 +437,265 @@ export function TwoFactorAuth() {
                 )}
               </Button>
             </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Passkey Management
+// ---------------------------------------------------------------------------
+
+type PasskeyInfo = {
+  id: string;
+  name: string | null;
+  createdAt: string | Date | null;
+};
+
+export function PasskeyManager() {
+  const [passkeys, setPasskeys] = useState<PasskeyInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const fetchPasskeys = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/passkey/list-user-passkeys");
+      if (res.ok) {
+        const data = await res.json();
+        setPasskeys(data as PasskeyInfo[]);
+      }
+    } catch {
+      // Passkey list may fail silently on first load
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPasskeys();
+  }, [fetchPasskeys]);
+
+  async function handleAdd() {
+    setAdding(true);
+    try {
+      await passkeyMethods.addPasskey({
+        name: `Passkey ${passkeys.length + 1}`,
+      });
+      toast.success("Passkey registered");
+      fetchPasskeys();
+    } catch {
+      toast.error(
+        "Passkey registration failed. Your browser may not support passkeys.",
+      );
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    try {
+      await fetch("/api/auth/passkey/delete-passkey", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      setPasskeys((prev) => prev.filter((p) => p.id !== id));
+      toast.success("Passkey removed");
+    } catch {
+      toast.error("Failed to remove passkey");
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <Card className="squircle rounded-lg">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Passkeys</CardTitle>
+            <CardDescription>
+              Register passkeys for fast, secure sign-in. You can have multiple
+              passkeys across devices.
+            </CardDescription>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleAdd}
+            disabled={adding}
+          >
+            {adding ? (
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+            ) : (
+              <Plus className="mr-1.5 size-4" />
+            )}
+            Add passkey
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center p-8">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : passkeys.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 p-8">
+            <KeyRound className="size-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No passkeys registered. Add one for instant sign-in.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {passkeys.map((pk) => (
+              <div
+                key={pk.id}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <KeyRound className="size-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">
+                      {pk.name || "Unnamed passkey"}
+                    </p>
+                    {pk.createdAt && (
+                      <p className="text-xs text-muted-foreground">
+                        Added{" "}
+                        {new Date(pk.createdAt).toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleDelete(pk.id)}
+                  disabled={deleting === pk.id}
+                >
+                  {deleting === pk.id ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4 text-destructive" />
+                  )}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Linked Accounts (OAuth providers)
+// ---------------------------------------------------------------------------
+
+type LinkedAccount = {
+  id: string;
+  providerId: string;
+  accountId: string;
+  createdAt: string;
+};
+
+const PROVIDER_LABELS: Record<string, { label: string; icon: typeof Github }> = {
+  github: { label: "GitHub", icon: Github },
+};
+
+export function LinkedAccounts() {
+  const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAccounts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/list-accounts");
+      if (res.ok) {
+        const data = await res.json();
+        const socialAccounts = (data as LinkedAccount[]).filter(
+          (a) => a.providerId !== "credential",
+        );
+        setAccounts(socialAccounts);
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
+
+  return (
+    <Card className="squircle rounded-lg">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Linked accounts</CardTitle>
+            <CardDescription>
+              External accounts you can use to sign in.
+            </CardDescription>
+          </div>
+          {!accounts.some((a) => a.providerId === "github") && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                window.location.href = `/api/auth/sign-in/social?provider=github&callbackURL=${encodeURIComponent(window.location.href)}`;
+              }}
+            >
+              <Github className="mr-1.5 size-4" />
+              Link GitHub
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center p-8">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : accounts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 p-8">
+            <Github className="size-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No linked accounts. Link GitHub for one-click sign-in.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {accounts.map((acct) => {
+              const provider = PROVIDER_LABELS[acct.providerId];
+              const Icon = provider?.icon ?? Github;
+              return (
+                <div
+                  key={acct.id}
+                  className="flex items-center justify-between rounded-lg border p-3"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Icon className="size-4 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {provider?.label ?? acct.providerId}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Connected{" "}
+                        {new Date(acct.createdAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </div>
+                  <Badge variant="secondary" className="text-xs">
+                    Connected
+                  </Badge>
+                </div>
+              );
+            })}
           </div>
         )}
       </CardContent>

--- a/apps/console/app/(public)/setup/setup-wizard.tsx
+++ b/apps/console/app/(public)/setup/setup-wizard.tsx
@@ -33,10 +33,10 @@ import { toast } from "@/lib/messenger";
 
 const STEPS = [
   {
-    id: "import",
-    label: "Import config",
-    description: "Restore from a previous installation",
-    icon: Upload,
+    id: "welcome",
+    label: "Welcome",
+    description: "Get started with Vardo",
+    icon: Rocket,
   },
   {
     id: "account",
@@ -83,7 +83,7 @@ const STEPS = [
   },
 ] as const;
 
-type StepId = (typeof STEPS)[number]["id"];
+type StepId = (typeof STEPS)[number]["id"] | "import";
 
 const STORAGE_KEY = "vardo-setup";
 
@@ -109,7 +109,7 @@ function saveProgress(step: StepId, completed: Set<StepId>) {
 export function SetupWizard({ meshEnabled = true }: { meshEnabled?: boolean }) {
   const router = useRouter();
   const steps = meshEnabled ? STEPS : STEPS.filter((s) => s.id !== "instances");
-  const [currentStep, setCurrentStep] = useState<StepId>("account");
+  const [currentStep, setCurrentStep] = useState<StepId>("welcome");
   const [loading, setLoading] = useState(false);
   const [completedSteps, setCompletedSteps] = useState<Set<StepId>>(new Set());
   const [hydrated, setHydrated] = useState(false);
@@ -229,12 +229,55 @@ export function SetupWizard({ meshEnabled = true }: { meshEnabled?: boolean }) {
 
           {/* Right column — current step form */}
           <div className="w-full space-y-6">
-            {currentStep === "import" && (
+            {currentStep === "welcome" && (
+              <div className="space-y-6">
+                <div>
+                  <h2 className="text-xl font-semibold">Welcome to Vardo</h2>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Deploy everything. Own everything.
+                  </p>
+                </div>
+                <div className="grid gap-3">
+                  <Button
+                    variant="default"
+                    className="w-full h-14 squircle rounded-lg justify-start px-4"
+                    onClick={() => {
+                      markComplete("welcome");
+                      goNext();
+                    }}
+                  >
+                    <Rocket className="w-5 h-5 mr-3 shrink-0" />
+                    <div className="text-left">
+                      <p className="text-sm font-medium">Fresh install</p>
+                      <p className="text-xs opacity-80">
+                        Create your account and configure services
+                      </p>
+                    </div>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="w-full h-14 squircle rounded-lg justify-start px-4"
+                    onClick={() => {
+                      markComplete("welcome");
+                      setCurrentStep("import" as StepId);
+                    }}
+                  >
+                    <Upload className="w-5 h-5 mr-3 shrink-0" />
+                    <div className="text-left">
+                      <p className="text-sm font-medium">Restore from backup</p>
+                      <p className="text-xs text-muted-foreground">
+                        Import a config from a previous Vardo installation
+                      </p>
+                    </div>
+                  </Button>
+                </div>
+              </div>
+            )}
+            {currentStep === ("import" as StepId) && (
               <ImportStep
                 loading={loading}
                 setLoading={setLoading}
                 onComplete={(importedSections) => {
-                  markComplete("import");
                   // Mark config steps as complete if they were imported
                   const sectionToStep: Record<string, StepId> = {
                     email: "email",
@@ -245,11 +288,10 @@ export function SetupWizard({ meshEnabled = true }: { meshEnabled?: boolean }) {
                     const stepId = sectionToStep[section];
                     if (stepId) markComplete(stepId);
                   }
-                  goNext();
+                  setCurrentStep("account");
                 }}
                 onSkip={() => {
-                  markComplete("import");
-                  goNext();
+                  setCurrentStep("account");
                 }}
               />
             )}


### PR DESCRIPTION
## Summary

- Passkey manager in auth settings — list, add, delete passkeys
- Linked accounts in auth settings — shows connected OAuth providers (GitHub), link button if not connected
- Passkeys and linked accounts displayed side by side on large screens
- Setup wizard now starts with a welcome page: "Fresh install" or "Restore from backup"
- All existing auth (password, TOTP 2FA, magic link, passkey sign-in) unchanged

## Auth settings layout

1. Passkeys + Linked accounts (side by side)
2. Password management
3. Two-factor authentication (TOTP)
4. Active sessions

## Setup wizard flow

1. Welcome (fresh install vs restore)
2. Create account (password)
3. Email provider
4. Backup storage
5. GitHub App
6. Domain & DNS
7. Instances
8. Done

## Test plan

- [ ] Auth settings shows passkey manager and linked accounts
- [ ] Add passkey works (triggers browser WebAuthn prompt)
- [ ] Delete passkey works
- [ ] Linked accounts shows GitHub if connected
- [ ] "Link GitHub" button appears if not connected
- [ ] Setup wizard starts on welcome page
- [ ] "Fresh install" proceeds to account creation
- [ ] "Restore from backup" goes to import flow
- [ ] Existing password/TOTP/magic link auth all still work

Closes #324