### PR TITLE
chore: rename API token prefix from host_ to vardo_

### DIFF
--- a/apps/console/app/api/v1/organizations/[orgId]/tokens/route.ts
+++ b/apps/console/app/api/v1/organizations/[orgId]/tokens/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // Generate a random token
-    const rawToken = `host_${randomBytes(32).toString("hex")}`;
+    const rawToken = `vardo_${randomBytes(32).toString("hex")}`;
     const tokenHash = hashToken(rawToken);
 
     await db.insert(apiTokens).values({

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ Use the token as a Bearer header:
 
 ```bash
 curl -s https://vardo.example.com/api/v1/organizations/{orgId}/apps \
-  -H "Authorization: Bearer host_<your-token>"
+  -H "Authorization: Bearer vardo_<your-token>"
 ```
 
 Tokens authenticate all API endpoints the same way session cookies do. The token's organization determines which resources are accessible — no org-switching cookie is needed.


### PR DESCRIPTION
Two-line change. New tokens get `vardo_` prefix instead of `host_`. Existing tokens unaffected — auth matches on the SHA-256 hash, not the prefix.

Closes #389