### PR TITLE
fix: HTTP redirect routers missing shared service link

### DIFF
--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -163,6 +163,7 @@ export function injectTraefikLabels(
     labels[`traefik.http.middlewares.${projectName}-https-redirect.redirectscheme.scheme`] = "https";
     labels[`traefik.http.middlewares.${projectName}-https-redirect.redirectscheme.permanent`] = "true";
     labels[`traefik.http.routers.${projectName}-http.middlewares`] = `${projectName}-https-redirect`;
+    labels[`traefik.http.routers.${projectName}-http.service`] = opts.appName || projectName;
   } else {
     // HTTP only — web entrypoint, no TLS
     labels[`traefik.http.routers.${projectName}.entrypoints`] = "web";


### PR DESCRIPTION
Reviewer caught that only HTTPS routers got the explicit .service label. HTTP redirect routers also need it for multi-domain apps.