### PR TITLE
fix: revert containerized builds — nixpacks doesn't publish a CLI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Build tools (nixpacks, railpack) run as separate containers, not installed here
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends git docker.io curl ca-certificates && \
+    curl -sSL https://nixpacks.com/install.sh | bash && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 nodejs && \
     useradd --system --uid 1001 --gid nodejs nextjs && \

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -1282,44 +1282,32 @@ async function buildFromRepo(
   const buildEnv = { ...process.env, ...envVars };
 
   if (deployType === "nixpacks") {
-    logs.push(`[build] Building with Nixpacks (container)...`);
+    logs.push(`[build] Building with Nixpacks...`);
 
-    // Run nixpacks as a container — mount repo dir and Docker socket
-    const args = [
-      "run", "--rm",
-      "-v", `${repoPath}:/workspace`,
-      "-v", "/var/run/docker.sock:/var/run/docker.sock",
-      "ghcr.io/railwayapp/nixpacks:latest",
-      "build", "/workspace", "--name", imageName,
-    ];
+    const args = ["build", repoPath, "--name", imageName];
     if (envVars) {
       for (const [k, v] of Object.entries(envVars)) {
         args.push("--env", `${k}=${v}`);
       }
     }
 
-    await spawnStream("docker", args, { env: buildEnv }, logs, "[build][nixpacks]");
+    await spawnStream("nixpacks", args, { cwd: repoPath, env: buildEnv }, logs, "[build][nixpacks]");
     logs.push(`[build] Nixpacks build complete: ${imageName}`);
     return;
   }
 
   if (deployType === "railpack") {
-    logs.push(`[build] Building with Railpack (container)...`);
+    logs.push(`[build] Building with Railpack...`);
 
-    const args = [
-      "run", "--rm",
-      "-v", `${repoPath}:/workspace`,
-      "-v", "/var/run/docker.sock:/var/run/docker.sock",
-      "ghcr.io/railwayapp/railpack:latest",
-      "build", "--name", imageName, "/workspace",
-    ];
+    const args = ["build", "--name", imageName];
     if (envVars) {
       for (const [k, v] of Object.entries(envVars)) {
         args.push("--env", `${k}=${v}`);
       }
     }
+    args.push(repoPath);
 
-    await spawnStream("docker", args, { env: buildEnv }, logs, "[build][railpack]");
+    await spawnStream("railpack", args, { cwd: repoPath, env: buildEnv }, logs, "[build][railpack]");
     logs.push(`[build] Railpack build complete: ${imageName}`);
     return;
   }


### PR DESCRIPTION
Nixpacks and Railpack don't publish their CLI as Docker images. The ghcr.io/railwayapp/nixpacks image is the builder base, not the CLI. Install them as binaries in the Vardo image instead.