### PR TITLE
Pulse online indicator on instances settings page

### DIFF
--- a/app/(authenticated)/admin/settings/instances-settings.tsx
+++ b/app/(authenticated)/admin/settings/instances-settings.tsx
@@ -385,7 +385,7 @@ export function InstancesSettings() {
                         <span
                           className={`size-2 rounded-full shrink-0 ${
                             peer.status === "online"
-                              ? "bg-status-success"
+                              ? "bg-status-success animate-pulse"
                               : "bg-status-neutral"
                           }`}
                           aria-hidden="true"


### PR DESCRIPTION
## Summary

- The green dot for online peers on the Instances settings page was static
- Added `animate-pulse` to match how every other online status dot in the app behaves

## Test plan

- [ ] Navigate to Admin > Settings > Instances with at least one online peer
- [ ] Confirm the green dot pulses
- [ ] Confirm offline peers show a static neutral dot (no pulse)