### PR TITLE
feat: MCP server with read-only tools

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { authenticateRequest } from "@/lib/mcp/auth";
+import { createMcpServer } from "@/lib/mcp/server";
+
+/**
+ * POST /api/mcp — Streamable HTTP transport for MCP.
+ *
+ * Handles initialize, tools/list, and tools/call JSON-RPC requests.
+ * Stateless: fresh McpServer instance per request, authenticated via
+ * Bearer token bound to an organization.
+ */
+export async function POST(request: NextRequest) {
+  const context = await authenticateRequest(request);
+  if (!context) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const server = createMcpServer(context);
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless — no session persistence
+  });
+
+  await server.connect(transport);
+
+  return transport.handleRequest(request);
+}
+
+/**
+ * GET /api/mcp — SSE endpoint for server-initiated notifications.
+ *
+ * Required by the MCP Streamable HTTP spec. In stateless mode we reject
+ * these since there's no persistent session to attach to.
+ */
+export async function GET() {
+  return new Response(
+    JSON.stringify({
+      error: "SSE not supported — this server is stateless. Use POST for all requests.",
+    }),
+    {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+/**
+ * DELETE /api/mcp — Session teardown.
+ *
+ * No-op in stateless mode — each request is independent.
+ */
+export async function DELETE() {
+  return new Response(null, { status: 204 });
+}

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,0 +1,55 @@
+import { createHash } from "crypto";
+import { db } from "@/lib/db";
+import { apiTokens, user } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export type McpAuthContext = {
+  userId: string;
+  organizationId: string;
+};
+
+/**
+ * Authenticate an MCP request using a Bearer token.
+ *
+ * Standalone function that takes a raw Request — no dependency on
+ * Next.js AsyncLocalStorage (headers()/cookies()).
+ *
+ * Returns the resolved user + org context, or null if invalid.
+ */
+export async function authenticateRequest(
+  request: Request
+): Promise<McpAuthContext | null> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const rawToken = authHeader.slice(7).trim();
+  if (!rawToken) return null;
+
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+
+  const token = await db.query.apiTokens.findFirst({
+    where: eq(apiTokens.tokenHash, tokenHash),
+    columns: { id: true, userId: true, organizationId: true },
+  });
+
+  if (!token) return null;
+
+  // Verify the user still exists
+  const tokenUser = await db.query.user.findFirst({
+    where: eq(user.id, token.userId),
+    columns: { id: true },
+  });
+
+  if (!tokenUser) return null;
+
+  // Update lastUsedAt in the background — fire and forget
+  db.update(apiTokens)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(apiTokens.id, token.id))
+    .catch(() => {});
+
+  return {
+    userId: token.userId,
+    organizationId: token.organizationId,
+  };
+}

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -1,0 +1,19 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpAuthContext } from "./auth";
+import { registerAllTools } from "./tools";
+
+/**
+ * Create a configured MCP server instance with all tools registered.
+ *
+ * Each request gets a fresh instance — stateless by design.
+ */
+export function createMcpServer(context: McpAuthContext): McpServer {
+  const server = new McpServer({
+    name: "vardo",
+    version: "1.0.0",
+  });
+
+  registerAllTools(server, context);
+
+  return server;
+}

