### PR TITLE
fix: frontend crash — postgres module missing from standalone build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/scripts/migrate.mjs ./scripts/migrate.mjs
+COPY --from=builder --chown=nextjs:nodejs /app/templates ./templates
+
+# Migration script imports postgres + drizzle-orm outside of Next.js trace
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/postgres ./node_modules/postgres
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
 
 USER nextjs
 


### PR DESCRIPTION
The migration script (scripts/migrate.mjs) imports postgres and drizzle-orm directly, but Next.js standalone mode only bundles modules it traces from app code. These need to be copied explicitly.