### PR TITLE
fix: domain settings editable from admin UI

### DIFF
--- a/app/(authenticated)/admin/settings/domain-settings.tsx
+++ b/app/(authenticated)/admin/settings/domain-settings.tsx
@@ -32,6 +32,8 @@ type DnsCheck = {
 type InstanceData = {
   baseDomain: string;
   serverIp: string;
+  domain: string;
+  instanceName: string;
 };
 
 const ISSUER_LABELS: Record<string, string> = {
@@ -49,9 +51,9 @@ function toDisplay(value: string): string {
 
 export function DomainSettings() {
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [checking, setChecking] = useState(false);
-  const [instance, setInstance] = useState<InstanceData>({ baseDomain: "", serverIp: "" });
-  const [hostDomain, setHostDomain] = useState("");
+  const [instance, setInstance] = useState<InstanceData>({ baseDomain: "", serverIp: "", domain: "", instanceName: "" });
   const [acmeEmail, setAcmeEmail] = useState("");
   const [dnsChecks, setDnsChecks] = useState<DnsCheck[]>([]);
 
@@ -84,6 +86,8 @@ export function DomainSettings() {
           setInstance({
             baseDomain: data.baseDomain ?? "",
             serverIp: data.serverIp ?? "",
+            domain: data.domain ?? "",
+            instanceName: data.instanceName ?? "",
           });
         }
 
@@ -91,7 +95,7 @@ export function DomainSettings() {
           const data = await dnsRes.json();
           setDnsChecks(data.checks ?? []);
           if (data.serverIp) {
-            setInstance((prev) => ({ ...prev, serverIp: data.serverIp }));
+            setInstance((prev) => ({ ...prev, serverIp: prev.serverIp || data.serverIp }));
           }
         }
       } catch {
@@ -101,11 +105,37 @@ export function DomainSettings() {
       }
     })();
 
-    // These are only available server-side via env vars, so we infer from
-    // the general endpoint or accept them as empty in dev
-    setHostDomain(typeof window !== "undefined" ? window.location.hostname : "");
     setAcmeEmail(process.env.NEXT_PUBLIC_ACME_EMAIL ?? "");
   }, []);
