### PR TITLE
feat: proper WireGuard mesh routing from frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list && \
     apt-get update -qq && \
-    apt-get install -y --no-install-recommends docker-ce-cli && \
+    apt-get install -y --no-install-recommends docker-ce-cli iproute2 gosu && \
     curl -sSL https://nixpacks.com/install.sh | bash && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then RAILPACK_ARCH="arm64"; else RAILPACK_ARCH="x86_64"; fi && \
@@ -65,10 +65,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
 COPY --from=builder --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
 
-USER nextjs
+COPY --chown=nextjs:nodejs scripts/entrypoint.sh ./scripts/entrypoint.sh
+RUN chmod +x ./scripts/entrypoint.sh
 
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["sh", "-c", "node scripts/migrate.mjs && npx next start"]
+# Entrypoint runs as root to set up mesh routing, then drops to nextjs for the app.
+# NET_ADMIN capability is required in docker-compose for the ip route command.
+ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,12 +35,15 @@ services:
       VARDO_PROJECTS_DIR: /var/lib/vardo/projects
       CADVISOR_URL: http://cadvisor:8080
       LOKI_URL: http://loki:3100
+      WIREGUARD_GATEWAY: 172.30.0.2
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+    cap_add:
+      - NET_ADMIN
     group_add:
       - ${DOCKER_GID:-999}
     volumes:
@@ -76,8 +79,10 @@ services:
       - "traefik.http.routers.vardo-fallback-https.tls=true"
       - "traefik.http.routers.vardo-fallback-https.service=vardo"
     networks:
-      - internal
-      - vardo-network
+      internal:
+      mesh:
+        ipv4_address: 172.30.0.3
+      vardo-network:
 
   postgres:
     container_name: vardo-postgres
@@ -226,6 +231,8 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      - POST_UP=iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE
+      - POST_DOWN=iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE
     ports:
       - "${WIREGUARD_PORT:-51820}:51820/udp"
     volumes:
@@ -237,8 +244,10 @@ services:
       retries: 3
       start_period: 10s
     networks:
-      - internal
-      - vardo-network
+      internal:
+      mesh:
+        ipv4_address: 172.30.0.2
+      vardo-network:
     mem_limit: 64m
 
   promtail:
@@ -268,5 +277,9 @@ volumes:
 
 networks:
   internal:
+  mesh:
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
   vardo-network:
     external: true

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Set up mesh routing if WireGuard gateway is configured.
+# Routes 10.99.0.0/24 (WireGuard mesh subnet) through the WireGuard container
+# so the frontend can reach peer APIs over the encrypted tunnel.
+if [ -n "${WIREGUARD_GATEWAY:-}" ]; then
+  ip route add 10.99.0.0/24 via "$WIREGUARD_GATEWAY" 2>/dev/null || true
+fi
+
+# Drop to nextjs user, run migrations, start the app
+exec gosu nextjs sh -c "node scripts/migrate.mjs && npx next start"


### PR DESCRIPTION
## Problem

Frontend container can't reach peer APIs at 10.99.0.x — only the WireGuard container has the tunnel interface. All mesh traffic falls back to public URLs instead of going through the encrypted tunnel.

## Solution

Proper routing through the WireGuard container:

- **Dedicated mesh network** (172.30.0.0/24) with fixed IPs — WireGuard at .2, frontend at .3
- **WireGuard as gateway** — IP forwarding enabled, iptables MASQUERADE for forwarded traffic
- **Frontend route setup** — entrypoint script adds `ip route add 10.99.0.0/24 via 172.30.0.2` at startup, then drops to nextjs user via gosu
- **NET_ADMIN cap on frontend** — accepted risk (already has Docker socket mounted)
- **Mesh heartbeat scheduler** — 30s interval, pings all known peers

## Changes

- `Dockerfile`: add iproute2 + gosu, entrypoint script
- `scripts/entrypoint.sh`: route setup + privilege drop
- `docker-compose.yml`: mesh network, fixed IPs, NET_ADMIN, WIREGUARD_GATEWAY env, masquerade
- `lib/mesh/scheduler.ts`: heartbeat scheduler
- `instrumentation.ts`: register scheduler at startup

## Test plan

- [ ] Frontend can `ping 10.99.0.1` (hub's mesh IP) from inside the container
- [ ] Heartbeat reaches peers via WireGuard tunnel (not public URL)
- [ ] Instances page shows peers as online within 30 seconds
- [ ] Non-mesh functionality unaffected (Traefik routing, deploys)