### PR TITLE
fix: Docker socket access in entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       CADVISOR_URL: http://cadvisor:8080
       LOKI_URL: http://loki:3100
       WIREGUARD_GATEWAY: 10.88.0.2
+      DOCKER_GID: ${DOCKER_GID:-999}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,10 +2,16 @@
 set -e
 
 # Set up mesh routing if WireGuard gateway is configured.
-# Routes 10.99.0.0/24 (WireGuard mesh subnet) through the WireGuard container
-# so the frontend can reach peer APIs over the encrypted tunnel.
 if [ -n "${WIREGUARD_GATEWAY:-}" ]; then
   ip route add 10.99.0.0/24 via "$WIREGUARD_GATEWAY" 2>/dev/null || true
+fi
+
+# Ensure nextjs user has access to the Docker socket.
+# DOCKER_GID is set in docker-compose via group_add, but we need it
+# as a proper group membership for gosu to inherit.
+if [ -n "${DOCKER_GID:-}" ]; then
+  getent group "$DOCKER_GID" >/dev/null 2>&1 || addgroup --gid "$DOCKER_GID" docker 2>/dev/null || true
+  adduser nextjs "$(getent group "$DOCKER_GID" | cut -d: -f1)" 2>/dev/null || true
 fi
 
 # Drop to nextjs user, run migrations, start the app


### PR DESCRIPTION
gosu drops supplementary groups. Add Docker GID as group membership before dropping to nextjs.