### PR TITLE
feat: multiple ACME certificate issuers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ VARDO_DOMAIN=localhost
 # TLS (production only)
 # ---------------------
 # ACME_EMAIL=you@example.com
+# ZEROSSL_EAB_KID=
+# ZEROSSL_EAB_HMAC=
 
 # ---------------------
 # Analytics (optional)

--- a/app/(authenticated)/admin/settings/domain-settings.tsx
+++ b/app/(authenticated)/admin/settings/domain-settings.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Check, X, Loader2, RefreshCw } from "lucide-react";
 import {
   Card,
@@ -12,6 +19,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { MASK_SENTINEL } from "@/lib/mask-secrets";
+import { useSystemSetting } from "./use-system-setting";
 
 type DnsCheck = {
   domain: string;
@@ -25,6 +34,19 @@ type InstanceData = {
   serverIp: string;
 };
 
+const ISSUER_LABELS: Record<string, string> = {
+  le: "Let's Encrypt",
+  google: "Google Trust Services",
+  zerossl: "ZeroSSL",
+};
+
+function toDisplay(value: string): string {
+  if (value.startsWith(MASK_SENTINEL)) {
+    return `••••${value.slice(MASK_SENTINEL.length)}`;
+  }
+  return value;
+}
+
 export function DomainSettings() {
   const [loading, setLoading] = useState(true);
   const [checking, setChecking] = useState(false);
@@ -32,6 +54,22 @@ export function DomainSettings() {
   const [hostDomain, setHostDomain] = useState("");
   const [acmeEmail, setAcmeEmail] = useState("");
   const [dnsChecks, setDnsChecks] = useState<DnsCheck[]>([]);
+
+  // SSL issuer settings
+  const [sslIssuer, setSslIssuer] = useState<string>("le");
+  const [zerosslKid, setZerosslKid] = useState("");
+  const [zerosslHmac, setZerosslHmac] = useState("");
+
+  const onSslLoad = useCallback((data: Record<string, unknown>) => {
+    setSslIssuer((data.defaultIssuer as string) || "le");
+    setZerosslKid((data.zerosslEabKid as string) || "");
+    setZerosslHmac((data.zerosslEabHmac as string) || "");
+  }, []);
+
+  const { loading: sslLoading, saving: sslSaving, save: saveSsl } = useSystemSetting(
+    "/api/setup/ssl",
+    { label: "SSL settings", onLoad: onSslLoad },
+  );
 
   useEffect(() => {
     (async () => {
@@ -154,9 +192,95 @@ export function DomainSettings() {
                 className="bg-muted"
               />
               <p className="text-xs text-muted-foreground">
-                Used for SSL certificate issuance with Let&apos;s Encrypt.
+                Used for SSL certificate issuance with {ISSUER_LABELS[sslIssuer] || "Let's Encrypt"}.
               </p>
             </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* SSL certificate issuer */}
+      <Card className="squircle rounded-lg">
+        <CardHeader>
+          <CardTitle className="text-sm">SSL certificate issuer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {sslLoading ? (
+            <div className="flex items-center gap-2 py-2">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Loading...</span>
+            </div>
+          ) : (
+            <>
+              <div className="max-w-md space-y-2">
+                <Label htmlFor="ssl-issuer">Default issuer</Label>
+                <Select value={sslIssuer} onValueChange={setSslIssuer}>
+                  <SelectTrigger id="ssl-issuer" className="squircle">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="le">Let&apos;s Encrypt</SelectItem>
+                    <SelectItem value="google">Google Trust Services</SelectItem>
+                    <SelectItem value="zerossl">ZeroSSL</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Certificate authority used for new domains. Can be overridden per domain.
+                </p>
+              </div>
+
+              {(sslIssuer === "zerossl" || zerosslKid) && (
+                <div className="max-w-md space-y-4 rounded-lg border bg-muted/30 p-4">
+                  <p className="text-xs font-medium">
+                    ZeroSSL requires External Account Binding (EAB) credentials.{" "}
+                    <a
+                      href="https://app.zerossl.com/developer"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline"
+                    >
+                      Get credentials
+                    </a>
+                  </p>
+                  <div className="space-y-2">
+                    <Label htmlFor="zerossl-kid">EAB Key ID</Label>
+                    <Input
+                      id="zerossl-kid"
+                      value={toDisplay(zerosslKid)}
+                      onChange={(e) => setZerosslKid(e.target.value)}
+                      placeholder="EAB Key ID from ZeroSSL dashboard"
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="zerossl-hmac">EAB HMAC Key</Label>
+                    <Input
+                      id="zerossl-hmac"
+                      value={toDisplay(zerosslHmac)}
+                      onChange={(e) => setZerosslHmac(e.target.value)}
+                      placeholder="EAB HMAC Key from ZeroSSL dashboard"
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                </div>
+              )}
+
+              <Button
+                className="squircle"
+                onClick={() => saveSsl({
+                  defaultIssuer: sslIssuer,
+                  zerosslEabKid: zerosslKid || undefined,
+                  zerosslEabHmac: zerosslHmac || undefined,
+                })}
+                disabled={sslSaving}
+              >
+                {sslSaving ? (
+                  <><Loader2 className="mr-2 size-4 animate-spin" />Saving...</>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </>
           )}
         </CardContent>
       </Card>
@@ -241,9 +365,9 @@ export function DomainSettings() {
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            HTTPS will activate automatically once DNS propagates and Let&apos;s
-            Encrypt issues certificates. The wildcard A record enables automatic
-            subdomains for deployed apps.
+            HTTPS will activate automatically once DNS propagates and your
+            certificate authority issues certificates. The wildcard A record
+            enables automatic subdomains for deployed apps.
           </p>
         </CardContent>
       </Card>

--- a/app/(authenticated)/apps/[...slug]/app-networking.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-networking.tsx
@@ -52,14 +52,27 @@ export function AppNetworking({
   const [domainSaving, setDomainSaving] = useState(false);
   const [newDomain, setNewDomain] = useState("");
   const [newDomainPort, setNewDomainPort] = useState("");
+  const [newDomainResolver, setNewDomainResolver] = useState("");
   const [deletingDomainId, setDeletingDomainId] = useState<string | null>(null);
   const [editingDomainId, setEditingDomainId] = useState<string | null>(null);
   const [editDomainValue, setEditDomainValue] = useState("");
   const [editDomainPort, setEditDomainPort] = useState("");
+  const [editDomainResolver, setEditDomainResolver] = useState("");
+  const [availableIssuers, setAvailableIssuers] = useState<string[]>(["le", "google"]);
   const [dnsDomainId, setDnsDomainId] = useState<string | null>(null);
   const [domainStatuses, setDomainStatuses] = useState<Record<string, "checking" | "resolving" | "not-configured">>({});
   const [domainCheckTick, setDomainCheckTick] = useState(0);
   const [serverIP, setServerIP] = useState<string | null>(null);
+
+  // Fetch available issuers
+  useEffect(() => {
+    fetch("/api/setup/ssl")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        if (data?.availableIssuers) setAvailableIssuers(data.availableIssuers);
+      })
+      .catch(() => { /* best effort */ });
+  }, []);
 
   function openDomainSheet(domainId: string) {
     setDnsDomainId(domainId);
@@ -150,6 +163,7 @@ export function AppNetworking({
           body: JSON.stringify({
             domain: newDomain.trim(),
             port: newDomainPort ? parseInt(newDomainPort, 10) : undefined,
+            ...(newDomainResolver && { certResolver: newDomainResolver }),
           }),
         }
       );
@@ -162,6 +176,7 @@ export function AppNetworking({
       setDomainOpen(false);
       setNewDomain("");
       setNewDomainPort("");
+      setNewDomainResolver("");
       router.refresh();
     } catch {
       toast.error("Failed to add domain");
@@ -208,6 +223,7 @@ export function AppNetworking({
             id,
             domain: editDomainValue.trim(),
             port: editDomainPort ? parseInt(editDomainPort, 10) : null,
+            ...(editDomainResolver !== undefined && { certResolver: editDomainResolver || "le" }),
           }),
         }
       );
@@ -242,6 +258,7 @@ export function AppNetworking({
             onClick={() => {
               setNewDomain("");
               setNewDomainPort("");
+              setNewDomainResolver("");
               setDomainOpen(!domainOpen);
             }}
           >
@@ -273,6 +290,19 @@ export function AppNetworking({
                 onKeyDown={(e) => { if (e.key === "Enter") handleDomainAdd(); }}
                 className="h-9 w-24 rounded-md border bg-background px-3 text-sm font-mono"
               />
+            </div>
+            <div className="grid gap-1.5">
+              <label className="text-xs text-muted-foreground">SSL issuer</label>
+              <select
+                value={newDomainResolver}
+                onChange={(e) => setNewDomainResolver(e.target.value)}
+                className="h-9 rounded-md border bg-background px-2 text-sm"
+              >
+                <option value="">Default</option>
+                {availableIssuers.includes("le") && <option value="le">Let&apos;s Encrypt</option>}
+                {availableIssuers.includes("google") && <option value="google">Google</option>}
+                {availableIssuers.includes("zerossl") && <option value="zerossl">ZeroSSL</option>}
+              </select>
             </div>
             <Button size="sm" onClick={handleDomainAdd} disabled={domainSaving || !newDomain.trim()}>
               {domainSaving ? <Loader2 className="size-3.5 animate-spin" /> : "Add"}
@@ -323,6 +353,19 @@ export function AppNetworking({
                           onKeyDown={(e) => { if (e.key === "Enter") handleDomainUpdate(domain.id); if (e.key === "Escape") setEditingDomainId(null); }}
                           className="h-9 w-24 rounded-md border bg-background px-3 text-sm font-mono"
                         />
+                      </div>
+                      <div className="grid gap-1.5">
+                        <label className="text-xs text-muted-foreground">SSL issuer</label>
+                        <select
+                          value={editDomainResolver}
+                          onChange={(e) => setEditDomainResolver(e.target.value)}
+                          className="h-9 rounded-md border bg-background px-2 text-sm"
+                        >
+                          <option value="">Default</option>
+                          {availableIssuers.includes("le") && <option value="le">Let&apos;s Encrypt</option>}
+                          {availableIssuers.includes("google") && <option value="google">Google</option>}
+                          {availableIssuers.includes("zerossl") && <option value="zerossl">ZeroSSL</option>}
+                        </select>
                       </div>
                       <Button size="sm" onClick={() => handleDomainUpdate(domain.id)} disabled={domainSaving || !editDomainValue.trim()}>
                         {domainSaving ? <Loader2 className="size-3.5 animate-spin" /> : "Save"}
@@ -395,6 +438,7 @@ export function AppNetworking({
                         setEditingDomainId(domain.id);
                         setEditDomainValue(domain.domain);
                         setEditDomainPort(domain.port?.toString() || "");
+                        setEditDomainResolver(domain.certResolver || "");
                       }}
                     >
                       <Pencil className="size-3.5" />

--- a/app/(authenticated)/apps/[...slug]/types.ts
+++ b/app/(authenticated)/apps/[...slug]/types.ts
@@ -25,6 +25,7 @@ export type Domain = {
   domain: string;
   serviceName: string | null;
   port: number | null;
+  certResolver: string | null;
   isPrimary: boolean | null;
 };
 

--- a/app/api/setup/ssl/route.ts
+++ b/app/api/setup/ssl/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdminAuth } from "@/lib/auth/admin";
+import { getSslConfig, setSystemSetting } from "@/lib/system-settings";
+import { maskSecret, isMasked } from "@/lib/mask-secrets";
+
+const ISSUER_LABELS: Record<string, string> = {
+  le: "Let's Encrypt",
+  google: "Google Trust Services",
+  zerossl: "ZeroSSL",
+};
+
+const sslSchema = z.object({
+  defaultIssuer: z.enum(["le", "google", "zerossl"]),
+  zerosslEabKid: z.string().optional(),
+  zerosslEabHmac: z.string().optional(),
+}).strict();
+
+export async function GET(request: NextRequest) {
+  await requireAdminAuth(request);
+
+  const config = await getSslConfig();
+
+  // Always-available issuers
+  const availableIssuers = ["le", "google"];
+  if (config.zerosslEabKid && config.zerosslEabHmac) {
+    availableIssuers.push("zerossl");
+  }
+
+  return NextResponse.json({
+    configured: true,
+    defaultIssuer: config.defaultIssuer,
+    zerosslEabKid: maskSecret(config.zerosslEabKid),
+    zerosslEabHmac: maskSecret(config.zerosslEabHmac),
+    availableIssuers,
+    issuerLabels: ISSUER_LABELS,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  await requireAdminAuth(request);
+
+  const body = await request.json();
+  const parsed = sslSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+
+  const { defaultIssuer, zerosslEabKid, zerosslEabHmac } = parsed.data;
+
+  // Keep secrets the user didn't change (sentinel-prefixed values)
+  const existing = await getSslConfig();
+
+  function resolveSecret(incoming: string | undefined, existingVal: string | undefined): string | undefined {
+    if (isMasked(incoming)) return existingVal;
+    return incoming;
+  }
+
+  await setSystemSetting("ssl_config", JSON.stringify({
+    defaultIssuer,
+    zerosslEabKid: resolveSecret(zerosslEabKid, existing.zerosslEabKid),
+    zerosslEabHmac: resolveSecret(zerosslEabHmac, existing.zerosslEabHmac),
+  }));
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/domains/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/domains/route.ts
@@ -76,6 +76,7 @@ const updateDomainSchema = z.object({
   id: z.string().min(1),
   domain: z.string().min(1).optional(),
   port: z.number().int().positive().nullable().optional(),
+  certResolver: z.string().optional(),
 }).strict();
 
 // PATCH /api/v1/organizations/[orgId]/apps/[appId]/domains

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,9 +106,22 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.websecure.http.tls=true"
+      # Let's Encrypt (default, always available)
       - "--certificatesresolvers.le.acme.tlschallenge=true"
       - "--certificatesresolvers.le.acme.email=${ACME_EMAIL:-}"
-      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme-le.json"
+      # Google Trust Services (free, no EAB required)
+      - "--certificatesresolvers.google.acme.tlschallenge=true"
+      - "--certificatesresolvers.google.acme.email=${ACME_EMAIL:-}"
+      - "--certificatesresolvers.google.acme.caserver=https://dv.acme-v02.api.pki.goog/directory"
+      - "--certificatesresolvers.google.acme.storage=/letsencrypt/acme-google.json"
+      # ZeroSSL (requires EAB credentials — non-functional until configured)
+      - "--certificatesresolvers.zerossl.acme.tlschallenge=true"
+      - "--certificatesresolvers.zerossl.acme.email=${ACME_EMAIL:-}"
+      - "--certificatesresolvers.zerossl.acme.caserver=https://acme.zerossl.com/v2/DV90"
+      - "--certificatesresolvers.zerossl.acme.eab.kid=${ZEROSSL_EAB_KID:-}"
+      - "--certificatesresolvers.zerossl.acme.eab.hmacencoded=${ZEROSSL_EAB_HMAC:-}"
+      - "--certificatesresolvers.zerossl.acme.storage=/letsencrypt/acme-zerossl.json"
       - "--log.level=${TRAEFIK_LOG_LEVEL:-WARN}"
     ports:
       - "80:80"

--- a/install.sh
+++ b/install.sh
@@ -1031,6 +1031,8 @@ BETTER_AUTH_SECRET=$auth_secret
 ENCRYPTION_MASTER_KEY=$enc_key
 GITHUB_WEBHOOK_SECRET=$webhook_secret
 ACME_EMAIL=${ACME_EMAIL}
+ZEROSSL_EAB_KID=${ZEROSSL_EAB_KID:-}
+ZEROSSL_EAB_HMAC=${ZEROSSL_EAB_HMAC:-}
 TRAEFIK_DASHBOARD_AUTH=$traefik_auth
 
 # GitHub App (optional — configure in setup wizard or Settings)
@@ -1334,6 +1336,14 @@ do_update() {
 
   # Rebuild
   step "Rebuilding"
+
+  # Migrate ACME storage from single file to per-resolver files
+  local acme_vol
+  acme_vol=$(docker volume inspect vardo_letsencrypt --format '{{ .Mountpoint }}' 2>/dev/null || true)
+  if [ -n "$acme_vol" ] && [ -f "$acme_vol/acme.json" ] && [ ! -f "$acme_vol/acme-le.json" ]; then
+    cp "$acme_vol/acme.json" "$acme_vol/acme-le.json"
+    info "Migrated acme.json → acme-le.json"
+  fi
 
   info "Building containers..."
   if $VERBOSE; then

--- a/lib/config/vardo-config.ts
+++ b/lib/config/vardo-config.ts
@@ -47,6 +47,9 @@ export type VardoConfig = {
     appSlug?: string;
     clientId?: string;
   };
+  ssl?: {
+    defaultIssuer?: "le" | "google" | "zerossl";
+  };
   features?: Record<string, boolean>;
 };
 
@@ -67,6 +70,10 @@ export type VardoSecrets = {
     privateKey?: string;
     webhookSecret?: string;
   };
+  zerossl?: {
+    eabKid?: string;
+    eabHmac?: string;
+  };
 };
 
 /** Config + secrets merged for internal use. */
@@ -76,6 +83,7 @@ export type VardoFullConfig = {
   email?: VardoConfig["email"] & VardoSecrets["email"];
   backup?: VardoConfig["backup"] & VardoSecrets["backup"];
   github?: VardoConfig["github"] & VardoSecrets["github"];
+  ssl?: VardoConfig["ssl"] & { zerossl?: VardoSecrets["zerossl"] };
   features?: VardoConfig["features"];
   secrets?: {
     encryptionKey?: string;
@@ -163,6 +171,7 @@ export async function readVardoConfig(): Promise<VardoFullConfig | null> {
     email: { ...config.email, ...secrets?.email },
     backup: { ...config.backup, ...secrets?.backup },
     github: { ...config.github, ...secrets?.github },
+    ssl: { ...config.ssl, zerossl: secrets?.zerossl },
     features: config.features,
     secrets: {
       encryptionKey: secrets?.encryptionKey,
@@ -216,16 +225,18 @@ export async function systemSettingsToVardoConfig(): Promise<{
     getEmailProviderConfig,
     getBackupStorageConfig,
     getGitHubAppConfig,
+    getSslConfig,
     getFeatureFlagsConfig,
   } = await import("@/lib/system-settings");
   const { getInstanceId } = await import("@/lib/constants");
 
-  const [instance, auth, email, backup, github, features] = await Promise.all([
+  const [instance, auth, email, backup, github, ssl, features] = await Promise.all([
     getInstanceConfig(),
     getAuthConfig(),
     getEmailProviderConfig(),
     getBackupStorageConfig(),
     getGitHubAppConfig(),
+    getSslConfig(),
     getFeatureFlagsConfig(),
   ]);
 
@@ -273,6 +284,11 @@ export async function systemSettingsToVardoConfig(): Promise<{
         clientId: github.clientId,
       },
     }),
+    ...(ssl.defaultIssuer !== "le" && {
+      ssl: {
+        defaultIssuer: ssl.defaultIssuer,
+      },
+    }),
     ...(features && { features }),
   };
 
@@ -297,6 +313,12 @@ export async function systemSettingsToVardoConfig(): Promise<{
         clientSecret: github.clientSecret,
         privateKey: github.privateKey,
         webhookSecret: github.webhookSecret,
+      },
+    }),
+    ...((ssl.zerosslEabKid || ssl.zerosslEabHmac) && {
+      zerossl: {
+        eabKid: ssl.zerosslEabKid,
+        eabHmac: ssl.zerosslEabHmac,
       },
     }),
   };
@@ -361,6 +383,15 @@ export async function importVardoConfig(
   if (full.github) {
     await setSystemSetting("github_app", JSON.stringify(full.github));
     imported.push("github");
+  }
+
+  if (full.ssl) {
+    await setSystemSetting("ssl_config", JSON.stringify({
+      defaultIssuer: full.ssl.defaultIssuer ?? "le",
+      zerosslEabKid: full.ssl.zerossl?.eabKid,
+      zerosslEabHmac: full.ssl.zerossl?.eabHmac,
+    }));
+    imported.push("ssl");
   }
 
   if (full.features) {

--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -240,6 +240,35 @@ export async function getFeatureFlagsConfig(): Promise<Record<string, boolean> |
 }
 
 // ---------------------------------------------------------------------------
+// SSL / ACME certificate issuer
+// ---------------------------------------------------------------------------
+
+export type SslConfig = {
+  defaultIssuer: "le" | "google" | "zerossl";
+  zerosslEabKid?: string;
+  zerosslEabHmac?: string;
+};
+
+const VALID_ISSUERS = ["le", "google", "zerossl"] as const;
+
+export async function getSslConfig(): Promise<SslConfig> {
+  const fileConfig = await getVardoConfig();
+  const dbConfig = await getSystemSettingRaw("ssl_config")
+    .then((raw) => raw ? parseJson<SslConfig>(raw, "ssl_config") : null);
+
+  const fileIssuer = fileConfig?.ssl?.defaultIssuer;
+  const validIssuer = fileIssuer && VALID_ISSUERS.includes(fileIssuer)
+    ? fileIssuer
+    : undefined;
+
+  return {
+    defaultIssuer: validIssuer ?? dbConfig?.defaultIssuer ?? "le",
+    zerosslEabKid: fileConfig?.ssl?.zerossl?.eabKid ?? dbConfig?.zerosslEabKid,
+    zerosslEabHmac: fileConfig?.ssl?.zerossl?.eabHmac ?? dbConfig?.zerosslEabHmac,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Authentication config
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Registers three ACME certificate resolvers in Traefik: Let's Encrypt (default), Google Trust Services, and ZeroSSL — each with its own storage file
- Adds admin UI card for configuring the default SSL issuer and ZeroSSL EAB credentials
- Adds per-domain cert resolver picker in the app networking UI so individual domains can override the instance default
- Extends the domain API to accept `certResolver` on PATCH alongside the existing POST support
- Includes ACME storage migration (`acme.json` → `acme-le.json`) in the install/upgrade script

## Test plan

- [ ] Verify Traefik starts with all three resolvers registered (`docker compose up -d` and check logs)
- [ ] Confirm existing Let's Encrypt certificates continue working after `acme.json` → `acme-le.json` migration
- [ ] Test admin SSL settings card: change default issuer, save, reload — verify it persists
- [ ] Test ZeroSSL EAB credential fields appear when ZeroSSL is selected and masked on reload
- [ ] Add a domain with a non-default cert resolver, verify it shows in the edit form and deploys with correct Traefik label
- [ ] Verify `pnpm typecheck` and `pnpm build` pass cleanly

Closes #323