### PR TITLE
fix: import fully takes over container

### DIFF
--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -11,6 +11,9 @@ import { generateComposeForImage, injectTraefikLabels, composeToYaml } from "@/l
 import { encrypt } from "@/lib/crypto/encrypt";
 import { getSslConfig, getPrimaryIssuer } from "@/lib/system-settings";
 import { recordActivity } from "@/lib/activity";
+import { stopContainer, removeContainer } from "@/lib/docker/client";
+import { requestDeploy } from "@/lib/docker/deploy-cancel";
+import { logger } from "@/lib/logger";
 
 type RouteParams = {
   params: Promise<{ orgId: string; containerId: string }>;
@@ -213,6 +216,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const { app } = result;
     const appId = app.id;
+
+    // Stop and remove the old unmanaged container so it disappears from discover
+    // and the new Vardo-managed container can take over its ports and name.
+    // Best-effort — the container may already be stopped or gone.
+    try {
+      await stopContainer(containerId);
+    } catch (err) {
+      logger.warn("import: could not stop old container", { containerId, err });
+    }
+    try {
+      await removeContainer(containerId);
+    } catch (err) {
+      logger.warn("import: could not remove old container", { containerId, err });
+    }
+
+    // Trigger a Vardo deploy so the container is recreated with vardo.managed=true
+    // labels, joined to vardo-network, and fully managed. Fire-and-forget — the
+    // caller can track progress via the app's deploy page.
+    void requestDeploy({
+      appId,
+      organizationId: orgId,
+      trigger: "api",
+      triggeredBy: org.session.user.id,
+    }).catch((err) => {
+      logger.error("import: deploy failed", { appId, err });
+    });
 
     const warnings: string[] = [];
 

--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -305,6 +305,18 @@ export async function inspectContainer(id: string): Promise<ContainerInspect> {
 }
 
 // ---------------------------------------------------------------------------
+// Container lifecycle
+// ---------------------------------------------------------------------------
+
+export async function stopContainer(id: string): Promise<void> {
+  await dockerRequest("POST", `/containers/${id}/stop`);
+}
+
+export async function removeContainer(id: string): Promise<void> {
+  await dockerRequest("DELETE", `/containers/${id}`);
+}
+
+// ---------------------------------------------------------------------------
 // Logs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- After creating the Vardo app record, stop and remove the old unmanaged container so it disappears from the discover list
- Trigger a Vardo deploy immediately after import so the container is recreated with `vardo.managed=true` labels, joined to `vardo-network`, and fully Vardo-managed
- Stop/remove is best-effort — warns in logs if the container is already gone
- Deploy is fire-and-forget — the caller is redirected to the app page where deploy progress is visible

Fixes #558.

## Test plan

- [ ] Import a running container via the discover page
- [ ] Verify the old container disappears from discover immediately after import
- [ ] Verify a deploy is triggered and the container reappears under Projects, managed by Vardo
- [ ] Verify the container has `vardo.project` label and is on `vardo-network`
- [ ] Import a container that has already stopped — confirm the stop error is logged but import still succeeds and deploy fires