### PR TITLE
Setup wizard saves progress to DB

### DIFF
--- a/app/(public)/setup/setup-wizard.tsx
+++ b/app/(public)/setup/setup-wizard.tsx
@@ -127,17 +127,53 @@ export function SetupWizard({
   const [completedSteps, setCompletedSteps] = useState<Set<StepId>>(new Set());
   const [hydrated, setHydrated] = useState(false);
 
-  // Restore progress from localStorage on mount
+  // Restore progress: DB is source of truth, localStorage is fallback
   useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      const saved = loadProgress();
-      if (saved) {
-        setCompletedSteps(new Set(saved.completed));
-        setCurrentStep(saved.step);
+    let cancelled = false;
+
+    async function hydrate() {
+      const local = loadProgress();
+      const dbCompleted: Set<StepId> = new Set();
+
+      try {
+        const res = await fetch("/api/setup/progress");
+        if (res.ok) {
+          const data: Record<string, boolean> = await res.json();
+          for (const [stepId, done] of Object.entries(data)) {
+            if (done) dbCompleted.add(stepId as StepId);
+          }
+        }
+      } catch {
+        // Network failure — fall through to localStorage only
       }
+
+      if (cancelled) return;
+
+      // Merge: DB wins for step completion, union with localStorage
+      const merged = new Set<StepId>([
+        ...dbCompleted,
+        ...(local?.completed ?? []),
+      ]);
+
+      // "welcome" is always implicitly complete if account exists
+      if (dbCompleted.has("account" as StepId)) {
+        merged.add("welcome");
+      }
+
+      setCompletedSteps(merged);
+
+      // Resume at the first incomplete step
+      const firstIncomplete = steps.find((s) => !merged.has(s.id));
+      setCurrentStep(firstIncomplete?.id ?? "done");
+
       setHydrated(true);
-    });
-    return () => cancelAnimationFrame(id);
+    }
+
+    hydrate();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist progress on every change
@@ -391,7 +427,12 @@ export function SetupWizard({
               />
             )}
             {currentStep === "done" && (
-              <DoneStep onFinish={() => router.push("/projects")} />
+              <DoneStep
+                onFinish={() => {
+                  localStorage.removeItem(STORAGE_KEY);
+                  router.push("/projects");
+                }}
+              />
             )}
           </div>
         </div>

--- a/app/api/setup/progress/route.ts
+++ b/app/api/setup/progress/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { needsSetup } from "@/lib/setup";
+import { requireAdminAuth } from "@/lib/auth/admin";
+import {
+  getEmailProviderConfig,
+  getBackupStorageConfig,
+  getGitHubAppConfig,
+  getInstanceConfig,
+} from "@/lib/system-settings";
+import { db } from "@/lib/db";
+import { meshPeers } from "@/lib/db/schema";
+import { sql } from "drizzle-orm";
+
+// GET /api/setup/progress — returns completion status for each setup step.
+// Unauthenticated during setup (no user exists yet); requires admin after.
+export async function GET() {
+  const setup = await needsSetup();
+
+  if (!setup) {
+    try {
+      await requireAdminAuth();
+    } catch {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const [emailConfig, backupConfig, githubConfig, instanceConfig, peerCount] =
+    await Promise.all([
+      getEmailProviderConfig(),
+      getBackupStorageConfig(),
+      getGitHubAppConfig(),
+      getInstanceConfig(),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(meshPeers)
+        .then(([r]) => Number(r.count)),
+    ]);
+
+  return NextResponse.json({
+    account: !setup,
+    email: emailConfig !== null,
+    backup: backupConfig !== null,
+    github: githubConfig !== null,
+    domain: Boolean(instanceConfig.baseDomain),
+    instances: peerCount > 0,
+  });
+}


### PR DESCRIPTION
## Summary
- New `GET /api/setup/progress` endpoint aggregates step completion from existing `system_settings` rows (email, backup, github, domain) and the `mesh_peer` table
- Wizard mount effect now fetches DB progress first, merges with localStorage (DB wins for completion, localStorage keeps skipped-step state), and resumes at the first incomplete step
- localStorage cleared on the done step to prevent stale data on next setup

## Test plan
- [ ] Fresh install: wizard starts at welcome, completes account, verify `/api/setup/progress` returns `account: true`
- [ ] Partially configured instance: configure email via wizard, refresh page — wizard resumes past email step
- [ ] Open setup on a different device after partial config — picks up DB-saved progress
- [ ] Kill network mid-setup — wizard falls back to localStorage-only gracefully
- [ ] After setup complete, unauthenticated request to `/api/setup/progress` returns 401

Closes #354