### PR TITLE
fix: exclude Vardo infrastructure from discover

### DIFF
--- a/lib/docker/discover.ts
+++ b/lib/docker/discover.ts
@@ -66,7 +66,9 @@ export function parseTraefikPort(labels: Record<string, string>): number | null 
  * from discovery. Checks both the new vardo.* and legacy host.* label prefixes.
  */
 function isManagedContainer(labels: Record<string, string>): boolean {
-  return !!(labels["vardo.project"] || labels["host.project"]);
+  if (labels["vardo.project"] || labels["host.project"]) return true;
+  if (labels["com.docker.compose.project"] === "vardo") return true;
+  return false;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Vardo's own containers (frontend, traefik, postgres, etc.) appeared in the discover page because they don't have `vardo.project` labels. Filter by compose project name `vardo` to exclude them.