### PR TITLE
fix(frontend): wire up mobile navigation

### DIFF
--- a/apps/console/components/layout/top-nav.tsx
+++ b/apps/console/components/layout/top-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Brand } from "../brand";
 import { UserMenu } from "./user-menu";
+import { MobileSidebar } from "./mobile-sidebar";
 import type { Organization } from "@/lib/types";
 
 type TopNavProps = {
@@ -25,13 +26,17 @@ export function TopNav({ currentOrgId, organizations }: TopNavProps) {
   return (
     <header className="bg-sidebar shrink-0">
       <div className="mx-auto max-w-screen-xl flex items-center h-16 px-5 lg:px-8 gap-4">
-        {/* Left: brand */}
-        <div className="flex-1">
+        {/* Left: hamburger (mobile) + brand */}
+        <div className="flex-1 flex items-center gap-2">
+          <MobileSidebar
+            currentOrgId={currentOrgId}
+            organizations={organizations}
+          />
           <Brand />
         </div>
 
-        {/* Center: nav */}
-        <nav className="flex items-center gap-1">
+        {/* Center: nav (hidden on mobile) */}
+        <nav className="hidden lg:flex items-center gap-1">
           {navItems.map((item) => {
             const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
             return (
@@ -52,12 +57,14 @@ export function TopNav({ currentOrgId, organizations }: TopNavProps) {
           })}
         </nav>
 
-        {/* Right: user */}
+        {/* Right: user (hidden on mobile — available in sidebar) */}
         <div className="flex-1 flex justify-end">
-          <UserMenu
-            currentOrgId={currentOrgId}
-            organizations={organizations}
-          />
+          <div className="hidden lg:block">
+            <UserMenu
+              currentOrgId={currentOrgId}
+              organizations={organizations}
+            />
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary

- Hide center nav links and user menu below `lg` breakpoint
- Show hamburger trigger for the existing `MobileSidebar` sheet component
- MobileSidebar was already built but never connected to the app layout

One file changed, 16 additions, 9 deletions.

## Test plan

- [ ] Desktop (>1024px): nav links and user menu visible, no hamburger
- [ ] Mobile (<1024px): hamburger visible, nav links hidden, sheet opens with full nav
- [ ] Test at 375px (iPhone SE) and 390px (iPhone 14)

Closes #123