### PR TITLE
infra: harden install.sh — multi-distro, logging, dry-run, port checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,7 +448,7 @@ get_port_process() {
       ps -p "$pid" -o comm= 2>/dev/null || echo "unknown (pid $pid)"
     fi
   else
-    ss -tlnp "sport = :$port" 2>/dev/null | grep -oP 'users:\(\("\K[^"]+' | head -1 || echo "unknown"
+    ss -tlnp "sport = :$port" 2>/dev/null | sed -n 's/.*users:(("\([^"]*\)".*/\1/p' | head -1
   fi
 }
 
@@ -657,7 +657,9 @@ setup_swap() {
       run_cmd chmod 600 /swapfile
       run_cmd mkswap /swapfile > /dev/null
       if run_cmd swapon /swapfile 2>/dev/null; then
-        grep -q '/swapfile' /etc/fstab 2>/dev/null || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+        if ! grep -q '/swapfile' /etc/fstab 2>/dev/null; then
+          run_cmd bash -c "echo '/swapfile none swap sw 0 0' >> /etc/fstab"
+        fi
         log "Swap enabled: 2GB"
       else
         rm -f /swapfile
@@ -1720,16 +1722,18 @@ do_uninstall() {
 
     info "Removing Docker volumes..."
     run_cmd docker compose -f "$VARDO_DIR/$COMPOSE_FILE" down -v 2>/dev/null || true
-    log "Volumes removed"
+    if ! $DRY_RUN; then log "Volumes removed"; fi
 
     info "Removing $VARDO_DIR..."
     if ! $DRY_RUN; then
       rm -rf "$VARDO_DIR"
+      log "Installation directory removed"
+    else
+      echo -e "  ${DIM}[dry-run] rm -rf $VARDO_DIR${RESET}"
     fi
-    log "Installation directory removed"
 
     run_cmd docker network rm vardo-network 2>/dev/null || true
-    log "Network removed"
+    if ! $DRY_RUN; then log "Network removed"; fi
 
     echo ""
     echo -e "  ${GREEN}${BOLD}Vardo has been completely removed.${RESET}"


### PR DESCRIPTION
## Summary

- **Package manager abstraction**: Distro detection with tiers (1=bulletproof Ubuntu/Debian, 2=supported Fedora/RHEL/Arch/Alpine, 3=best-effort everything else). Adds `pkg_update()`, `pkg_install()`, `pkg_check()`, `pkg_name()` with case statements for apt/dnf/pacman/apk/zypper. Only apt is fully implemented — others warn and return 1 with manual install instructions.
- **Replaced all hardcoded `apt-get`/`dpkg` calls** with the new `pkg_install()`/`pkg_check()` abstractions, including the `dnsutils` install in DNS verification.
- **Install logging**: Tees all output to `/var/log/vardo-install.log` (Linux) or `~/vardo-install.log` (macOS). Adds `log_to_file()` for timestamped entries.
- **Disk space check**: Fails if < 2GB free, warns if < 5GB.
- **Port conflict detection**: Checks ports 80, 443, 3000 before starting Docker services. Shows the conflicting process name via `ss -tlnp` (Linux) or `lsof -i` (macOS).
- **`--dry-run` mode**: Wraps destructive operations in `run_cmd()` that prints instead of executing.
- **`--verbose` mode**: Shows full command output instead of suppressing to `/dev/null`.
- **Progress indicator**: Step counter `[3/7] Installing packages...` format during install.
- **Broadened OS checks**: Recognizes Fedora, RHEL, Rocky, AlmaLinux, Arch, Alpine — displays version and tier info. Prompts for confirmation on untested distros.
- **Better error messages**: Every `fail()` call now explains what went wrong AND suggests how to fix it.

Passes `shellcheck` clean.

## Test plan

- [ ] Fresh install on Ubuntu 24.04 — verify full flow works
- [ ] `--dry-run` flag — verify no destructive operations execute
- [ ] `--verbose` flag — verify full output shown
- [ ] Run on unsupported distro — verify tier 3 warning and confirmation prompt
- [ ] Verify log file created at `/var/log/vardo-install.log`
- [ ] Verify disk space check fails with < 2GB free
- [ ] Verify port conflict detection shows process name
- [ ] `shellcheck install.sh` — clean

Closes #299