+
+  async function saveDomainSettings() {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/setup/general", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instanceName: instance.instanceName,
+          baseDomain: instance.baseDomain,
+          serverIp: instance.serverIp,
+          domain: instance.domain,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+      const { toast } = await import("sonner");
+      toast.success("Domain settings saved");
+      // Re-check DNS with updated values
+      recheckDns();
+    } catch (err) {
+      const { toast } = await import("sonner");
+      toast.error(err instanceof Error ? err.message : "Failed to save domain settings");
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function recheckDns() {
     setChecking(true);
@@ -140,7 +170,7 @@ export function DomainSettings() {
         </p>
       </div>
 
-      {/* Domain configuration (read-only) */}
+      {/* Domain configuration */}
       <Card className="squircle rounded-lg">
         <CardHeader>
           <CardTitle className="text-sm">Domain info</CardTitle>
@@ -150,12 +180,12 @@ export function DomainSettings() {
             <Label htmlFor="sys-host-domain">Primary domain</Label>
             <Input
               id="sys-host-domain"
-              value={hostDomain || "Not configured"}
-              disabled
-              className="bg-muted"
+              value={instance.domain}
+              onChange={(e) => setInstance((prev) => ({ ...prev, domain: e.target.value }))}
+              placeholder="vardo.example.com"
             />
             <p className="text-xs text-muted-foreground">
-              Set at install time via the VARDO_DOMAIN environment variable.
+              The domain where this Vardo instance is accessible.
             </p>
           </div>
 
@@ -163,9 +193,9 @@ export function DomainSettings() {
             <Label htmlFor="sys-base-domain-dns">Base domain</Label>
             <Input
               id="sys-base-domain-dns"
-              value={instance.baseDomain || "Not configured"}
-              disabled
-              className="bg-muted"
+              value={instance.baseDomain}
+              onChange={(e) => setInstance((prev) => ({ ...prev, baseDomain: e.target.value }))}
+              placeholder="example.com"
             />
             <p className="text-xs text-muted-foreground">
               Wildcard domain used for auto-generated app subdomains.
@@ -176,10 +206,13 @@ export function DomainSettings() {
             <Label htmlFor="sys-server-ip-dns">Server IP</Label>
             <Input
               id="sys-server-ip-dns"
-              value={instance.serverIp || "Not configured"}
-              disabled
-              className="bg-muted"
+              value={instance.serverIp}
+              onChange={(e) => setInstance((prev) => ({ ...prev, serverIp: e.target.value }))}
+              placeholder="203.0.113.1"
             />
+            <p className="text-xs text-muted-foreground">
+              Public IP address of this server. DNS A records should point here.
+            </p>
           </div>
 
           {acmeEmail && (
@@ -196,6 +229,18 @@ export function DomainSettings() {
               </p>
             </div>
           )}
+
+          <Button
+            className="squircle"
+            onClick={saveDomainSettings}
+            disabled={saving}
+          >
+            {saving ? (
+              <><Loader2 className="mr-2 size-4 animate-spin" />Saving...</>
+            ) : (
+              "Save"
+            )}
+          </Button>
         </CardContent>
       </Card>
 

--- a/app/(public)/setup/setup-wizard.tsx
+++ b/app/(public)/setup/setup-wizard.tsx
@@ -1084,16 +1084,83 @@ function DomainStep({
   onComplete: () => void;
   onSkip: () => void;
 }) {
+  const [domain, setDomain] = useState("");
+  const [baseDomain, setBaseDomain] = useState("");
+  const [serverIp, setServerIp] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      // Fetch existing config to preserve instanceName
+      const existing = await fetch("/api/setup/general").then((r) => r.json()).catch(() => ({}));
+      const res = await fetch("/api/setup/general", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instanceName: existing.instanceName || "Vardo",
+          domain: domain || undefined,
+          baseDomain: baseDomain || undefined,
+          serverIp: serverIp || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      onComplete();
+    } catch {
+      toast.error("Failed to save domain settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <div className="space-y-4">
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="setup-domain">Primary domain</Label>
+          <Input
+            id="setup-domain"
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+            placeholder="vardo.example.com"
+          />
+          <p className="text-xs text-muted-foreground">
+            The domain where this Vardo instance will be accessible.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="setup-base-domain">Base domain</Label>
+          <Input
+            id="setup-base-domain"
+            value={baseDomain}
+            onChange={(e) => setBaseDomain(e.target.value)}
+            placeholder="example.com"
+          />
+          <p className="text-xs text-muted-foreground">
+            Wildcard domain for auto-generated app subdomains.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="setup-server-ip">Server IP</Label>
+          <Input
+            id="setup-server-ip"
+            value={serverIp}
+            onChange={(e) => setServerIp(e.target.value)}
+            placeholder="203.0.113.1"
+          />
+          <p className="text-xs text-muted-foreground">
+            Public IP of this server. Point your DNS A records here.
+          </p>
+        </div>
+      </div>
       <div className="rounded-lg border p-4 space-y-3">
         <div className="text-sm font-medium">Required DNS records</div>
         <div className="space-y-1 font-mono text-xs text-muted-foreground">
           <div>
-            A &nbsp;&nbsp; your-domain.com &nbsp;&nbsp; → &nbsp; this server IP
+            A &nbsp;&nbsp; {baseDomain || "your-domain.com"} &nbsp;&nbsp; → &nbsp; {serverIp || "your server IP"}
           </div>
           <div>
-            A &nbsp;&nbsp; *.your-domain.com → &nbsp; this server IP
+            A &nbsp;&nbsp; *.{baseDomain || "your-domain.com"} → &nbsp; {serverIp || "your server IP"}
           </div>
         </div>
         <p className="text-xs text-muted-foreground">
@@ -1109,8 +1176,16 @@ function DomainStep({
         >
           Skip
         </Button>
-        <Button className="squircle flex-1" onClick={onComplete}>
-          DNS is configured
+        <Button
+          className="squircle flex-1"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saving ? (
+            <><Loader2 className="mr-2 size-4 animate-spin" />Saving...</>
+          ) : (
+            "Save & continue"
+          )}
         </Button>
       </div>
     </div>

--- a/app/api/setup/general/route.ts
+++ b/app/api/setup/general/route.ts
@@ -8,6 +8,7 @@ const generalSchema = z.object({
   instanceName: z.string().min(1).max(100),
   baseDomain: z.string().optional(),
   serverIp: z.string().optional(),
+  domain: z.string().optional(),
 }).strict();
 
 export async function GET(request: NextRequest) {
@@ -20,6 +21,7 @@ export async function GET(request: NextRequest) {
     instanceName: config.instanceName,
     baseDomain: config.baseDomain,
     serverIp: config.serverIp,
+    domain: config.domain,
   });
 }
 
@@ -38,13 +40,13 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Only instanceName is editable; preserve baseDomain and serverIp from existing config
   const existing = await getInstanceConfig();
 
   await setSystemSetting("instance_config", JSON.stringify({
     instanceName: parsed.data.instanceName,
-    baseDomain: existing.baseDomain,
-    serverIp: existing.serverIp,
+    baseDomain: parsed.data.baseDomain ?? existing.baseDomain,
+    serverIp: parsed.data.serverIp ?? existing.serverIp,
+    domain: parsed.data.domain ?? existing.domain,
   }));
 
   return NextResponse.json({ ok: true });

--- a/app/api/v1/admin/dns-check/route.ts
+++ b/app/api/v1/admin/dns-check/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { resolve4 } from "dns/promises";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { handleRouteError } from "@/lib/api/error-response";
+import { getInstanceConfig } from "@/lib/system-settings";
 
 type DnsCheck = {
   domain: string;
@@ -14,9 +15,10 @@ export async function GET(request: NextRequest) {
   try {
     await requireAdminAuth(request);
 
-    const serverIp = process.env.VARDO_SERVER_IP ?? "";
-    const baseDomain = process.env.VARDO_BASE_DOMAIN ?? "";
-    const hostDomain = process.env.VARDO_DOMAIN ?? "";
+    const config = await getInstanceConfig();
+    const serverIp = config.serverIp;
+    const baseDomain = config.baseDomain;
+    const hostDomain = config.domain;
 
     const domains = [hostDomain, baseDomain].filter(Boolean);
     // Deduplicate

--- a/app/api/v1/admin/mesh/invite/route.ts
+++ b/app/api/v1/admin/mesh/invite/route.ts
@@ -3,16 +3,18 @@ import { handleRouteError } from "@/lib/api/error-response";
 import { requireAppAdmin } from "@/lib/auth/admin";
 import { createInvite } from "@/lib/mesh/invite";
 import { ensureHubConfig, HUB_IP } from "@/lib/mesh";
+import { getInstanceConfig } from "@/lib/system-settings";
 
 /** POST /api/v1/admin/mesh/invite — generate an invite code for a new peer */
 export async function POST() {
   try {
     await requireAppAdmin();
 
-    const serverIp = process.env.VARDO_SERVER_IP || process.env.VARDO_DOMAIN;
+    const config = await getInstanceConfig();
+    const serverIp = config.serverIp || config.domain;
     if (!serverIp) {
       return NextResponse.json(
-        { error: "VARDO_SERVER_IP or VARDO_DOMAIN must be set" },
+        { error: "Server IP or primary domain must be configured in admin settings" },
         { status: 503 }
       );
     }
@@ -23,7 +25,7 @@ export async function POST() {
     const port = process.env.WIREGUARD_PORT || "51820";
     const endpoint = `${serverIp}:${port}`;
 
-    const domain = process.env.VARDO_DOMAIN || serverIp;
+    const domain = config.domain || serverIp;
     const protocol = domain === "localhost" ? "http" : "https";
     const apiUrl = `${protocol}://${domain}`;
 

--- a/app/api/v1/admin/mesh/join/route.ts
+++ b/app/api/v1/admin/mesh/join/route.ts
@@ -6,6 +6,7 @@ import { decodeInviteToken } from "@/lib/mesh/invite";
 import { generateMeshToken } from "@/lib/mesh/auth";
 import { ensureHubConfig, HUB_IP } from "@/lib/mesh";
 import { getInstanceId } from "@/lib/constants";
+import { getInstanceConfig } from "@/lib/system-settings";
 import { db } from "@/lib/db";
 import { meshPeers } from "@/lib/db/schema";
 import { nanoid } from "nanoid";
@@ -46,7 +47,8 @@ export async function POST(request: NextRequest) {
     const localPublicKey = await ensureHubConfig(HUB_IP);
 
     const instanceId = await getInstanceId();
-    const hostname = process.env.HOSTNAME || process.env.VARDO_DOMAIN || "unknown";
+    const instanceConfig = await getInstanceConfig();
+    const hostname = process.env.HOSTNAME || instanceConfig.domain || "unknown";
 
     // Generate a token the hub can use to call our API
     const { raw: ourToken, hash: ourTokenHash } = generateMeshToken();

--- a/app/api/v1/admin/mesh/peers/route.ts
+++ b/app/api/v1/admin/mesh/peers/route.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { registerPeer } from "@/lib/mesh/peers";
 import { listInvites } from "@/lib/mesh/invite";
+import { getInstanceConfig } from "@/lib/system-settings";
 
 const WG_KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
 
@@ -23,7 +24,8 @@ export async function GET() {
   try {
     await requireAppAdmin();
 
-    const serverIp = process.env.VARDO_SERVER_IP || process.env.VARDO_DOMAIN || "localhost";
+    const config = await getInstanceConfig();
+    const serverIp = config.serverIp || config.domain || "localhost";
     const protocol = serverIp === "localhost" ? "http" : "https";
     const apiUrl = `${protocol}://${serverIp}`;
 

--- a/lib/config/vardo-config.ts
+++ b/lib/config/vardo-config.ts
@@ -251,7 +251,7 @@ export async function systemSettingsToVardoConfig(): Promise<{
     instance: {
       id: instanceId,
       name: instance.instanceName,
-      domain: process.env.VARDO_DOMAIN || undefined,
+      domain: instance.domain || undefined,
       baseDomain: instance.baseDomain || undefined,
       serverIp: instance.serverIp || undefined,
     },

--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -99,6 +99,7 @@ export type InstanceConfig = {
   instanceName: string;
   baseDomain: string;
   serverIp: string;
+  domain: string;
 };
 
 export async function getInstanceConfig(): Promise<InstanceConfig> {
@@ -106,11 +107,13 @@ export async function getInstanceConfig(): Promise<InstanceConfig> {
   const dbConfig = await getSystemSettingRaw("instance_config")
     .then((raw) => raw ? parseJson<InstanceConfig>(raw, "instance_config") : null);
 
-  // Merge: config file fields > DB fields > defaults
+  // Merge: config file fields > DB fields > env fallback > defaults
+  // Env fallbacks support migration from env-only setups to DB-managed config
   return {
     instanceName: fileConfig?.instance?.name ?? dbConfig?.instanceName ?? DEFAULT_APP_NAME,
-    baseDomain: fileConfig?.instance?.baseDomain ?? dbConfig?.baseDomain ?? "",
-    serverIp: fileConfig?.instance?.serverIp ?? dbConfig?.serverIp ?? "",
+    baseDomain: fileConfig?.instance?.baseDomain ?? dbConfig?.baseDomain ?? process.env.VARDO_BASE_DOMAIN ?? "",
+    serverIp: fileConfig?.instance?.serverIp ?? dbConfig?.serverIp ?? process.env.VARDO_SERVER_IP ?? "",
+    domain: fileConfig?.instance?.domain ?? dbConfig?.domain ?? process.env.VARDO_DOMAIN ?? "",
   };
 }
 


### PR DESCRIPTION
## Summary

- Domain info fields (primary domain, base domain, server IP) are now editable in admin settings with a save button, replacing the old read-only "Not configured" display
- All domain values persist to DB via `system_settings`, with env var fallback for migration from `.env`-only setups
- Setup wizard domain step now collects and saves domain/IP to DB during onboarding
- DNS check and mesh routes read from `getInstanceConfig()` instead of raw env vars

## Test plan

- [ ] Verify admin settings > Domain & SSL shows editable fields with current values
- [ ] Change base domain / server IP / primary domain and save — confirm values persist across page reload
- [ ] Confirm DNS re-check uses the new saved values
- [ ] Run setup wizard through the domain step — verify values save to DB
- [ ] Confirm env var fallback works when DB has no values (fresh install migration)
- [ ] `pnpm typecheck` and `pnpm build` pass

Closes #490