### PR TITLE
chore: add .env.example to apps/console

### DIFF
--- a/apps/console/.env.example
+++ b/apps/console/.env.example
@@ -1,0 +1,11 @@
+# Vardo Console — Environment Variables
+#
+# The primary .env.example is at the repo root (../../.env.example).
+# Copy it to the repo root as .env — Next.js loads it from there.
+#
+# For local development:
+#   cp ../../.env.example ../../.env
+#   docker compose up -d        # Start Postgres + Redis
+#   pnpm dev:console             # Start the dev server
+#
+# See ../../.env.example for all available variables.


### PR DESCRIPTION
Contributors working inside apps/console/ now see a .env.example that points to the root config. No duplication — just a breadcrumb.

Found by DX audit (#360).

Closes #373