### PR TITLE
fix: build tools run as containers — no more binary installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Runtime dependencies for the deploy engine
+# Runtime dependencies — git for cloning, docker-cli for orchestrating builds/deploys
+# Build tools (nixpacks, railpack) run as separate containers, not installed here
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends git docker.io curl && \
-    curl -sSL https://nixpacks.com/install.sh | bash && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 nodejs && \
     useradd --system --uid 1001 --gid nodejs nextjs && \

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1282,32 +1282,44 @@ async function buildFromRepo(
   const buildEnv = { ...process.env, ...envVars };
 
   if (deployType === "nixpacks") {
-    logs.push(`[build] Building with Nixpacks...`);
+    logs.push(`[build] Building with Nixpacks (container)...`);
 
-    const args = ["build", repoPath, "--name", imageName];
+    // Run nixpacks as a container — mount repo dir and Docker socket
+    const args = [
+      "run", "--rm",
+      "-v", `${repoPath}:/workspace`,
+      "-v", "/var/run/docker.sock:/var/run/docker.sock",
+      "ghcr.io/railwayapp/nixpacks:latest",
+      "build", "/workspace", "--name", imageName,
+    ];
     if (envVars) {
       for (const [k, v] of Object.entries(envVars)) {
         args.push("--env", `${k}=${v}`);
       }
     }
 
-    await spawnStream("nixpacks", args, { cwd: repoPath, env: buildEnv }, logs, "[build][nixpacks]");
+    await spawnStream("docker", args, { env: buildEnv }, logs, "[build][nixpacks]");
     logs.push(`[build] Nixpacks build complete: ${imageName}`);
     return;
   }
 
   if (deployType === "railpack") {
-    logs.push(`[build] Building with Railpack...`);
+    logs.push(`[build] Building with Railpack (container)...`);
 
-    const args = ["build", "--name", imageName];
+    const args = [
+      "run", "--rm",
+      "-v", `${repoPath}:/workspace`,
+      "-v", "/var/run/docker.sock:/var/run/docker.sock",
+      "ghcr.io/railwayapp/railpack:latest",
+      "build", "--name", imageName, "/workspace",
+    ];
     if (envVars) {
       for (const [k, v] of Object.entries(envVars)) {
         args.push("--env", `${k}=${v}`);
       }
     }
-    args.push(repoPath);
 
-    await spawnStream("railpack", args, { cwd: repoPath, env: buildEnv }, logs, "[build][railpack]");
+    await spawnStream("docker", args, { env: buildEnv }, logs, "[build][railpack]");
     logs.push(`[build] Railpack build complete: ${imageName}`);
     return;
   }


### PR DESCRIPTION
Nixpacks and Railpack now run as docker containers (ghcr.io/railwayapp/nixpacks, ghcr.io/railwayapp/railpack) instead of binaries installed in the Vardo image. The repo dir and Docker socket are mounted in. This keeps the Vardo container thin and avoids alpine/musl compatibility issues.