### PR TITLE
fix: install Docker CLI from official repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,14 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # Runtime dependencies — git for cloning, docker-cli for orchestrating builds/deploys
+# Install Docker CLI from official Docker repo (docker.io from apt is too old for modern daemons)
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends git docker.io curl ca-certificates && \
+    apt-get install -y --no-install-recommends git curl ca-certificates gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends docker-ce-cli && \
     curl -sSL https://nixpacks.com/install.sh | bash && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then RAILPACK_ARCH="arm64"; else RAILPACK_ARCH="x86_64"; fi && \


### PR DESCRIPTION
## Problem

The Dockerfile installs `docker.io` from apt which ships Docker CLI API version 1.41. Modern Docker daemons (29.x) require API version 1.44+. This causes all Docker operations from the frontend container to fail with "client version too old" errors.

Affects: deployments, WireGuard key generation, container management — basically everything.

## Fix

Replace `docker.io` with `docker-ce-cli` from Docker's official Debian repo.

## Test plan

- [ ] Build the image
- [ ] `docker exec vardo-frontend docker version` shows API version >= 1.44