### PR TITLE
fix: disable chart animations on metrics pages

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-metrics.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-metrics.tsx
@@ -254,7 +254,7 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
             <XAxis dataKey="time" tick={chartTickStyle} />
             <YAxis width={45} tickFormatter={(v) => `${v}%`} tick={chartTickStyle} />
             <Tooltip content={<CpuTooltip />} />
-            <Area type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#appCpuGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#appCpuGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>
@@ -283,7 +283,7 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
               domain={[0, latestMemoryLimit > 0 ? latestMemoryLimit * 1.1 : "auto"]}
             />
             <Tooltip content={<MemTooltip />} />
-            <Area type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#appMemGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#appMemGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>
@@ -306,8 +306,8 @@ export function AppMetrics({ orgId, appId, environmentName }: AppMetricsProps) {
             <XAxis dataKey="time" tick={chartTickStyle} />
             <YAxis width={75} tickFormatter={(v) => `${formatBytesShort(v)}/s`} tick={chartTickStyle} />
             <Tooltip content={<NetTooltip />} />
-            <Area type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#appNetRxGradient)" />
-            <Area type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#appNetTxGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#appNetRxGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#appNetTxGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>

--- a/app/(authenticated)/metrics/org-metrics.tsx
+++ b/app/(authenticated)/metrics/org-metrics.tsx
@@ -411,7 +411,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                   <XAxis dataKey="time" tick={chartTickStyle} />
                   <YAxis width={45} tickFormatter={(v) => `${v}%`} tick={chartTickStyle} />
                   <Tooltip content={<CpuTooltip />} />
-                  <Area type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#orgCpuGradient)" />
+                  <Area isAnimationActive={false} type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#orgCpuGradient)" />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
@@ -434,7 +434,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                   <XAxis dataKey="time" tick={chartTickStyle} />
                   <YAxis width={65} tickFormatter={formatBytesShort} tick={chartTickStyle} />
                   <Tooltip content={<MemTooltip />} />
-                  <Area type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#orgMemGradient)" />
+                  <Area isAnimationActive={false} type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#orgMemGradient)" />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
@@ -461,8 +461,8 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                   <XAxis dataKey="time" tick={chartTickStyle} />
                   <YAxis width={65} tickFormatter={(v) => `${formatBytesShort(v)}/s`} tick={chartTickStyle} />
                   <Tooltip content={<NetTooltip />} />
-                  <Area type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#orgNetRxGradient)" />
-                  <Area type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#orgNetTxGradient)" />
+                  <Area isAnimationActive={false} type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#orgNetRxGradient)" />
+                  <Area isAnimationActive={false} type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#orgNetTxGradient)" />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
@@ -485,7 +485,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
                   <XAxis dataKey="time" tick={chartTickStyle} />
                   <YAxis width={65} tickFormatter={formatBytesShort} tick={chartTickStyle} />
                   <Tooltip content={<DiskTooltip />} />
-                  <Area type="monotone" dataKey="diskTotal" stroke={CHART_COLORS.disk} fill="url(#orgDiskGradient)" />
+                  <Area isAnimationActive={false} type="monotone" dataKey="diskTotal" stroke={CHART_COLORS.disk} fill="url(#orgDiskGradient)" />
                 </AreaChart>
               </ResponsiveContainer>
             </div>

--- a/app/(authenticated)/projects/[...slug]/project-metrics.tsx
+++ b/app/(authenticated)/projects/[...slug]/project-metrics.tsx
@@ -142,7 +142,7 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
             <XAxis dataKey="time" tick={chartTickStyle} />
             <YAxis width={45} tickFormatter={(v) => `${v}%`} tick={chartTickStyle} />
             <Tooltip content={<CpuTooltip />} />
-            <Area type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#projCpuGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="cpu" stroke={CHART_COLORS.cpu} fill="url(#projCpuGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>
@@ -160,7 +160,7 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
             <XAxis dataKey="time" tick={chartTickStyle} />
             <YAxis width={65} tickFormatter={formatBytesShort} tick={chartTickStyle} />
             <Tooltip content={<MemTooltip />} />
-            <Area type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#projMemGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="memory" stroke={CHART_COLORS.memory} fill="url(#projMemGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>
@@ -182,8 +182,8 @@ export function ProjectMetrics({ orgId, projectId, apps }: ProjectMetricsProps) 
             <XAxis dataKey="time" tick={chartTickStyle} />
             <YAxis width={65} tickFormatter={(v) => `${formatBytesShort(v)}/s`} tick={chartTickStyle} />
             <Tooltip content={<NetTooltip />} />
-            <Area type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#projNetRxGradient)" />
-            <Area type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#projNetTxGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="networkRxRate" stroke={CHART_COLORS.networkRx} fill="url(#projNetRxGradient)" />
+            <Area isAnimationActive={false} type="monotone" dataKey="networkTxRate" stroke={CHART_COLORS.networkTx} fill="url(#projNetTxGradient)" />
           </AreaChart>
         </ResponsiveContainer>
       </ChartCard>


### PR DESCRIPTION
Recharts animates on every data update by default, causing charts to bounce when live metrics stream in. Added isAnimationActive={false} to all Area components across org, project, and app metrics.