### PR TITLE
fix: correct mesh IP allocation and WireGuard endpoint

### DIFF
--- a/app/api/v1/admin/mesh/join/route.ts
+++ b/app/api/v1/admin/mesh/join/route.ts
@@ -4,7 +4,7 @@ import { handleRouteError } from "@/lib/api/error-response";
 import { requireAppAdmin } from "@/lib/auth/admin";
 import { decodeInviteToken } from "@/lib/mesh/invite";
 import { generateMeshToken } from "@/lib/mesh/auth";
-import { ensureHubConfig, HUB_IP } from "@/lib/mesh";
+import { ensureHubConfig } from "@/lib/mesh";
 import { getInstanceId } from "@/lib/constants";
 import { getInstanceConfig } from "@/lib/system-settings";
 import { needsSetup } from "@/lib/setup";
@@ -13,7 +13,7 @@ import { rebuildAndSync } from "@/lib/mesh/wireguard";
 import { db } from "@/lib/db";
 import { meshPeers } from "@/lib/db/schema";
 import { nanoid } from "nanoid";
-import { allocateIp, toCidr } from "@/lib/mesh/ip-allocator";
+import { toCidr } from "@/lib/mesh/ip-allocator";
 
 const joinSchema = z.object({ token: z.string().min(1, "Invite token is required") }).strict();
 
@@ -57,12 +57,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: urlCheck.error }, { status: 400 });
     }
 
-    // Bootstrap local WireGuard (generates keypair if needed)
-    const localPublicKey = await ensureHubConfig(HUB_IP);
+    // Bootstrap local WireGuard with a temporary address (just to get the keypair).
+    // The correct address will be set by rebuildAndSync after the hub assigns our IP.
+    const localPublicKey = await ensureHubConfig("10.99.0.254");
 
     const instanceId = await getInstanceId();
     const instanceConfig = await getInstanceConfig();
-    const hostname = process.env.HOSTNAME || instanceConfig.domain || "unknown";
+    const hostname = instanceConfig.instanceName || instanceConfig.domain || "unknown";
 
     // Generate a token the hub can use to call our API
     const { raw: ourToken, hash: ourTokenHash } = generateMeshToken();
@@ -98,12 +99,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Register the hub as a peer on our side so we can call its API
-    const allPeers = await db.query.meshPeers.findMany({
-      columns: { internalIp: true },
-    });
-    const internalIp = allocateIp(allPeers.map((p) => p.internalIp));
+    // The hub allocated an IP for us: joinData.peer.internalIp
+    // The hub's own mesh IP: joinData.hub.internalIp
+    // The hub's WireGuard endpoint: joinData.hub.endpoint (IP:port for UDP)
+    const ourMeshIp = joinData.peer.internalIp;
 
+    // Register the hub as a peer on our side
     await db.insert(meshPeers).values({
       id: nanoid(),
       instanceId: joinData.peer.instanceId,
@@ -112,7 +113,7 @@ export async function POST(request: NextRequest) {
       publicKey: joinData.hub.publicKey,
       endpoint: joinData.hub.endpoint,
       allowedIps: toCidr(joinData.hub.internalIp),
-      internalIp,
+      internalIp: joinData.hub.internalIp,
       apiUrl: decoded.hubApiUrl,
       tokenHash: ourTokenHash,
       outboundToken: joinData.token,
@@ -120,12 +121,11 @@ export async function POST(request: NextRequest) {
       lastSeenAt: new Date(),
     });
 
-    // Rebuild WireGuard config with the hub as a peer
-    // (joiner inserts the hub directly, not via registerPeer, so sync here)
+    // Rebuild WireGuard config with the hub as a peer and our correct mesh IP
     try {
       const { isWireguardRunning } = await import("@/lib/mesh/wireguard");
       if (await isWireguardRunning()) {
-        await rebuildAndSync();
+        await rebuildAndSync(ourMeshIp);
       }
     } catch (err) {
       console.warn(`[mesh] WireGuard sync failed after joining hub: ${err}`);

--- a/lib/mesh/wireguard.ts
+++ b/lib/mesh/wireguard.ts
@@ -110,8 +110,12 @@ export async function syncConfig(): Promise<void> {
 /**
  * Rebuild wg0.conf from all peers in the database and hot-reload WireGuard.
  * Call this after any peer registration or removal.
+ *
+ * @param overrideAddress — if provided, use this as the local WireGuard address
+ *   instead of reading from the existing config. Used when the joiner's address
+ *   needs to change from the bootstrap HUB_IP to the hub-assigned IP.
  */
-export async function rebuildAndSync(): Promise<void> {
+export async function rebuildAndSync(overrideAddress?: string): Promise<void> {
   // Dynamic imports to avoid circular dependencies
   const { db } = await import("@/lib/db");
   const { meshPeers } = await import("@/lib/db/schema");
@@ -126,14 +130,18 @@ export async function rebuildAndSync(): Promise<void> {
     throw new Error("Could not read WireGuard private key from config");
   }
 
-  // Read the current address
-  const { stdout: addrOut } = await execFileAsync("docker", [
-    "exec", WG_CONTAINER, "sh", "-c",
-    "cat /config/wg_confs/wg0.conf | grep Address | cut -d= -f2- | tr -d ' ' | cut -d/ -f1",
-  ]);
-  const address = addrOut.trim();
+  let address: string;
+  if (overrideAddress) {
+    address = overrideAddress;
+  } else {
+    const { stdout: addrOut } = await execFileAsync("docker", [
+      "exec", WG_CONTAINER, "sh", "-c",
+      "cat /config/wg_confs/wg0.conf | grep Address | cut -d= -f2- | tr -d ' ' | cut -d/ -f1",
+    ]);
+    address = addrOut.trim();
+  }
   if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(address)) {
-    throw new Error(`Invalid WireGuard address from config: ${address}`);
+    throw new Error(`Invalid WireGuard address: ${address}`);
   }
 
   // Get all peers from the database


### PR DESCRIPTION
## Problems

1. **Joiner gets wrong mesh IP** — `ensureHubConfig(HUB_IP)` assigns `10.99.0.1` to the joiner, same as the hub. Both sides think they're `.1`, tunnel traffic stays local.

2. **Hub endpoint uses Cloudflare domain** — `console.vardo.run:51820` goes through Cloudflare which doesn't proxy UDP. WireGuard needs the raw IP.

3. **Joiner locally allocates hub's IP** — redundant, hub already tells us its IP in the join response.

## Fixes

- Joiner bootstraps WireGuard with temporary address (`10.99.0.254`), reconfigures with hub-assigned IP after join
- `rebuildAndSync()` accepts optional `overrideAddress` for the reconfiguration
- Hub peer record uses `joinData.hub.internalIp` directly
- VPS needs `VARDO_SERVER_IP` env var set to its public IP (already done manually)
- Peer display name uses `instanceName` instead of `HOSTNAME` env var

## Test plan

- [ ] Join from homelab — joiner gets `.2`, hub stays `.1`
- [ ] WireGuard endpoint is raw IP, not Cloudflare domain
- [ ] `wg show` on both sides shows peers with correct IPs
- [ ] Handshake establishes, heartbeat works