--- a/lib/mcp/tools/get-app-logs.ts
+++ b/lib/mcp/tools/get-app-logs.ts
@@ -1,0 +1,175 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import {
+  isLokiAvailable,
+  queryRange,
+  buildLogQLQuery,
+} from "@/lib/loki/client";
+import { listContainers, getContainerLogs } from "@/lib/docker/client";
+import type { McpAuthContext } from "../auth";
+
+export function registerGetAppLogs(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_get_app_logs",
+    "Get recent logs for an app. Uses Loki if available, falls back to Docker logs. Returns log lines with optional filtering by service, environment, or search term.",
+    {
+      appId: z.string().describe("The app ID to get logs for"),
+      lines: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .default(100)
+        .describe("Number of log lines to return (1-1000, default 100)"),
+      since: z
+        .string()
+        .default("1h")
+        .describe("Time range — e.g. '30m', '1h', '6h', '1d'"),
+      search: z
+        .string()
+        .optional()
+        .describe("Filter logs by search term (case-insensitive)"),
+      service: z
+        .string()
+        .optional()
+        .describe("Filter by service name (for compose apps)"),
+    },
+    async ({ appId, lines, since, search, service }) => {
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, name: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Try Loki first
+      if (await isLokiAvailable()) {
+        const query = buildLogQLQuery({
+          project: app.name,
+          service,
+          search,
+        });
+
+        const start = relativeToTimestamp(since);
+
+        const entries = await queryRange({
+          query,
+          start,
+          limit: lines,
+          direction: "backward",
+        });
+
+        entries.reverse();
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  source: "loki",
+                  app: app.name,
+                  lineCount: entries.length,
+                  logs: entries.map((e) => e.line).join("\n"),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      // Docker direct fallback
+      const containers = await listContainers(app.name);
+
+      if (containers.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                source: "docker",
+                app: app.name,
+                lineCount: 0,
+                logs: "No running containers found for this app.",
+              }),
+            },
+          ],
+        };
+      }
+
+      const allLogs: string[] = [];
+      for (const container of containers) {
+        try {
+          const log = await getContainerLogs(container.id, { tail: lines });
+          allLogs.push(`── ${container.name} ──`);
+          allLogs.push(log || "(no output)");
+          allLogs.push("");
+        } catch (err) {
+          allLogs.push(`── ${container.name} ──`);
+          allLogs.push(
+            `Error: ${err instanceof Error ? err.message : String(err)}`
+          );
+          allLogs.push("");
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                source: "docker",
+                app: app.name,
+                containerCount: containers.length,
+                logs: allLogs.join("\n"),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}
+
+function relativeToTimestamp(duration: string): string {
+  const match = duration.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    return String((Date.now() - 3600_000) * 1_000_000);
+  }
+
+  const value = parseInt(match[1]);
+  const unit = match[2];
+  const ms: Record<string, number> = {
+    s: 1000,
+    m: 60_000,
+    h: 3600_000,
+    d: 86400_000,
+  };
+
+  const ago = Date.now() - value * ms[unit];
+  return String(ago * 1_000_000);
+}

--- a/lib/mcp/tools/get-app-status.ts
+++ b/lib/mcp/tools/get-app-status.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import type { McpAuthContext } from "../auth";
+
+export function registerGetAppStatus(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_get_app_status",
+    "Get detailed status and configuration for a specific app. Includes recent deployments, domains, environments, and resource limits.",
+    {
+      appId: z.string().describe("The app ID to get status for"),
+    },
+    async ({ appId }) => {
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        with: {
+          deployments: {
+            columns: {
+              id: true,
+              status: true,
+              trigger: true,
+              startedAt: true,
+              finishedAt: true,
+            },
+            orderBy: (d, { desc }) => [desc(d.startedAt)],
+            limit: 5,
+          },
+          project: {
+            columns: { id: true, name: true, displayName: true },
+          },
+          domains: {
+            columns: { id: true, domain: true, sslEnabled: true },
+          },
+          environments: {
+            columns: { id: true, name: true, type: true, isDefault: true },
+          },
+        },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ app }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -1,0 +1,19 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpAuthContext } from "../auth";
+import { registerListApps } from "./list-apps";
+import { registerGetAppStatus } from "./get-app-status";
+import { registerGetAppLogs } from "./get-app-logs";
+import { registerListProjects } from "./list-projects";
+
+/**
+ * Register all MCP tools on the server instance.
+ */
+export function registerAllTools(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  registerListApps(server, context);
+  registerGetAppStatus(server, context);
+  registerGetAppLogs(server, context);
+  registerListProjects(server, context);
+}

