### PR TITLE
fix(db): add FK constraints for parentAppId, rollbackFromId, and clonedFromId

### DIFF
--- a/apps/console/lib/db/schema.ts
+++ b/apps/console/lib/db/schema.ts
@@ -1,6 +1,7 @@
 import {
   bigint,
   boolean,
+  foreignKey,
   index,
   integer,
   pgEnum,
@@ -377,6 +378,7 @@ export const apps = pgTable(
     unique("app_org_name_uniq").on(t.organizationId, t.name),
     index("app_org_id_idx").on(t.organizationId),
     index("app_parent_app_id_idx").on(t.parentAppId),
+    foreignKey({ columns: [t.parentAppId], foreignColumns: [t.id] }).onDelete("set null"),
   ]
 );
 
@@ -415,6 +417,8 @@ export const deployments = pgTable("deployment", {
   (t) => [
     index("deployment_app_id_idx").on(t.appId),
     index("deployment_app_started_at_idx").on(t.appId, t.startedAt),
+    index("deployment_rollback_from_id_idx").on(t.rollbackFromId),
+    foreignKey({ columns: [t.rollbackFromId], foreignColumns: [t.id] }).onDelete("set null"),
   ]
 );
 
@@ -511,7 +515,10 @@ export const environments = pgTable(
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
-  (t) => [unique("env_app_name_uniq").on(t.appId, t.name)]
+  (t) => [
+    unique("env_app_name_uniq").on(t.appId, t.name),
+    foreignKey({ columns: [t.clonedFromId], foreignColumns: [t.id] }).onDelete("set null"),
+  ]
 );
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds database-level foreign key constraints to three columns that referenced other rows without referential integrity: `app.parentAppId`, `deployment.rollbackFromId`, and `environment.clonedFromId`
- All three use `onDelete: set null` since the parent/source row may be deleted independently
- Adds a missing index on `deployment.rollback_from_id`
- Used Drizzle's table-level `foreignKey()` helper instead of column-level `.references()` to avoid a known TypeScript circular inference issue with self-referential tables in Drizzle ORM

## Test plan

- [ ] `pnpm typecheck` passes (verified — no errors)
- [ ] `pnpm db:push` applies cleanly (verified — "Changes applied")
- [ ] Verify FK constraints exist in DB: `\d app`, `\d deployment`, `\d environment` should show FK constraints on the three columns
- [ ] Delete a parent app — child apps should have `parent_app_id` set to null
- [ ] Delete a deployment that was rolled back from — source deployment's `rollback_from_id` set to null on dependent deployments
- [ ] Delete an environment used as a clone source — cloned environments have `cloned_from_id` set to null

Closes #74