### PR TITLE
fix: profile page uses save button instead of auto-save on blur

### DIFF
--- a/app/(authenticated)/user/settings/account-settings.tsx
+++ b/app/(authenticated)/user/settings/account-settings.tsx
@@ -38,7 +38,8 @@ export function AccountInfo() {
     }
   }, [sessionData]);
 
-  async function handleSaveName() {
+  async function handleSaveName(e: React.FormEvent) {
+    e.preventDefault();
     if (!name.trim()) return;
     setSaving(true);
     try {
@@ -67,31 +68,31 @@ export function AccountInfo() {
     <Card className="squircle rounded-lg">
       <CardHeader>
         <CardTitle>Account</CardTitle>
-        <CardDescription>Name saves automatically on blur or Enter.</CardDescription>
+        <CardDescription>Update your display name.</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="grid gap-2">
-            <Label htmlFor="profile-name">Name</Label>
-            <div className="flex gap-2">
+        <form onSubmit={handleSaveName} className="space-y-3 max-w-sm">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-2">
+              <Label htmlFor="profile-name">Name</Label>
               <Input
                 id="profile-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                onBlur={() => {
-                  if (name.trim() && name !== sessionData?.user?.name) handleSaveName();
-                }}
-                onKeyDown={(e) => { if (e.key === "Enter") handleSaveName(); }}
               />
-              {saving && <Loader2 className="size-4 animate-spin text-muted-foreground mt-2.5" />}
+            </div>
+
+            <div className="grid gap-2">
+              <Label>Email</Label>
+              <Input value={sessionData?.user?.email || ""} disabled />
             </div>
           </div>
 
-          <div className="grid gap-2">
-            <Label>Email</Label>
-            <Input value={sessionData?.user?.email || ""} disabled />
-          </div>
-        </div>
+          <Button type="submit" size="sm" disabled={saving}>
+            {saving && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+            Save
+          </Button>
+        </form>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

- Replaces auto-save-on-blur/Enter behavior in the Account settings name field with an explicit Save button
- Wraps the name/email fields in a `<form>` with `onSubmit` handler, matching the pattern used on every other settings page
- Updates the card description to reflect the new behavior

## Test plan

- [ ] Navigate to User Settings > Account
- [ ] Edit name and click Save — confirm toast and name persists
- [ ] Confirm tabbing away from the name field no longer triggers a save
- [ ] Confirm other settings sections (Password, 2FA, etc.) are unaffected

Closes #483