### PR TITLE
fix: DNS check shows actual IP, detects Cloudflare proxy

### DIFF
--- a/app/(authenticated)/admin/settings/domain-settings.tsx
+++ b/app/(authenticated)/admin/settings/domain-settings.tsx
@@ -27,6 +27,9 @@ type DnsCheck = {
   resolved: boolean;
   ips: string[];
   matches: boolean;
+  proxied?: boolean;
+  reachable?: boolean;
+  proxyProvider?: "cloudflare" | null;
 };
 
 type InstanceData = {
@@ -367,10 +370,22 @@ export function DomainSettings() {
                     </p>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
-                    {check.resolved && check.matches ? (
+                    {check.resolved && check.matches && check.proxied ? (
                       <>
                         <Check className="size-3.5 text-status-success" />
-                        <span className="text-xs font-medium text-status-success">Matches</span>
+                        <span className="text-xs font-medium text-status-success">
+                          Connected (via {check.proxyProvider === "cloudflare" ? "Cloudflare" : "proxy"})
+                        </span>
+                      </>
+                    ) : check.resolved && check.matches ? (
+                      <>
+                        <Check className="size-3.5 text-status-success" />
+                        <span className="text-xs font-medium text-status-success">Connected</span>
+                      </>
+                    ) : check.resolved && !check.reachable ? (
+                      <>
+                        <X className="size-3.5 text-status-error" />
+                        <span className="text-xs font-medium text-status-error">Not responding</span>
                       </>
                     ) : check.resolved ? (
                       <>
@@ -380,7 +395,7 @@ export function DomainSettings() {
                     ) : (
                       <>
                         <X className="size-3.5 text-muted-foreground" />
-                        <span className="text-xs font-medium text-muted-foreground">Not resolved</span>
+                        <span className="text-xs font-medium text-muted-foreground">DNS not configured</span>
                       </>
                     )}
                   </div>

--- a/app/api/v1/admin/dns-check/route.ts
+++ b/app/api/v1/admin/dns-check/route.ts
@@ -3,12 +3,17 @@ import { resolve4 } from "dns/promises";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { handleRouteError } from "@/lib/api/error-response";
 import { getInstanceConfig } from "@/lib/system-settings";
+import { getServerIP } from "@/lib/server-ip";
+import { isCloudflareIp } from "@/lib/cloudflare-ips";
 
 type DnsCheck = {
   domain: string;
   resolved: boolean;
   ips: string[];
   matches: boolean;
+  proxied: boolean;
+  reachable: boolean;
+  proxyProvider: "cloudflare" | null;
 };
 
 export async function GET(request: NextRequest) {
@@ -16,22 +21,54 @@ export async function GET(request: NextRequest) {
     await requireAdminAuth(request);
 
     const config = await getInstanceConfig();
-    const serverIp = config.serverIp;
+    const serverIp = config.serverIp || (await getServerIP());
     const baseDomain = config.baseDomain;
     const hostDomain = config.domain;
 
     const domains = [hostDomain, baseDomain].filter(Boolean);
-    // Deduplicate
     const unique = [...new Set(domains)];
 
     const checks: DnsCheck[] = await Promise.all(
       unique.map(async (domain) => {
         try {
           const ips = await resolve4(domain);
-          const matches = serverIp ? ips.includes(serverIp) : false;
-          return { domain, resolved: true, ips, matches };
+          const directMatch = serverIp ? ips.includes(serverIp) : false;
+          const allCloudflare = ips.length > 0 && ips.every(isCloudflareIp);
+
+          let reachable = false;
+          if (!directMatch && ips.length > 0) {
+            // Check HTTP reachability when IPs don't directly match
+            try {
+              await fetch(`https://${domain}`, {
+                method: "HEAD",
+                signal: AbortSignal.timeout(5000),
+                redirect: "manual",
+              });
+              reachable = true;
+            } catch {
+              // Domain didn't respond
+            }
+          }
+
+          return {
+            domain,
+            resolved: true,
+            ips,
+            matches: directMatch || (allCloudflare && reachable),
+            proxied: allCloudflare,
+            reachable: directMatch || reachable,
+            proxyProvider: allCloudflare ? "cloudflare" as const : null,
+          };
         } catch {
-          return { domain, resolved: false, ips: [], matches: false };
+          return {
+            domain,
+            resolved: false,
+            ips: [],
+            matches: false,
+            proxied: false,
+            reachable: false,
+            proxyProvider: null,
+          };
         }
       }),
     );

--- a/app/api/v1/dns-check/route.ts
+++ b/app/api/v1/dns-check/route.ts
@@ -1,29 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolve4, resolveCname } from "dns/promises";
-import { networkInterfaces } from "os";
+import { getServerIP } from "@/lib/server-ip";
+import { isCloudflareIp } from "@/lib/cloudflare-ips";
 
 const BASE_DOMAIN = process.env.VARDO_BASE_DOMAIN || "localhost";
-
-function getServerIPs(): string[] {
-  // Use the configured public IP when available (production / Docker).
-  // os.networkInterfaces() inside a container returns internal Docker IPs
-  // (172.x.x.x) which will never match external A records.
-  const serverIp = process.env.VARDO_SERVER_IP;
-  if (serverIp) return [serverIp];
-
-  // Fallback for local dev where the env var isn't set
-  const ips: string[] = [];
-  const nets = networkInterfaces();
-  for (const interfaces of Object.values(nets)) {
-    if (!interfaces) continue;
-    for (const iface of interfaces) {
-      if (!iface.internal && iface.family === "IPv4") {
-        ips.push(iface.address);
-      }
-    }
-  }
-  return ips;
-}
 
 // GET /api/v1/dns-check?domain=example.com&expected=auto-generated.localhost
 export async function GET(request: NextRequest) {
@@ -95,19 +75,39 @@ export async function GET(request: NextRequest) {
       (expected && (r === expected || r === `${expected}.`))
     );
 
-    // Check if A record points to one of this server's IPs
-    const serverIPs = getServerIPs();
-    const aCorrect = aRecords.some((ip) => serverIPs.includes(ip));
+    // Check if A record points to this server's IP
+    const serverIp = await getServerIP();
+    const aCorrect = serverIp ? aRecords.some((ip) => ip === serverIp) : false;
 
-    const configured = cnameCorrect || aCorrect;
+    // Check for Cloudflare proxy
+    const allCloudflare = aRecords.length > 0 && aRecords.every(isCloudflareIp);
+
+    let reachable = false;
+    if (!aCorrect && !cnameCorrect && aRecords.length > 0) {
+      try {
+        await fetch(`https://${domain}`, {
+          method: "HEAD",
+          signal: AbortSignal.timeout(5000),
+          redirect: "manual",
+        });
+        reachable = true;
+      } catch {
+        // Domain didn't respond
+      }
+    }
+
+    const configured = cnameCorrect || aCorrect || (allCloudflare && reachable);
 
     return NextResponse.json({
       domain,
       status: configured ? "configured" : "wrong-target",
       resolves: hasRecords,
       configured,
+      proxied: allCloudflare,
+      reachable: aCorrect || cnameCorrect || reachable,
+      proxyProvider: allCloudflare ? "cloudflare" : null,
       records: { a: aRecords, cname: cnameRecords },
-      serverIPs: serverIPs,
+      serverIp,
     });
   } catch {
     return NextResponse.json({

--- a/lib/cloudflare-ips.ts
+++ b/lib/cloudflare-ips.ts
@@ -1,0 +1,46 @@
+/**
+ * Cloudflare IPv4 CIDR ranges.
+ * Source: https://www.cloudflare.com/ips-v4
+ * Last updated: 2026-03-25
+ */
+const CLOUDFLARE_IPV4_RANGES = [
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+];
+
+/** Parse a CIDR string into a numeric base address and mask. */
+function parseCidr(cidr: string): { base: number; mask: number } {
+  const [ip, prefixStr] = cidr.split("/");
+  const prefix = parseInt(prefixStr, 10);
+  const parts = ip.split(".").map(Number);
+  const base = ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return { base, mask };
+}
+
+const parsedRanges = CLOUDFLARE_IPV4_RANGES.map(parseCidr);
+
+/** Convert a dotted-quad IPv4 string to a 32-bit unsigned integer. */
+function ipToNum(ip: string): number {
+  const parts = ip.split(".").map(Number);
+  return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+}
+
+/** Returns true if the given IPv4 address belongs to a Cloudflare range. */
+export function isCloudflareIp(ip: string): boolean {
+  const num = ipToNum(ip);
+  return parsedRanges.some(({ base, mask }) => (num & mask) === base);
+}

--- a/lib/server-ip.ts
+++ b/lib/server-ip.ts
@@ -1,0 +1,49 @@
+import { getInstanceConfig } from "@/lib/system-settings";
+
+let cachedIp: string | null = null;
+
+/**
+ * Returns the server's public IPv4 address.
+ *
+ * Resolution order:
+ * 1. Instance config `serverIp` from the database
+ * 2. `VARDO_SERVER_IP` environment variable
+ * 3. Auto-detect via https://api.ipify.org
+ *
+ * The result is cached for the lifetime of the process.
+ */
+export async function getServerIP(): Promise<string> {
+  if (cachedIp) return cachedIp;
+
+  // 1. Database config
+  try {
+    const config = await getInstanceConfig();
+    if (config.serverIp) {
+      cachedIp = config.serverIp;
+      return cachedIp;
+    }
+  } catch {
+    // DB may not be available yet — continue
+  }
+
+  // 2. Environment variable
+  if (process.env.VARDO_SERVER_IP) {
+    cachedIp = process.env.VARDO_SERVER_IP;
+    return cachedIp;
+  }
+
+  // 3. Auto-detect
+  try {
+    const res = await fetch("https://api.ipify.org", {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (res.ok) {
+      cachedIp = (await res.text()).trim();
+      return cachedIp;
+    }
+  } catch {
+    // auto-detect failed
+  }
+
+  return "";
+}


### PR DESCRIPTION
## Summary

- Adds shared `getServerIP()` utility that resolves the server's public IP from DB config, env var, or auto-detection via ipify.org
- Adds Cloudflare IPv4 CIDR range checker so proxied domains aren't flagged as "Wrong IP"
- Both DNS check routes now detect Cloudflare proxy and perform HTTP reachability checks
- Domain settings UI shows contextual status: Connected, Connected (via Cloudflare), Not responding, DNS not configured

## Test plan

- [ ] Verify DNS check returns `proxied: true` and `proxyProvider: "cloudflare"` for Cloudflare-proxied domains
- [ ] Verify direct A record match still shows "Connected"
- [ ] Verify unreachable domain with DNS records shows "Not responding"
- [ ] Verify domain with no DNS records shows "DNS not configured"
- [ ] Verify `getServerIP()` falls back correctly when `serverIp` is empty in DB and env

Closes #487