### PR TITLE
fix: Traefik routing broken with multiple domains — shared service

### DIFF
--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -115,6 +115,7 @@ export function injectTraefikLabels(
     domain: string;
     containerPort: number;
     serviceName?: string;
+    appName?: string;
     certResolver?: string;
     ssl?: boolean;
   },
@@ -136,8 +137,11 @@ export function injectTraefikLabels(
     ...existing.labels,
     "traefik.enable": "true",
     [`traefik.http.routers.${projectName}.rule`]: `Host(\`${domain}\`)`,
-    [`traefik.http.services.${projectName}.loadbalancer.server.port`]:
+    // All domains share one Traefik service — keyed by app name, not per-domain router name
+    [`traefik.http.services.${opts.appName || projectName}.loadbalancer.server.port`]:
       String(containerPort),
+    // Explicitly link this router to the shared service
+    [`traefik.http.routers.${projectName}.service`]: opts.appName || projectName,
   };
 
   if (ssl) {

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -598,6 +598,7 @@ export async function runDeployment(
       const port = domain.port || containerPort;
       compose = injectTraefikLabels(compose, {
         projectName: `${app.name}-${domain.id.slice(0, 6)}`,
+        appName: app.name,
         domain: domain.domain,
         containerPort: port,
         certResolver: domain.certResolver || "le",


### PR DESCRIPTION
Each domain was creating its own Traefik service. Traefik couldn't auto-link routers to services when multiple existed. Now all domains share one service keyed by app name.