### PR TITLE
fix: docker-compose-plugin not in Debian repos — install binary directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Runtime dependencies — git for cloning, docker-cli for orchestrating builds/deploys
 # Build tools (nixpacks, railpack) run as separate containers, not installed here
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends git docker.io docker-compose-plugin curl ca-certificates && \
+    apt-get install -y --no-install-recommends git docker.io curl ca-certificates && \
     curl -sSL https://nixpacks.com/install.sh | bash && \
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -sSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 nodejs && \
     useradd --system --uid 1001 --gid nodejs --create-home nextjs && \


### PR DESCRIPTION
Debian doesn't ship docker-compose-plugin. Download the binary from Docker's GitHub releases.