### PR TITLE
fix: WireGuard DNAT for mesh API routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -231,8 +231,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - POST_UP=iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE
-      - POST_DOWN=iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE
     ports:
       - "${WIREGUARD_PORT:-51820}:51820/udp"
     volumes:

--- a/lib/mesh/wireguard.ts
+++ b/lib/mesh/wireguard.ts
@@ -59,11 +59,17 @@ export function buildWgConfig(
     throw new Error("Invalid WireGuard private key format");
   }
 
+  // Frontend container IP on the mesh Docker network (fixed in docker-compose.yml)
+  const FRONTEND_MESH_IP = "10.88.0.3";
+
   const lines = [
     "[Interface]",
     `PrivateKey = ${privateKey}`,
     `ListenPort = ${listenPort}`,
     `Address = ${address}/24`,
+    // Forward incoming mesh traffic to the frontend container
+    `PostUp = iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE; iptables -t nat -A PREROUTING -i wg0 -p tcp --dport 3000 -j DNAT --to-destination ${FRONTEND_MESH_IP}:3000; iptables -A FORWARD -i wg0 -p tcp --dport 3000 -j ACCEPT`,
+    `PostDown = iptables -t nat -D POSTROUTING -o wg0 -j MASQUERADE; iptables -t nat -D PREROUTING -i wg0 -p tcp --dport 3000 -j DNAT --to-destination ${FRONTEND_MESH_IP}:3000; iptables -D FORWARD -i wg0 -p tcp --dport 3000 -j ACCEPT`,
     "",
   ];
 


### PR DESCRIPTION
Incoming mesh traffic on wg0:3000 needs to reach the frontend container. Add PostUp/PostDown iptables rules to wg0.conf for MASQUERADE + DNAT to frontend on mesh network.