### PR TITLE
fix: client component importing server-only module via resolve-recipients

### DIFF
--- a/app/(authenticated)/user/settings/user-notification-preferences.tsx
+++ b/app/(authenticated)/user/settings/user-notification-preferences.tsx
@@ -5,8 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "@/lib/messenger";
 import { Loader2, Bell, AlertCircle } from "lucide-react";
 import { EVENT_CATEGORIES, type BusEventType, type EventCategory } from "@/lib/bus/events";
-import { CRITICAL_EVENT_TYPES } from "@/lib/notifications/resolve-recipients";
-import { CHANNEL_TYPE_DEFAULTS } from "@/lib/notifications/channel-defaults";
+import { CRITICAL_EVENT_TYPES, CHANNEL_TYPE_DEFAULTS } from "@/lib/notifications/channel-defaults";
 
 type Channel = {
   id: string;

--- a/lib/notifications/channel-defaults.ts
+++ b/lib/notifications/channel-defaults.ts
@@ -1,3 +1,5 @@
+import type { BusEventType } from "@/lib/bus";
+
 /**
  * Default enabled state per channel type when a user has no preference row.
  * Email is on by default (primary channel). Slack and webhook require opt-in.
@@ -7,3 +9,14 @@ export const CHANNEL_TYPE_DEFAULTS: Record<string, boolean> = {
   slack: false,
   webhook: false,
 };
+
+/**
+ * Events that always send regardless of user preferences.
+ * Users cannot mute these.
+ */
+export const CRITICAL_EVENT_TYPES: ReadonlySet<BusEventType> = new Set([
+  "deploy.failed",
+  "security.file-exposed",
+  "system.service-down",
+  "system.disk-alert",
+] as BusEventType[]);

--- a/lib/notifications/resolve-recipients.ts
+++ b/lib/notifications/resolve-recipients.ts
@@ -2,18 +2,7 @@ import { db } from "@/lib/db";
 import { memberships, userNotificationPreferences } from "@/lib/db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import type { BusEventType } from "@/lib/bus";
-import { CHANNEL_TYPE_DEFAULTS } from "./channel-defaults";
-
-/**
- * Events that always send regardless of user preferences.
- * Users cannot mute these.
- */
-export const CRITICAL_EVENT_TYPES: ReadonlySet<BusEventType> = new Set([
-  "deploy.failed",
-  "security.file-exposed",
-  "system.service-down",
-  "system.disk-alert",
-] as BusEventType[]);
+import { CHANNEL_TYPE_DEFAULTS, CRITICAL_EVENT_TYPES } from "./channel-defaults";
 
 /**
  * Fetch all member user IDs for an org. Called once per dispatch, outside the


### PR DESCRIPTION
Moves CRITICAL_EVENT_TYPES from resolve-recipients.ts (imports db/postgres) to channel-defaults.ts (no server deps). Fixes build error.