### PR TITLE
fix: clean up stale repo directory before git clone

### DIFF
--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -9,7 +9,7 @@ import { nanoid } from "nanoid";
 import { publishEvent, appChannel } from "@/lib/events";
 import { execFile, spawn as nodeSpawn} from "child_process";
 import { promisify } from "util";
-import { mkdir, writeFile, readFile } from "fs/promises";
+import { mkdir, writeFile, readFile, rm } from "fs/promises";
 import { join, resolve } from "path";
 import {
   generateComposeForImage,
@@ -328,6 +328,8 @@ export async function runDeployment(
           await execFileAsync("git", ["-C", repoDir, "reset", "--hard", `origin/${branch}`], execOpts);
           log(`[deploy] Pulled latest from ${branch}`);
         } catch {
+          // Remove stale repo directory left behind by a previously failed clone
+          await rm(repoDir, { recursive: true, force: true });
           // Fresh clone
           await execFileAsync("git", ["clone", "--depth", "1", "--branch", branch, cloneUrl, repoDir], execOpts);
           log(`[deploy] Cloned repo (${branch})`);


### PR DESCRIPTION
## Summary

- Removes stale repo directory before attempting a fresh `git clone` during deploy
- Fixes the case where a previously failed deploy leaves behind a corrupt/partial repo directory, causing all subsequent deploys to fail with "destination path already exists and is not an empty directory"

## What changed

In `lib/docker/deploy.ts`, added `await rm(repoDir, { recursive: true, force: true })` before the `git clone` fallback. The `force` flag means it's a no-op if the directory doesn't exist.

## Test plan

- [ ] Deploy an app with git source — should clone normally on first deploy
- [ ] Simulate a failed clone (kill mid-deploy) — next deploy should succeed by cleaning up the stale directory
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes

Closes #454