### PR TITLE
fix: drop Next.js standalone mode — regular build for reliability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,33 +24,26 @@ ENV NEXT_PUBLIC_PLAUSIBLE_SRC=$NEXT_PUBLIC_PLAUSIBLE_SRC
 
 RUN pnpm build
 
-# Production — standalone output, no node_modules needed
-FROM node:22-alpine AS runner
+# Production
+FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Create a non-root user for the Node process.
-# The docker group (GID 999) matches the conventional Docker socket GID on
-# Debian/Ubuntu hosts so the process can communicate with the mounted socket
-# without running as root. If the host's docker group uses a different GID,
-# override at runtime with: --group-add <host-docker-gid>
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 --ingroup nodejs nextjs && \
     mkdir -p /var/lib/vardo/projects && \
     chown nextjs:nodejs /var/lib/vardo/projects
 
-# Copy standalone output (includes only needed node_modules)
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Copy built app + all dependencies
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
-COPY --from=builder --chown=nextjs:nodejs /app/scripts/migrate.mjs ./scripts/migrate.mjs
 COPY --from=builder --chown=nextjs:nodejs /app/templates ./templates
-
-# Migration script imports postgres + drizzle-orm outside of Next.js trace
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules/postgres ./node_modules/postgres
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
+COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
+COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
 
 USER nextjs
 
@@ -58,4 +51,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "node scripts/migrate.mjs && node server.js"]
+CMD ["sh", "-c", "node scripts/migrate.mjs && npx next start"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,6 @@ try {
 }
 
 const nextConfig: NextConfig = {
-  output: "standalone",
   outputFileTracingRoot: resolve(__dirname),
   env: {
     NEXT_PUBLIC_GIT_SHA: gitSha,


### PR DESCRIPTION
Standalone mode excludes modules not traced from app code, causing crash loops (postgres, drizzle-orm missing). Regular build copies full node_modules. Bigger image but zero surprises. Standalone optimization can be revisited post-v1 with proper testing.