### PR TITLE
fix: bump Docker API version in HTTP client

### DIFF
--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -57,7 +57,7 @@ export async function dockerRequest<T = unknown>(
     const req = http.request(
       {
         ...conn,
-        path: `/v1.43${path}`,
+        path: `/v1.47${path}`,
         method,
         headers: {
           ...(payload


### PR DESCRIPTION
The Docker HTTP client in `lib/docker/client.ts` hardcodes API version 1.43. Modern Docker daemons (29.x) require 1.44+. This breaks container discovery, disk metrics, and any other direct Docker API call. Bump to 1.47.