### PR TITLE
fix: GitHub App install callback + sync recovery

### DIFF
--- a/app/(authenticated)/user/settings/github-connection.tsx
+++ b/app/(authenticated)/user/settings/github-connection.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { Github, Loader2, ExternalLink, Trash2 } from "lucide-react";
+import { Github, Loader2, ExternalLink, Trash2, RefreshCw } from "lucide-react";
 import { toast } from "@/lib/messenger";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +23,7 @@ export function GitHubConnection() {
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
   const [removing, setRemoving] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
 
   // Show toast based on callback result
   useEffect(() => {
@@ -93,6 +94,29 @@ export function GitHubConnection() {
     }
   }
 
+  async function handleSync() {
+    setSyncing(true);
+    try {
+      const res = await fetch("/api/v1/github/installations/sync");
+      if (res.ok) {
+        const data = await res.json();
+        setInstallations(data.installations || []);
+        if (data.synced > 0) {
+          toast.success(`Synced ${data.synced} installation(s)`);
+        } else {
+          toast.info("No new installations found");
+        }
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to sync installations");
+      }
+    } catch {
+      toast.error("Failed to sync GitHub installations");
+    } finally {
+      setSyncing(false);
+    }
+  }
+
   return (
     <Card className="squircle rounded-lg">
       <CardHeader>
@@ -101,19 +125,34 @@ export function GitHubConnection() {
             <CardTitle>GitHub</CardTitle>
             <CardDescription>Link a GitHub account to deploy from private repos and enable auto-deploy on push.</CardDescription>
           </div>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={handleConnect}
-            disabled={connecting}
-          >
-            {connecting ? (
-              <Loader2 className="mr-1.5 size-4 animate-spin" />
-            ) : (
-              <Github className="mr-1.5 size-4" />
-            )}
-            Connect GitHub
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleSync}
+              disabled={syncing}
+              title="Sync existing installations from GitHub"
+            >
+              {syncing ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleConnect}
+              disabled={connecting}
+            >
+              {connecting ? (
+                <Loader2 className="mr-1.5 size-4 animate-spin" />
+              ) : (
+                <Github className="mr-1.5 size-4" />
+              )}
+              Connect GitHub
+            </Button>
+          </div>
         </div>
       </CardHeader>
       <CardContent>
@@ -127,6 +166,20 @@ export function GitHubConnection() {
           <p className="text-sm text-muted-foreground">
             No GitHub accounts connected yet.
           </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleSync}
+            disabled={syncing}
+            className="mt-2"
+          >
+            {syncing ? (
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1.5 size-4" />
+            )}
+            Sync existing installations
+          </Button>
         </div>
       ) : (
         <div className="space-y-2">

--- a/app/api/v1/github/connect/route.ts
+++ b/app/api/v1/github/connect/route.ts
@@ -19,7 +19,9 @@ export async function GET() {
     }
 
     const state = createInstallationState(session.user.id);
-    const url = `https://github.com/apps/${slug}/installations/new?state=${encodeURIComponent(state)}`;
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const redirectUri = `${appUrl}/api/v1/github/callback`;
+    const url = `https://github.com/apps/${slug}/installations/new?state=${encodeURIComponent(state)}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 
     return NextResponse.json({ url });
   } catch (error) {

--- a/app/api/v1/github/installations/sync/route.ts
+++ b/app/api/v1/github/installations/sync/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { handleRouteError } from "@/lib/api/error-response";
+import { db } from "@/lib/db";
+import { githubAppInstallations } from "@/lib/db/schema";
+import { requireSession } from "@/lib/auth/session";
+import { getAppOctokit } from "@/lib/github/app";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { logger } from "@/lib/logger";
+
+const log = logger.child("github-installations-sync");
+
+// GET /api/v1/github/installations/sync — Sync existing GitHub App installations for current user
+export async function GET() {
+  try {
+    const session = await requireSession();
+    const userId = session.user.id;
+
+    const octokit = await getAppOctokit();
+
+    // List all installations of this GitHub App
+    const { data } = await octokit.rest.apps.listInstallations({
+      per_page: 100,
+    });
+
+    // Get existing installations for this user
+    const existing = await db.query.githubAppInstallations.findMany({
+      where: eq(githubAppInstallations.userId, userId),
+    });
+    const existingIds = new Set(existing.map((i) => i.installationId));
+
+    let synced = 0;
+
+    for (const installation of data) {
+      if (existingIds.has(installation.id)) continue;
+
+      const account = installation.account;
+      if (!account) continue;
+
+      // Account type varies between User/Org and Enterprise
+      const acct = account as Record<string, unknown>;
+      const accountLogin =
+        (acct.login as string) ?? (acct.slug as string) ?? "unknown";
+      const accountType =
+        (acct.type as string) ?? "User";
+      const accountAvatarUrl =
+        (acct.avatar_url as string) || null;
+
+      await db
+        .insert(githubAppInstallations)
+        .values({
+          id: nanoid(),
+          userId,
+          installationId: installation.id,
+          accountLogin,
+          accountType,
+          accountAvatarUrl,
+        })
+        .onConflictDoUpdate({
+          target: [
+            githubAppInstallations.userId,
+            githubAppInstallations.installationId,
+          ],
+          set: {
+            accountLogin,
+            accountType,
+            accountAvatarUrl,
+            updatedAt: new Date(),
+          },
+        });
+
+      synced++;
+    }
+
+    log.info(`Synced ${synced} installation(s) for user ${userId}`);
+
+    // Return the updated list
+    const installations = await db.query.githubAppInstallations.findMany({
+      where: eq(githubAppInstallations.userId, userId),
+    });
+
+    return NextResponse.json({ installations, synced });
+  } catch (error) {
+    return handleRouteError(error, "Error syncing GitHub installations");
+  }
+}


### PR DESCRIPTION
## Summary

- **redirect_uri on install URL** — the connect endpoint now includes `redirect_uri` so GitHub sends users back to the correct Vardo instance instead of falling back to the first callback URL in the App settings (which may be localhost).
- **Sync endpoint** — `GET /api/v1/github/installations/sync` uses the App JWT to list all installations from GitHub and upserts any missing ones for the current user. This is the recovery path when the App is already installed and GitHub shows "already installed" without triggering the callback.
- **UI sync button** — added to both the header and the empty state of the GitHub connection card so users can recover without reinstalling.

## Test plan

- [ ] Install the GitHub App on a fresh account — verify the callback URL matches the Vardo instance
- [ ] With an existing installation not in the DB, click "Sync existing installations" — verify it appears
- [ ] With all installations already synced, click sync — verify "No new installations found" toast
- [ ] Verify typecheck, lint (on changed files), and build all pass

Closes #442