### PR TITLE
fix: session redirect to /login + abort button styling

### DIFF
--- a/app/(authenticated)/apps/[...slug]/in-progress-deploy-card.tsx
+++ b/app/(authenticated)/apps/[...slug]/in-progress-deploy-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, Check, X, ChevronDown, Square } from "lucide-react";
+import { Loader2, Check, X, ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TerminalOutput, highlightLogLine, detectLogLevel } from "@/components/log-viewer";
@@ -96,11 +96,10 @@ export function InProgressDeployCard({
           {canAbort && onAbort && (
             <Button
               size="sm"
-              variant="ghost"
-              className="text-destructive hover:text-destructive"
+              variant="destructive"
               onClick={(e) => { e.stopPropagation(); onAbort(); }}
             >
-              <Square className="mr-1 size-3" />
+              <X className="mr-1 size-3" />
               Abort
             </Button>
           )}

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -4,7 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { TopNav } from "@/components/layout/top-nav";
 import { CommandPalette } from "@/components/command-palette";
 import { NotificationListener } from "@/components/notification-listener";
-import { getCurrentOrg, getUserOrganizations } from "@/lib/auth/session";
+import { getSession, getCurrentOrg, getUserOrganizations } from "@/lib/auth/session";
 import { isFeatureEnabled } from "@/lib/config/features";
 import { SessionFooter } from "@/components/layout/session-footer";
 
@@ -31,6 +31,12 @@ export default async function AppLayout({
         </div>
       </div>
     );
+  }
+
+  const session = await getSession();
+
+  if (!session) {
+    redirect("/login");
   }
 
   const orgData = await getCurrentOrg();


### PR DESCRIPTION
## Summary

- **#485** — Expired sessions now redirect to `/login` instead of `/create-org`. Added a `getSession()` check before `getCurrentOrg()` in the authenticated layout. Both are `cache()`-wrapped so the extra call is free.
- **#463** — Abort button on in-progress deploy card now uses `variant="destructive"` with an `X` icon instead of ghost styling with a `Square` icon.

## Test plan

- [ ] Log out or let session expire, then visit an authenticated route — should redirect to `/login`
- [ ] With a valid session but no org, should still redirect to `/create-org`
- [ ] Trigger a deploy, verify the abort button renders with destructive (red) styling and X icon

Closes #485, closes #463