### PR TITLE
fix: deploys fail — docker compose plugin missing from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Runtime dependencies — git for cloning, docker-cli for orchestrating builds/deploys
 # Build tools (nixpacks, railpack) run as separate containers, not installed here
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends git docker.io curl ca-certificates && \
+    apt-get install -y --no-install-recommends git docker.io docker-compose-plugin curl ca-certificates && \
     curl -sSL https://nixpacks.com/install.sh | bash && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 nodejs && \


### PR DESCRIPTION
The deploy engine runs docker compose for blue-green deploys. The slim image only had docker.io (base CLI) without the compose plugin.