### PR TITLE
fix: vardo wrapper updates itself during vardo update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1435,6 +1435,9 @@ do_update() {
 _do_rebuild() {
   step "Rebuilding"
 
+  # Refresh the /usr/local/bin/vardo wrapper so it picks up new commands/fixes
+  install_shortcut
+
   # Migrate ACME storage from single file to per-resolver files
   local acme_vol
   acme_vol=$(docker volume inspect vardo_letsencrypt --format '{{ .Mountpoint }}' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Calls `install_shortcut` at the top of `_do_rebuild()` so every `vardo update` regenerates the `/usr/local/bin/vardo` wrapper script
- Previously the wrapper was only written during initial install, meaning new commands and bug fixes in the wrapper never reached existing users

Closes #474