### PR TITLE
fix: sweep stuck deployments + expandable deploying card

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import {
   Loader2,
   Rocket,
@@ -93,6 +93,8 @@ export const AppDeployPanel = forwardRef<AppDeployPanelHandle, AppDeployPanelPro
     handleRollbackConfirm,
   } = deploy;
 
+  const [expandedServerDeploy, setExpandedServerDeploy] = useState(false);
+
   useImperativeHandle(ref, () => ({
     handleDeploy: deploy.handleDeploy,
     setViewingLogId: deploy.setViewingLogId,
@@ -129,10 +131,10 @@ export const AppDeployPanel = forwardRef<AppDeployPanelHandle, AppDeployPanelPro
             {!deploying && serverRunningDeploy && (
               <InProgressDeployCard
                 stages={{}}
-                log={[]}
+                log={serverRunningDeploy.log ? serverRunningDeploy.log.split("\n") : []}
                 startTime={new Date(serverRunningDeploy.startedAt).getTime()}
-                expanded={false}
-                onToggleExpand={() => {}}
+                expanded={expandedServerDeploy}
+                onToggleExpand={() => setExpandedServerDeploy((prev) => !prev)}
                 trigger={serverRunningDeploy.trigger}
               />
             )}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -93,6 +93,13 @@ export async function register() {
         })
         .catch((err) => log.error("Failed to start digest scheduler:", err)),
 
+      import("./lib/deploy/scheduler")
+        .then(({ startDeploySweeper }) => {
+          startDeploySweeper();
+          log.info("Deploy sweeper started");
+        })
+        .catch((err) => log.error("Failed to start deploy sweeper:", err)),
+
       Promise.resolve().then(() => {
         const domainLog = logger.child("domain-monitor");
         let ticking = false;

--- a/lib/deploy/scheduler.ts
+++ b/lib/deploy/scheduler.ts
@@ -1,0 +1,27 @@
+import { sweepStuckDeployments } from "./sweeper";
+import { logger } from "@/lib/logger";
+
+const log = logger.child("deploy-sweeper");
+
+let interval: NodeJS.Timeout | null = null;
+
+export function startDeploySweeper(): void {
+  if (interval) return; // Already running
+
+  log.info("Deploy sweeper started (60s interval)");
+  interval = setInterval(async () => {
+    try {
+      await sweepStuckDeployments();
+    } catch (err) {
+      log.error("Sweep error:", err);
+    }
+  }, 60_000); // Every minute
+}
+
+export function stopDeploySweeper(): void {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+    log.info("Deploy sweeper stopped");
+  }
+}

--- a/lib/deploy/sweeper.ts
+++ b/lib/deploy/sweeper.ts
@@ -1,0 +1,113 @@
+import { db } from "@/lib/db";
+import { deployments } from "@/lib/db/schema/apps";
+import { apps } from "@/lib/db/schema/apps";
+import { publishEvent, appChannel } from "@/lib/events";
+import { acquireLock } from "@/lib/redis-lock";
+import { logger } from "@/lib/logger";
+import { eq, and, lt } from "drizzle-orm";
+
+const log = logger.child("deploy-sweeper");
+
+const TIMEOUT_MINUTES = Number(process.env.DEPLOY_TIMEOUT_MINUTES) || 15;
+
+/**
+ * Find deployments stuck in "running" status for longer than the timeout
+ * threshold and mark them as failed.
+ */
+export async function sweepStuckDeployments(): Promise<void> {
+  const cutoff = new Date(Date.now() - TIMEOUT_MINUTES * 60_000);
+
+  const stuck = await db
+    .select({
+      id: deployments.id,
+      appId: deployments.appId,
+      log: deployments.log,
+      startedAt: deployments.startedAt,
+    })
+    .from(deployments)
+    .where(
+      and(
+        eq(deployments.status, "running"),
+        lt(deployments.startedAt, cutoff),
+      ),
+    );
+
+  if (stuck.length === 0) return;
+
+  log.info(`Found ${stuck.length} stuck deployment(s)`);
+
+  for (const deploy of stuck) {
+    // Distributed lock prevents double-processing across instances
+    const lockKey = `sweep:deploy:${deploy.id}`;
+    const acquired = await acquireLock(lockKey, 60_000);
+    if (!acquired) continue;
+
+    try {
+      const now = new Date();
+      const timeoutLine = `[${now.toISOString()}] [TIMEOUT] Deployment timed out after ${TIMEOUT_MINUTES} minutes`;
+      const updatedLog = deploy.log
+        ? `${deploy.log}\n${timeoutLine}`
+        : timeoutLine;
+
+      const durationMs = now.getTime() - new Date(deploy.startedAt).getTime();
+
+      await db
+        .update(deployments)
+        .set({
+          status: "failed",
+          log: updatedLog,
+          finishedAt: now,
+          durationMs,
+        })
+        .where(
+          and(eq(deployments.id, deploy.id), eq(deployments.status, "running")),
+        );
+
+      // Reset the app status if it's still "deploying"
+      await db
+        .update(apps)
+        .set({ status: "stopped", updatedAt: now })
+        .where(
+          and(eq(apps.id, deploy.appId), eq(apps.status, "deploying")),
+        );
+
+      // Notify any connected SSE clients
+      publishEvent(appChannel(deploy.appId), {
+        event: "deploy:complete",
+        status: "error",
+        deploymentId: deploy.id,
+        success: false,
+        durationMs,
+      }).catch(() => {});
+
+      // Emit notification
+      try {
+        const { emit } = await import("@/lib/notifications/dispatch");
+        const app = await db.query.apps.findFirst({
+          where: eq(apps.id, deploy.appId),
+          columns: { organizationId: true, name: true, displayName: true },
+        });
+        if (app) {
+          const projectName = app.displayName || app.name;
+          emit(app.organizationId, {
+            type: "deploy.failed",
+            title: `Deploy timed out: ${projectName}`,
+            message: `Deployment exceeded the ${TIMEOUT_MINUTES}-minute timeout and was marked as failed.`,
+            projectName,
+            appId: deploy.appId,
+            deploymentId: deploy.id,
+            errorMessage: `Deployment timed out after ${TIMEOUT_MINUTES} minutes`,
+          });
+        }
+      } catch {
+        // notification failure is non-fatal
+      }
+
+      log.info(
+        `Marked deployment ${deploy.id} (app ${deploy.appId}) as failed — timed out after ${TIMEOUT_MINUTES}m`,
+      );
+    } catch (err) {
+      log.error(`Failed to sweep deployment ${deploy.id}:`, err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a background deploy sweeper (`lib/deploy/sweeper.ts` + `lib/deploy/scheduler.ts`) that runs every 60s, finds deployments stuck in `running` status for >15 minutes, and marks them `failed` with a timeout log message. Resets the parent app status from `deploying`, publishes `deploy:complete` for SSE clients, and fires a deploy.failed notification.
- Makes the server-side "Deploying" card expandable — passes the deployment's existing log and wires up expand/collapse toggle so users can inspect partial logs before the SSE stream connects.

## Test plan

- [ ] Verify sweeper catches deployments with `status = 'running'` and `started_at` older than 15 minutes
- [ ] Confirm the app status resets from `deploying` to `stopped` after sweep
- [ ] Confirm SSE clients receive `deploy:complete` event after sweep
- [ ] Confirm the deploying card for server-side running deploys shows a chevron and expands to show logs
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes

Closes #473