### PR TITLE
fix: add ?force=true to removeContainer

### DIFF
--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -11,6 +11,9 @@ import { generateComposeForImage, injectTraefikLabels, composeToYaml } from "@/l
 import { encrypt } from "@/lib/crypto/encrypt";
 import { getSslConfig, getPrimaryIssuer } from "@/lib/system-settings";
 import { recordActivity } from "@/lib/activity";
+import { stopContainer, removeContainer } from "@/lib/docker/client";
+import { requestDeploy } from "@/lib/docker/deploy-cancel";
+import { logger } from "@/lib/logger";
 
 type RouteParams = {
   params: Promise<{ orgId: string; containerId: string }>;
@@ -213,6 +216,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const { app } = result;
     const appId = app.id;
+
+    // Stop and remove the old unmanaged container so it disappears from discover
+    // and the new Vardo-managed container can take over its ports and name.
+    // Best-effort — the container may already be stopped or gone.
+    try {
+      await stopContainer(containerId);
+    } catch (err) {
+      logger.warn("import: could not stop old container", { containerId, err });
+    }
+    try {
+      await removeContainer(containerId);
+    } catch (err) {
+      logger.warn("import: could not remove old container", { containerId, err });
+    }
+
+    // Trigger a Vardo deploy so the container is recreated with vardo.managed=true
+    // labels, joined to vardo-network, and fully managed. Fire-and-forget — the
+    // caller can track progress via the app's deploy page.
+    void requestDeploy({
+      appId,
+      organizationId: orgId,
+      trigger: "api",
+      triggeredBy: org.session.user.id,
+    }).catch((err) => {
+      logger.error("import: deploy failed", { appId, err });
+    });
 
     const warnings: string[] = [];
 

--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -305,6 +305,18 @@ export async function inspectContainer(id: string): Promise<ContainerInspect> {
 }
 
 // ---------------------------------------------------------------------------
+// Container lifecycle
+// ---------------------------------------------------------------------------
+
+export async function stopContainer(id: string): Promise<void> {
+  await dockerRequest("POST", `/containers/${id}/stop`);
+}
+
+export async function removeContainer(id: string): Promise<void> {
+  await dockerRequest("DELETE", `/containers/${id}?force=true`);
+}
+
+// ---------------------------------------------------------------------------
 // Logs
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `stopContainer` and `removeContainer` to `lib/docker/client.ts`
- Fixes `removeContainer` to use `?force=true` on the DELETE call so removal succeeds even if `stopContainer` throws
- Wires up stop/remove and a fire-and-forget deploy trigger in the container import route

Without `?force=true`, if `stopContainer` throws (container already stopped, already gone, etc.), the subsequent `DELETE /containers/{id}` hits a running container and Docker returns 409. The `force` flag tells Docker to kill and remove regardless of state.

Fixes the review finding on #570 for #558.

## Test plan

- [ ] Import a running container — old container disappears from discover, deploy fires
- [ ] Import a container that is already stopped — stop error is logged, remove succeeds, deploy fires
- [ ] Import a container that is already gone — both stop and remove log warnings, deploy still fires