### PR TITLE
fix: git clone fails — missing CA certificates in slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Runtime dependencies — git for cloning, docker-cli for orchestrating builds/deploys
 # Build tools (nixpacks, railpack) run as separate containers, not installed here
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends git docker.io curl && \
+    apt-get install -y --no-install-recommends git docker.io curl ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 nodejs && \
     useradd --system --uid 1001 --gid nodejs nextjs && \


### PR DESCRIPTION
ca-certificates needed for HTTPS git clones.