### PR TITLE
Add POST /api/v1/admin/restart endpoint

### DIFF
--- a/app/api/v1/admin/restart/route.ts
+++ b/app/api/v1/admin/restart/route.ts
@@ -3,23 +3,36 @@ import { spawn } from "child_process";
 import { hostname } from "os";
 import { handleRouteError } from "@/lib/api/error-response";
 import { requireAppAdmin } from "@/lib/auth/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger.child("admin:restart");
 
 // POST /api/v1/admin/restart
+//
+// Restarts the Vardo container. Requires app admin.
+//
+// Container identity: reads CONTAINER_ID env var first (set this explicitly if
+// the container runs with a custom hostname), falls back to os.hostname() which
+// matches Docker's default naming scheme. The value is passed as a positional
+// arg to `docker restart` — not interpolated into a shell string.
 export async function POST() {
   try {
     await requireAppAdmin();
 
-    const containerId = hostname();
+    // CONTAINER_ID lets operators override the default hostname-based lookup.
+    // Useful when the container is started with a custom --hostname or hostname: key.
+    const containerId = process.env.CONTAINER_ID ?? hostname();
 
     setTimeout(() => {
-      spawn("docker", ["restart", containerId], { detached: true, stdio: "ignore" }).unref();
+      log.info(`restarting container: ${containerId}`);
+      spawn("docker", ["restart", containerId], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
     }, 2000);
 
     return NextResponse.json({ success: true, message: "Restarting in 2 seconds..." });
   } catch (error) {
-    if (error instanceof Error && error.message === "Forbidden") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
     return handleRouteError(error);
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
     group_add:
       - ${DOCKER_GID:-999}
     volumes:
+      # Docker socket — required for the deploy engine and admin restart endpoint.
+      # Accepted risk: mounting the socket grants this container full control over
+      # the host daemon. Mitigated by admin-only auth, non-root user, and docker GID mapping.
+      # Set CONTAINER_ID in .env if you run Vardo with a custom container hostname.
       - /var/run/docker.sock:/var/run/docker.sock
       - vardo_projects:/var/lib/vardo/projects
       - traefik_dynamic:/etc/traefik/dynamic


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/admin/restart` endpoint that restarts the Vardo container
- Requires admin auth via `requireAppAdmin`
- Gets container ID from `hostname()` (OS hostname matches Docker container name)
- Fires `docker restart <hostname>` via spawn after a 2-second delay, then returns immediately
- Process dies when Docker restarts — expected behavior

Closes #506

## Test plan

- [ ] `POST /api/v1/admin/restart` as a non-admin returns 403
- [ ] `POST /api/v1/admin/restart` as an admin returns `{ success: true, message: "Restarting in 2 seconds..." }`
- [ ] Container restarts ~2 seconds after the response