### PR TITLE
feat: mesh heartbeat scheduler

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -100,6 +100,13 @@ export async function register() {
         })
         .catch((err) => log.error("Failed to start deploy sweeper:", err)),
 
+      import("./lib/mesh/scheduler")
+        .then(({ startMeshHeartbeatScheduler }) => {
+          startMeshHeartbeatScheduler();
+          log.info("Mesh heartbeat scheduler started");
+        })
+        .catch((err) => log.error("Failed to start mesh heartbeat scheduler:", err)),
+
       Promise.resolve().then(() => {
         const domainLog = logger.child("domain-monitor");
         let ticking = false;

--- a/lib/mesh/scheduler.ts
+++ b/lib/mesh/scheduler.ts
@@ -1,0 +1,45 @@
+import { db } from "@/lib/db";
+import { meshPeers } from "@/lib/db/schema";
+import { sendHeartbeatToPeer } from "./heartbeat";
+import { logger } from "@/lib/logger";
+
+const log = logger.child("mesh-heartbeat");
+const INTERVAL_MS = 30_000; // 30 seconds
+
+/**
+ * Start the mesh heartbeat scheduler.
+ * Pings all known peers at a regular interval to maintain liveness tracking.
+ */
+export function startMeshHeartbeatScheduler(): void {
+  let ticking = false;
+
+  setInterval(async () => {
+    if (ticking) return;
+    ticking = true;
+
+    try {
+      const peers = await db.query.meshPeers.findMany({
+        columns: { id: true, name: true },
+      });
+
+      if (peers.length === 0) return;
+
+      const results = await Promise.allSettled(
+        peers.map((peer) => sendHeartbeatToPeer(peer.id))
+      );
+
+      const online = results.filter(
+        (r) => r.status === "fulfilled" && r.value === true
+      ).length;
+      const offline = peers.length - online;
+
+      if (offline > 0) {
+        log.debug(`Heartbeat: ${online}/${peers.length} peers online`);
+      }
+    } catch (err) {
+      log.error("Heartbeat scheduler error:", err);
+    } finally {
+      ticking = false;
+    }
+  }, INTERVAL_MS);
+}


### PR DESCRIPTION
## Problem

The heartbeat function and endpoint existed but nothing called `sendHeartbeatToPeer` on a schedule. Peers showed 'Awaiting first heartbeat' forever.

## Fix

30-second interval scheduler that pings all known peers. Combined with the `publicApiUrl` fallback (#549), NAT'd peers maintain liveness by sending heartbeats to the hub via public URL. The hub marks them online when it receives the heartbeat.

## Files

- `lib/mesh/scheduler.ts` — new heartbeat scheduler
- `instrumentation.ts` — register at startup