### PR TITLE
fix: health check uses curl after switch to slim

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       CADVISOR_URL: http://cadvisor:8080
       LOKI_URL: http://loki:3100
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Switched from alpine (wget) to slim (curl) but didn't update the compose healthcheck.