--- a/lib/mcp/tools/list-apps.ts
+++ b/lib/mcp/tools/list-apps.ts
@@ -1,0 +1,68 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { desc, eq } from "drizzle-orm";
+import type { McpAuthContext } from "../auth";
+
+export function registerListApps(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_list_apps",
+    "List all apps in the organization. Returns app name, status, deploy type, project, and latest deployment info.",
+    {
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(50)
+        .describe("Max apps to return (1-100, default 50)"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Offset for pagination"),
+    },
+    async ({ limit, offset }) => {
+      const appList = await db.query.apps.findMany({
+        where: eq(apps.organizationId, context.organizationId),
+        with: {
+          deployments: {
+            columns: { id: true, status: true, startedAt: true },
+            orderBy: (d, { desc }) => [desc(d.startedAt)],
+            limit: 1,
+          },
+          project: {
+            columns: { id: true, name: true, displayName: true },
+          },
+        },
+        columns: {
+          id: true,
+          name: true,
+          displayName: true,
+          status: true,
+          deployType: true,
+          source: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy: [desc(apps.createdAt)],
+        limit,
+        offset,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ apps: appList, count: appList.length }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/list-projects.ts
+++ b/lib/mcp/tools/list-projects.ts
@@ -1,0 +1,40 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "@/lib/db";
+import { projects } from "@/lib/db/schema";
+import { desc, eq } from "drizzle-orm";
+import type { McpAuthContext } from "../auth";
+
+export function registerListProjects(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_list_projects",
+    "List all projects in the organization. Projects group related apps together. Returns project name, description, color, and the apps within each project.",
+    {},
+    async () => {
+      const projectList = await db.query.projects.findMany({
+        where: eq(projects.organizationId, context.organizationId),
+        with: {
+          apps: {
+            columns: { id: true, name: true, displayName: true, status: true },
+          },
+        },
+        orderBy: [desc(projects.createdAt)],
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { projects: projectList, count: projectList.length },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,7 +19,7 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,
   },
-  serverExternalPackages: ["node-ical", "nodemailer"],
+  serverExternalPackages: ["node-ical", "nodemailer", "@modelcontextprotocol/sdk"],
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@iarna/toml": "^2.2.5",
     "@lezer/highlight": "^1.2.3",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
     "@radix-ui/react-icons": "^1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
       '@octokit/auth-app':
         specifier: ^8.2.0
         version: 8.2.0
@@ -1706,8 +1709,8 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@modelcontextprotocol/sdk@1.26.0':
-    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -8887,7 +8890,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
@@ -8906,6 +8909,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.7)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.7
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -15013,7 +15038,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.52.0
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -15838,6 +15863,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a stateless MCP server at `POST /api/mcp` using the Streamable HTTP transport from `@modelcontextprotocol/sdk`
- Authenticated via existing API tokens (Bearer token → SHA-256 hash → `apiTokens` table lookup)
- Four read-only tools: `vardo_list_apps`, `vardo_get_app_status`, `vardo_get_app_logs`, `vardo_list_projects`
- Standalone auth layer (`lib/mcp/auth.ts`) that works without Next.js AsyncLocalStorage context

## How to test

```bash
# Start dev server
pnpm dev:console

# Create an API token via Settings → API Tokens in the UI

# Test with curl (JSON-RPC initialize)
curl -X POST http://localhost:3000/api/mcp \
  -H "Authorization: Bearer vardo_xxx" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'

# Add to Claude Code
claude mcp add --transport http \
  --header "Authorization: Bearer vardo_xxx" \
  vardo http://localhost:3000/api/mcp
```

## Architecture

```
lib/mcp/
  auth.ts              # Bearer token → { userId, organizationId }
  server.ts            # McpServer factory
  tools/
    list-apps.ts       # vardo_list_apps
    get-app-status.ts  # vardo_get_app_status
    get-app-logs.ts    # vardo_get_app_logs (Loki + Docker fallback)
    list-projects.ts   # vardo_list_projects
    index.ts           # registerAllTools barrel
app/api/mcp/route.ts   # POST/GET/DELETE handlers
```

## Out of scope (follow-up PRs)

- Mutation tools (deploy, restart, stop)
- Rate limiting on the MCP route (needs testing to find the right tier)
- Event store / resumability
- Integration tests

Closes #57