### PR TITLE
fix: broken session system — empty user data, sign out not working

### DIFF
--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -207,12 +207,20 @@ function buildAuth() {
 
 // Lazy singleton — rebuilt when GitHub credentials change via refreshGitHubOAuthCredentials()
 type AuthInstance = ReturnType<typeof buildAuth>;
+
+function getAuthInstance(): AuthInstance {
+  if (!_authInstance) {
+    _authInstance = buildAuth();
+  }
+  return _authInstance;
+}
+
 export const auth = new Proxy({} as AuthInstance, {
-  get(_target, prop, receiver) {
-    if (!_authInstance) {
-      _authInstance = buildAuth();
-    }
-    return Reflect.get(_authInstance, prop, receiver);
+  get(_target, prop) {
+    return Reflect.get(getAuthInstance(), prop, getAuthInstance());
+  },
+  has(_target, prop) {
+    return Reflect.has(getAuthInstance(), prop);
   },
 });
 


### PR DESCRIPTION
## Summary

The lazy `Proxy` wrapping the Better Auth instance (added in PR #436 for dynamic GitHub OAuth) was missing a `has` trap and passing the wrong `receiver` to `Reflect.get`. This broke all auth API routes:

- `toNextJsHandler` uses `"handler" in auth` — without a `has` trap, this checked the empty proxy target `{}`, returned `false`, and tried to call the proxy as a function instead of using `auth.handler()`
- `Reflect.get` passed the proxy as `receiver` instead of the real auth instance, breaking `this` context in Better Auth internals

Every request to `/api/auth/[...all]` was failing silently. The client `useSession()` hook received empty data, which cascaded into: empty profile fields, "User" fallback in the nav, missing `isAppAdmin` (no admin nav), broken sign out, broken profile save.

## Fix

- Add `has` trap to the auth Proxy so `"handler" in auth` correctly delegates to the real Better Auth instance
- Pass the real instance as `receiver` in `Reflect.get` so `this` context is correct
- Extract `getAuthInstance()` helper to consolidate the lazy-init logic

## Test plan

- [ ] Sign in — session should load with name, email, isAppAdmin
- [ ] User menu shows actual name, not "User"
- [ ] Profile page shows populated Name and Email fields
- [ ] Profile name update saves without error
- [ ] Admin nav appears for app admins
- [ ] Sign out redirects to login
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes

Closes #482