### PR TITLE
fix: rename remaining Host references to Vardo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,6 +16,6 @@ labels: bug
 3.
 
 ## Environment
-- Host version:
+- Vardo version:
 - OS:
 - Browser (if UI):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Host -- a self-hosted PaaS for managing Docker Compose deployments. Built on Next.js with a PostgreSQL + Redis backend.
+Vardo — a self-hosted PaaS for managing Docker Compose deployments. Built on Next.js with a PostgreSQL + Redis backend.
 
 ## Tech Stack
 

--- a/app/(authenticated)/admin/admin-system.tsx
+++ b/app/(authenticated)/admin/admin-system.tsx
@@ -37,7 +37,7 @@ export function AdminSystem() {
     <div className="space-y-4">
       {/* Runtime — always has data from process.* (instant) */}
       <div className="squircle rounded-lg border bg-card p-4">
-        <p className="text-xs text-muted-foreground mb-3">Host Runtime</p>
+        <p className="text-xs text-muted-foreground mb-3">Server Runtime</p>
         {data ? (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <div>

--- a/app/(authenticated)/settings/notification-channels.tsx
+++ b/app/(authenticated)/settings/notification-channels.tsx
@@ -38,7 +38,7 @@ const EVENT_LABELS: Record<BusEventType, string> = {
   "org.invitation-accepted": "Invitation accepted",
   "system.service-down": "Service down",
   "system.disk-alert": "Disk space alert",
-  "system.restart-loop": "Host restarted",
+  "system.restart-loop": "Vardo restarted",
   "system.cert-expiring": "Certificate expiring",
   "system.update-available": "Update available",
   "digest.weekly": "Weekly digest",

--- a/app/(authenticated)/settings/system-alerts.tsx
+++ b/app/(authenticated)/settings/system-alerts.tsx
@@ -43,7 +43,7 @@ function alertTypeLabel(type: string): string {
   const labels: Record<string, string> = {
     "service-degraded": "Service Degraded",
     "disk-space": "Disk Space",
-    "host-restarted": "Host Restarted",
+    "host-restarted": "Vardo Restarted",
     "cert-expiring": "Certificate Expiring",
     "update-available": "Update Available",
   };

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -34,7 +34,7 @@ export async function register() {
       backupTargetReady = ensureHostBackupTarget()
         .then(async (target) => {
           if (target) {
-            log.info(`Host backup target ready: ${target.name} (${target.type})`);
+            log.info(`Vardo backup target ready: ${target.name} (${target.type})`);
             // Create system backup job for Vardo's own database
             await ensureSystemBackupJob(target.id);
           } else {

--- a/lib/backup/auto-backup.ts
+++ b/lib/backup/auto-backup.ts
@@ -2,7 +2,7 @@
 // Auto-Backup Configuration
 //
 // Provides three capabilities:
-// 1. ensureHostBackupTarget() — on app startup, auto-creates a Host-level
+// 1. ensureHostBackupTarget() — on app startup, auto-creates a system-level
 //    backup target from config file or DB settings if none exists.
 // 2. ensureSystemBackupJob() — creates a backup job for Vardo's own
 //    PostgreSQL database, linked via a system volume with pg_dump strategy.
@@ -22,18 +22,18 @@ import { logger } from "@/lib/logger";
 const log = logger.child("auto-backup");
 
 // ---------------------------------------------------------------------------
-// 1. Host-level backup target from config
+// 1. System-level backup target from config
 // ---------------------------------------------------------------------------
 
 /**
- * Check if a Host-level backup target exists. If not, but backup storage
+ * Check if a system-level backup target exists. If not, but backup storage
  * is configured (via config file or DB), auto-create one. This is the
  * global safety-net target that any org can fall back to.
  *
- * Returns the Host-level target if one exists (or was created), null otherwise.
+ * Returns the system-level target if one exists (or was created), null otherwise.
  */
 export async function ensureHostBackupTarget() {
-  // Check if a Host-level target already exists (organizationId IS NULL)
+  // Check if a system-level target already exists (organizationId IS NULL)
   const existing = await db.query.backupTargets.findFirst({
     where: isNull(backupTargets.organizationId),
   });
@@ -73,13 +73,13 @@ export async function ensureHostBackupTarget() {
     secretAccessKey: string;
   };
 
-  log.info(`Creating Host-level backup target (${type}://${storageConfig.bucket})`);
+  log.info(`Creating system-level backup target (${type}://${storageConfig.bucket})`);
 
   const [target] = await db
     .insert(backupTargets)
     .values({
       id: nanoid(),
-      organizationId: null, // Host-level
+      organizationId: null, // system-level
       name: "System default",
       type,
       config,
@@ -208,7 +208,7 @@ function staggeredSchedule(seed: string): string {
 /**
  * Resolve the best backup target for an organization:
  * 1. Org-level default target (takes precedence)
- * 2. Host-level target (fallback safety net)
+ * 2. System-level target (fallback safety net)
  * Returns null if no target is configured anywhere.
  */
 export async function resolveBackupTarget(organizationId: string) {
@@ -239,7 +239,7 @@ export async function resolveBackupTarget(organizationId: string) {
 
 /**
  * After a deploy detects persistent volumes, check if the app already has a
- * backup job. If not and a backup target exists (org-level or Host-level),
+ * backup job. If not and a backup target exists (org-level or system-level),
  * auto-create a daily backup job.
  *
  * Returns the created job ID, or null if skipped.

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// Docker Compose generation and manipulation for Host projects.
+// Docker Compose generation and manipulation for Vardo projects.
 //
 // NOTE: This module includes a minimal YAML serializer/parser sufficient for
 // Docker Compose files. For production hardening, install `yaml` or `js-yaml`

--- a/lib/system-alerts/monitor.ts
+++ b/lib/system-alerts/monitor.ts
@@ -92,7 +92,7 @@ async function checkDiskAlerts(health: Awaited<ReturnType<typeof getSystemHealth
         await emitAll({
           type: "system.disk-alert",
           title: `Disk usage at ${Math.round(disk.percent)}%`,
-          message: `Host disk usage has reached ${Math.round(disk.percent)}% (threshold: ${threshold}%). Free up space to prevent service disruption.`,
+          message: `Vardo disk usage has reached ${Math.round(disk.percent)}% (threshold: ${threshold}%). Free up space to prevent service disruption.`,
           percent: disk.percent,
           threshold,
           severity: isCritical ? "critical" : "warning",
@@ -109,7 +109,7 @@ async function checkDiskAlerts(health: Awaited<ReturnType<typeof getSystemHealth
 }
 
 // ---------------------------------------------------------------------------
-// Host restart detection
+// Restart detection
 // ---------------------------------------------------------------------------
 
 // Process-level flag: only evaluate once per process lifetime to prevent
@@ -150,12 +150,12 @@ async function checkHostRestart(): Promise<void> {
 
     await emitAll({
       type: "system.restart-loop",
-      title: "Host restarted",
-      message: `The host process restarted. Current uptime: ${Math.round(uptimeSeconds)}s. All services are reinitializing.`,
+      title: "Vardo restarted",
+      message: `The Vardo process restarted. Current uptime: ${Math.round(uptimeSeconds)}s. All services are reinitializing.`,
       uptimeSeconds,
     });
   } catch (err) {
-    log.error("Host restart check error:", err);
+    log.error("Restart check error:", err);
   }
 
   // Always update last_known_uptime
@@ -272,8 +272,8 @@ async function checkUpdateAlert(): Promise<void> {
 
     await emitAll({
       type: "system.update-available",
-      title: "Host update available",
-      message: `A new version of Host is available. Remote: ${remoteHead.slice(0, 8)} — Local: ${localHead.slice(0, 8)}. Pull and redeploy when ready.`,
+      title: "Vardo update available",
+      message: `A new version of Vardo is available. Remote: ${remoteHead.slice(0, 8)} — Local: ${localHead.slice(0, 8)}. Pull and redeploy when ready.`,
       remoteHead: remoteHead.slice(0, 8),
       localHead: localHead.slice(0, 8),
     });


### PR DESCRIPTION
## Summary

- Renamed product references from "Host" to "Vardo" across log messages, UI strings, comments, and issue templates
- Changed "Host-level" backup terminology to "System-level" (these are system backups, not product-branded)
- Changed "Host Runtime" to "Server Runtime" in admin panel (refers to the server, not the product)

Intentionally left unchanged:
- Traefik `Host()` rules (hostname matching, not product name)
- SSH/SMTP "Host" field labels (network hostname)
- "Host Port" in ports manager (Docker port binding)
- `host_current_org` cookie name (requires a dedicated migration)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [ ] Verify alert notification text reads "Vardo restarted" / "Vardo update available" / "Vardo disk usage"
- [ ] Verify admin panel shows "Server Runtime" heading
- [ ] Verify notification channel editor shows "Vardo restarted" for system.restart-loop