### PR TITLE
fix: check TTY availability before writing to /dev/tty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -314,12 +314,12 @@ run_cmd() {
 }
 
 # Returns true if a usable controlling terminal is available.
-# Checks each standard fd first (fast path), then tries to open /dev/tty.
+# Checks stdin fd first (fast path), then tries to actually open /dev/tty.
 # [ -e /dev/tty ] && [ -w /dev/tty ] is not sufficient — the device node
 # always exists and always has write permission bits set, even when there is
 # no controlling terminal (e.g. ssh host 'cmd' without -t).
 has_tty() {
-  [ -t 0 ] || [ -t 1 ] || [ -t 2 ] || { [ -e /dev/tty ] && { : < /dev/tty; } 2>/dev/null; }
+  [ -t 0 ] || { : < /dev/tty; } 2>/dev/null
 }
 
 # Run a command with elapsed timer — for long-running operations
@@ -337,7 +337,8 @@ run_with_spinner() {
   fi
   log_to_file "CMD: $*"
 
-  # Determine output target for progress: /dev/tty when available, stderr otherwise
+  # Safe to hardcode /dev/tty — the ! has_tty early return above ensures we
+  # only reach this point when a controlling terminal is actually available.
   local tty_out="/dev/tty"
 
   # Start a timer in a background subshell that updates every 5s


### PR DESCRIPTION
Fixes #501

## Problem

`vardo update -y` crashes when run non-interactively (e.g. `ssh root@server 'vardo update -y'`) because the TTY check throughout the script was unreliable:

\`\`\`bash
[ -e /dev/tty ] && [ -w /dev/tty ]
\`\`\`

This always passes — \`/dev/tty\` is always present as a device node, and its permission bits are always set. So the script falls through to \`read < /dev/tty\` or \`printf > /dev/tty\`, which fail when there is no controlling terminal. Under \`set -euo pipefail\` this kills the script.

The same broken check was used in \`confirm()\` so even with \`-y\` the no-TTY fallback path was never reached (though \`AUTO_YES\` guards most confirm calls anyway, the broken check left a latent crash path).

## Fix

- Add \`has_tty()\` — checks stdin fd with \`[ -t 0 ]\` (fast path), then tries to actually open \`/dev/tty\` as a final fallback
- Use \`has_tty\` in \`run_with_spinner\`, \`wait_healthy\`, \`confirm\`, and all direct \`/dev/tty\` reads
- \`run_with_spinner\` now degrades to simple labelled output (same behaviour as \`--verbose\`) when no TTY is available — long-running steps are still logged without attempting terminal control sequences

## Test plan

- [ ] \`ssh root@server 'vardo update -y'\` completes without TTY errors
- [ ] \`vardo update -y\` in an interactive shell still shows spinner/timer
- [ ] \`vardo update\` in an interactive shell still prompts as expected
- [ ] \`vardo update --unattended\` still works
- [ ] \`vardo install < /dev/null\` completes — stdin redirected, stdout still a TTY
- [ ] Running inside a Docker container with no TTY (no \`-t\` flag) degrades cleanly to verbose output