### PR TITLE
fix: pnpm test now runs vitest

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -8,7 +8,7 @@
     "start": "drizzle-kit migrate && next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm typecheck && pnpm lint",
+    "test": "pnpm typecheck && pnpm lint && vitest run",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:unit:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

`pnpm test` only ran typecheck + lint, silently skipping all 87 unit tests. Added `vitest run` to the chain.

Before: `pnpm typecheck && pnpm lint`
After: `pnpm typecheck && pnpm lint && vitest run`

One line change, one file.

## Test plan

- [x] `pnpm test:unit` — 87 tests pass
- [ ] `pnpm test` — runs typecheck + lint + vitest

Closes #365