### PR TITLE
feat: post-deploy security probe for exposed files

### DIFF
--- a/app/(authenticated)/settings/notification-channels.tsx
+++ b/app/(authenticated)/settings/notification-channels.tsx
@@ -21,6 +21,7 @@ const CATEGORY_LABELS: Record<EventCategory, string> = {
   volume: "Volume",
   disk: "Disk",
   org: "Organization",
+  security: "Security",
   system: "System",
   digest: "Digest",
 };
@@ -36,6 +37,7 @@ const EVENT_LABELS: Record<BusEventType, string> = {
   "disk.write-alert": "High disk writes",
   "org.invitation-sent": "Invitation sent",
   "org.invitation-accepted": "Invitation accepted",
+  "security.file-exposed": "Sensitive file exposed",
   "system.service-down": "Service down",
   "system.disk-alert": "Disk space alert",
   "system.restart-loop": "Vardo restarted",

--- a/lib/bus/events.ts
+++ b/lib/bus/events.ts
@@ -17,6 +17,7 @@ export const EVENT_CATEGORIES = {
   volume: ["volume.drift"],
   disk: ["disk.write-alert"],
   org: ["org.invitation-sent", "org.invitation-accepted"],
+  security: ["security.file-exposed"],
   system: [
     "system.service-down",
     "system.disk-alert",
@@ -184,6 +185,15 @@ export type SystemUpdateAvailableEvent = {
   localHead: string;
 };
 
+export type SecurityFileExposedEvent = {
+  type: "security.file-exposed";
+  title: string;
+  message: string;
+  appName: string;
+  domain: string;
+  exposedPaths: string[];
+};
+
 export type DigestWeeklyEvent = {
   type: "digest.weekly";
   title: string;
@@ -219,6 +229,7 @@ export type BusEvent =
   | SystemRestartLoopEvent
   | SystemCertExpiringEvent
   | SystemUpdateAvailableEvent
+  | SecurityFileExposedEvent
   | DigestWeeklyEvent;
 
 export type BusEventType = BusEvent["type"];

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1223,6 +1223,27 @@ async function sendDeployNotification(
         gitMessage: deployment?.gitMessage ?? undefined,
         triggeredBy: triggeredByName,
       });
+
+      // Post-deploy security probe — delayed to allow the app to become ready
+      if (domain) {
+        const probeDomain = domain;
+        setTimeout(async () => {
+          try {
+            const { checkFileExposure } = await import("@/lib/security/file-exposure");
+            const exposed = await checkFileExposure(probeDomain);
+            if (exposed.length > 0) {
+              emit(app.organizationId!, {
+                type: "security.file-exposed",
+                title: `Exposed files detected: ${projectName}`,
+                message: `${exposed.length} sensitive file(s) publicly accessible on ${probeDomain}: ${exposed.join(", ")}`,
+                appName: projectName,
+                domain: probeDomain,
+                exposedPaths: exposed,
+              });
+            }
+          } catch { /* probe failure is non-fatal */ }
+        }, 10_000);
+      }
     } else {
       emit(app.organizationId, {
         type: "deploy.failed",

--- a/lib/security/file-exposure.ts
+++ b/lib/security/file-exposure.ts
@@ -1,0 +1,75 @@
+import pLimit from "p-limit";
+import { logger } from "@/lib/logger";
+
+const log = logger.child("security");
+
+/**
+ * Paths to probe for sensitive file exposure after deploy.
+ * Each entry optionally includes a content heuristic — if provided,
+ * the response body must match for the path to count as exposed.
+ */
+const PROBE_PATHS: { path: string; heuristic?: (body: string) => boolean }[] = [
+  { path: "/.env", heuristic: (b) => b.includes("=") },
+  { path: "/.git/config", heuristic: (b) => b.includes("[core]") },
+  { path: "/.git/HEAD", heuristic: (b) => b.startsWith("ref:") || /^[0-9a-f]{40}/.test(b) },
+  { path: "/wp-config.php", heuristic: (b) => b.includes("DB_NAME") || b.includes("DB_PASSWORD") },
+  { path: "/.htaccess", heuristic: (b) => b.includes("RewriteEngine") || b.includes("Deny") },
+  { path: "/.DS_Store", heuristic: (b) => b.startsWith("\x00\x00\x00\x01Bud1") || b.length > 0 },
+  { path: "/server.key" },
+  { path: "/.ssh/id_rsa", heuristic: (b) => b.includes("PRIVATE KEY") },
+  { path: "/phpinfo.php", heuristic: (b) => b.includes("phpinfo()") || b.includes("PHP Version") },
+  { path: "/.svn/entries" },
+  { path: "/backup.sql", heuristic: (b) => b.includes("INSERT INTO") || b.includes("CREATE TABLE") },
+  { path: "/dump.sql", heuristic: (b) => b.includes("INSERT INTO") || b.includes("CREATE TABLE") },
+  { path: "/.npmrc", heuristic: (b) => b.includes("registry") || b.includes("//") },
+  { path: "/.docker/config.json", heuristic: (b) => b.includes("auths") },
+  { path: "/config.yml", heuristic: (b) => b.includes(":") },
+];
+
+const TIMEOUT_MS = 3_000;
+const CONCURRENCY = 5;
+
+/**
+ * Probe a deployed domain for commonly exposed sensitive files.
+ * Returns an array of paths that appear to be publicly accessible.
+ */
+export async function checkFileExposure(domain: string): Promise<string[]> {
+  const limit = pLimit(CONCURRENCY);
+  const exposed: string[] = [];
+
+  const tasks = PROBE_PATHS.map(({ path, heuristic }) =>
+    limit(async () => {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+        const res = await fetch(`https://${domain}${path}`, {
+          method: "GET",
+          redirect: "manual",
+          signal: controller.signal,
+        });
+
+        clearTimeout(timer);
+
+        if (res.status !== 200) return;
+
+        const body = await res.text();
+
+        if (heuristic) {
+          if (heuristic(body)) {
+            exposed.push(path);
+            log.warn(`Exposed file detected: https://${domain}${path}`);
+          }
+        } else if (body.length > 0) {
+          exposed.push(path);
+          log.warn(`Exposed file detected: https://${domain}${path}`);
+        }
+      } catch {
+        // Timeout or network error — not exposed
+      }
+    }),
+  );
+
+  await Promise.all(tasks);
+  return exposed;
+}


### PR DESCRIPTION
## Summary

- Adds `lib/security/file-exposure.ts` — probes 15 sensitive paths (`.env`, `.git/config`, `wp-config.php`, `backup.sql`, etc.) with content-based heuristics to avoid false positives
- Adds `security.file-exposed` bus event type and wires it into the notification channel settings UI
- Hooks into `sendDeployNotification` in `lib/docker/deploy.ts` — after a successful deploy, fires the probe on a 10s delay as a non-blocking background task

## How it works

After deploy success, if the app has a domain, a `setTimeout` fires the file exposure check. Probes run with `p-limit(5)` concurrency, 3s per-request timeout, and `redirect: "manual"` to avoid following redirects to login pages. Each path uses a content heuristic (e.g. `.env` must contain `=`, `.git/config` must contain `[core]`) so custom 404 pages that return 200 don't trigger false alerts.

If any paths are exposed, a `security.file-exposed` event is emitted through the existing bus/notification system.

## Test plan

- [ ] Deploy an app with a known `.env` file accessible — verify the event fires
- [ ] Deploy an app with proper file protection — verify no false positives
- [ ] Confirm `pnpm typecheck` and `pnpm build` pass

Partial fix for #343