### PR TITLE
fix: Docker GID detection — Dockerfile build fails on Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,9 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # without running as root. If the host's docker group uses a different GID,
 # override at runtime with: --group-add <host-docker-gid>
 RUN addgroup --system --gid 1001 nodejs && \
-    addgroup --system --gid 999 docker && \
     adduser --system --uid 1001 --ingroup nodejs nextjs && \
-    adduser nextjs docker && \
-    mkdir -p /var/lib/host/projects && \
-    chown nextjs:nodejs /var/lib/host/projects
+    mkdir -p /var/lib/vardo/projects && \
+    chown nextjs:nodejs /var/lib/vardo/projects
 
 # Copy standalone output (includes only needed node_modules)
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       REDIS_URL: redis://redis:6379
       NEXT_PUBLIC_BETTER_AUTH_URL: https://${VARDO_DOMAIN:-localhost}
       NEXT_PUBLIC_APP_URL: https://${VARDO_DOMAIN:-localhost}
-      VARDO_PROJECTS_DIR: /var/lib/host/projects
+      VARDO_PROJECTS_DIR: /var/lib/vardo/projects
       CADVISOR_URL: http://cadvisor:8080
       LOKI_URL: http://loki:3100
     healthcheck:
@@ -41,9 +41,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    group_add:
+      - ${DOCKER_GID:-999}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - host_projects:/var/lib/host/projects
+      - vardo_projects:/var/lib/vardo/projects
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.vardo.rule=Host(`${VARDO_DOMAIN:-localhost}`)"
@@ -210,7 +212,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
-  host_projects:
+  vardo_projects:
   letsencrypt:
   loki_data:
   wireguard_config:

--- a/install.sh
+++ b/install.sh
@@ -993,11 +993,16 @@ generate_env() {
     instance_id="${hex:0:8}-${hex:8:4}-4${hex:13:3}-$(printf '%x' $(( 0x${hex:16:2} & 0x3f | 0x80 )))${hex:18:2}-${hex:20:12}"
   fi
 
+  # Detect Docker group GID for socket access
+  local docker_gid
+  docker_gid=$(getent group docker 2>/dev/null | cut -d: -f3 || echo "999")
+
   if [[ "$VARDO_ROLE" == "development" ]]; then
     # Dev .env — minimal, no TLS/domain config
     cat > "$env_file" <<EOF
 VARDO_ROLE=development
 VARDO_INSTANCE_ID=$instance_id
+DOCKER_GID=$docker_gid
 DB_PASSWORD=$db_pass
 BETTER_AUTH_SECRET=$auth_secret
 ENCRYPTION_MASTER_KEY=$enc_key
@@ -1009,6 +1014,7 @@ EOF
 VARDO_ROLE=staging
 VARDO_INSTANCE_ID=$instance_id
 COMPOSE_PROFILES=production
+DOCKER_GID=$docker_gid
 DB_PASSWORD=$db_pass
 BETTER_AUTH_SECRET=$auth_secret
 ENCRYPTION_MASTER_KEY=$enc_key
@@ -1024,6 +1030,7 @@ EOF
 VARDO_ROLE=${VARDO_ROLE}
 VARDO_INSTANCE_ID=$instance_id
 COMPOSE_PROFILES=production
+DOCKER_GID=$docker_gid
 VARDO_DOMAIN=${VARDO_DOMAIN}
 VARDO_BASE_DOMAIN=${VARDO_BASE_DOMAIN}
 DB_PASSWORD=$db_pass


### PR DESCRIPTION
GID 999 is already taken by the docker group on Ubuntu 24.04. Instead of creating the group in the Dockerfile, detect the host's Docker GID at install time and pass it via group_add in docker-compose.yml. Also fixes stale host_projects volume name.