### PR TITLE
fix: nixpacks install needs bash on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,9 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # - docker-cli: container management, compose operations
 # - curl: health checks, API calls
 # - nixpacks: buildpack deploys (auto-detect language, build image)
-RUN apk add --no-cache git docker-cli curl && \
+RUN apk add --no-cache git docker-cli curl bash && \
     curl -sSL https://nixpacks.com/install.sh | bash && \
+    apk del bash && \
     addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 --ingroup nodejs nextjs && \
     mkdir -p /var/lib/vardo/projects && \


### PR DESCRIPTION
The nixpacks install script requires bash. Install it, run the script, remove it.