### PR TITLE
chore: remove unused framer-motion, gitignore cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ next-env.d.ts
 # worktrees
 .worktrees/
 .host/
+.claude/worktrees/
+
+# node compile cache
+node-compile-cache/

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -48,7 +48,6 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",
-    "framer-motion": "^12.31.0",
     "ioredis": "^5.9.2",
     "jszip": "^3.10.1",
     "lucide-react": "^0.563.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,6 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(kysely@0.28.11)(postgres@3.4.8)
-      framer-motion:
-        specifier: ^12.31.0
-        version: 12.31.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ioredis:
         specifier: ^5.9.2
         version: 5.9.2


### PR DESCRIPTION
## Summary

- Remove `framer-motion` dependency (all imports use `motion/react` from the `motion` package)
- Add `node-compile-cache/` and `.claude/worktrees/` to .gitignore

## Context

Found by DX audit (#360). These are the lowest-risk cleanups.

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] All motion animations still work (imports unchanged, only unused dep removed)

Closes #372, closes #378