### PR TITLE
fix: rebuild WireGuard config after mesh join

### DIFF
--- a/app/api/v1/admin/mesh/join/route.ts
+++ b/app/api/v1/admin/mesh/join/route.ts
@@ -121,10 +121,14 @@ export async function POST(request: NextRequest) {
     });
 
     // Rebuild WireGuard config with the hub as a peer
+    // (joiner inserts the hub directly, not via registerPeer, so sync here)
     try {
-      await rebuildAndSync();
-    } catch {
-      // WireGuard sync failure shouldn't fail the join
+      const { isWireguardRunning } = await import("@/lib/mesh/wireguard");
+      if (await isWireguardRunning()) {
+        await rebuildAndSync();
+      }
+    } catch (err) {
+      console.warn(`[mesh] WireGuard sync failed after joining hub: ${err}`);
     }
 
     // Pull shareable config from the hub (best-effort)

--- a/app/api/v1/mesh/join/route.ts
+++ b/app/api/v1/mesh/join/route.ts
@@ -7,7 +7,6 @@ import { meshPeers } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { redeemInvite } from "@/lib/mesh/invite";
 import { registerPeer } from "@/lib/mesh/peers";
-import { rebuildAndSync } from "@/lib/mesh/wireguard";
 
 const WG_KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
 
@@ -58,13 +57,6 @@ async function handler(request: NextRequest) {
         .update(meshPeers)
         .set({ outboundToken: joinerOutboundToken })
         .where(eq(meshPeers.id, peer.id));
-    }
-
-    // Rebuild WireGuard config with the new peer
-    try {
-      await rebuildAndSync();
-    } catch {
-      // WireGuard sync failure shouldn't fail the join
     }
 
     const { tokenHash: _hash, ...peerWithoutHash } = peer;

--- a/lib/mesh/peers.ts
+++ b/lib/mesh/peers.ts
@@ -3,6 +3,8 @@ import { meshPeers } from "@/lib/db/schema";
 import { nanoid } from "nanoid";
 import { allocateIp, toCidr } from "./ip-allocator";
 import { generateMeshToken } from "./auth";
+import { rebuildAndSync, isWireguardRunning } from "./wireguard";
+import { logger } from "@/lib/logger";
 
 interface RegisterPeerInput {
   instanceId: string;
@@ -48,6 +50,15 @@ export async function registerPeer(
   };
 
   await db.insert(meshPeers).values(peer);
+
+  // Rebuild WireGuard config with the new peer
+  try {
+    if (await isWireguardRunning()) {
+      await rebuildAndSync();
+    }
+  } catch (err) {
+    logger.warn(`[mesh] WireGuard sync failed after registering peer ${peer.name}: ${err}`);
+  }
 
   return { peer, token };
 }

--- a/lib/mesh/wireguard.ts
+++ b/lib/mesh/wireguard.ts
@@ -132,6 +132,9 @@ export async function rebuildAndSync(): Promise<void> {
     "cat /config/wg_confs/wg0.conf | grep Address | cut -d= -f2- | tr -d ' ' | cut -d/ -f1",
   ]);
   const address = addrOut.trim();
+  if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(address)) {
+    throw new Error(`Invalid WireGuard address from config: ${address}`);
+  }
 
   // Get all peers from the database
   const allPeers = await db.query.meshPeers.findMany({


### PR DESCRIPTION
## Problem

The mesh join flow registers peers in the database but never syncs the WireGuard config. Both sides end up with `wg show` showing no peers — the tunnel is up but empty. Peers show "Awaiting first heartbeat" forever.

## Fix

Add `rebuildAndSync()` to `lib/mesh/wireguard.ts` that:
1. Reads the current private key and address from wg0.conf
2. Queries all peers from the database
3. Rebuilds the full wg0.conf with all peers
4. Hot-reloads via `wg syncconf`

Called on both sides after peer registration:
- Hub: after `registerPeer()` in `/api/v1/mesh/join`
- Joiner: after inserting the hub peer in `/api/v1/admin/mesh/join`

Wrapped in try/catch — WireGuard sync failure doesn't fail the join.

## Test plan

- [ ] Join mesh from a new instance — both sides show peers in `wg show`
- [ ] Heartbeat starts working — instances go from "Awaiting first heartbeat" to "Online"
- [ ] NAT'd instance connects via PersistentKeepalive