### PR TITLE
fix: WireGuard networking and address restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,7 @@ services:
       start_period: 10s
     networks:
       - internal
+      - vardo-network
     mem_limit: 64m
 
   promtail:

--- a/lib/mesh/wireguard.ts
+++ b/lib/mesh/wireguard.ts
@@ -158,7 +158,15 @@ export async function rebuildAndSync(overrideAddress?: string): Promise<void> {
   const port = parseInt(process.env.WIREGUARD_PORT || "51820", 10);
   const config = buildWgConfig(privateKey, port, address, wgPeers);
   await writeWgConfig(config);
-  await syncConfig();
+
+  if (overrideAddress) {
+    // Address changed — syncconf can't update the interface address, need full restart
+    await execFileAsync("docker", [
+      "exec", WG_CONTAINER, "sh", "-c", "wg-quick down wg0; wg-quick up wg0",
+    ]);
+  } else {
+    await syncConfig();
+  }
 }
 
 /** Check if the WireGuard container is running. */


### PR DESCRIPTION
## Problems

1. WireGuard container only on `internal` network — can't reach public IPs for the tunnel
2. `wg syncconf` doesn't change interface address — joining instance stays on bootstrap IP

## Fixes

- Add `vardo-network` to WireGuard container so it can reach the internet
- Full `wg-quick down/up` when address changes (override provided), `syncconf` for peer-only updates