### PR TITLE
fix: remove env var fallbacks from getInstanceConfig

### DIFF
--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -107,13 +107,12 @@ export async function getInstanceConfig(): Promise<InstanceConfig> {
   const dbConfig = await getSystemSettingRaw("instance_config")
     .then((raw) => raw ? parseJson<InstanceConfig>(raw, "instance_config") : null);
 
-  // Merge: config file fields > DB fields > env fallback > defaults
-  // Env fallbacks support migration from env-only setups to DB-managed config
+  // Merge: config file fields > DB fields > defaults
   return {
     instanceName: fileConfig?.instance?.name ?? dbConfig?.instanceName ?? DEFAULT_APP_NAME,
-    baseDomain: fileConfig?.instance?.baseDomain ?? dbConfig?.baseDomain ?? process.env.VARDO_BASE_DOMAIN ?? "",
-    serverIp: fileConfig?.instance?.serverIp ?? dbConfig?.serverIp ?? process.env.VARDO_SERVER_IP ?? "",
-    domain: fileConfig?.instance?.domain ?? dbConfig?.domain ?? process.env.VARDO_DOMAIN ?? "",
+    baseDomain: fileConfig?.instance?.baseDomain ?? dbConfig?.baseDomain ?? "",
+    serverIp: fileConfig?.instance?.serverIp ?? dbConfig?.serverIp ?? "",
+    domain: fileConfig?.instance?.domain ?? dbConfig?.domain ?? "",
   };
 }
 


### PR DESCRIPTION
## Summary

- Removes `VARDO_DOMAIN`, `VARDO_BASE_DOMAIN`, and `VARDO_SERVER_IP` env var fallbacks from `getInstanceConfig()` in `lib/system-settings.ts`
- Config chain is now strictly `file (vardo.yml) > DB (system_settings) > defaults (empty string)` with no env vars in between
- Updates inline comment to reflect the correct resolution order

## Security

No regression. Removing env var fallbacks eliminates the possibility of env var values silently influencing instance config when neither the config file nor DB have been set. Empty string defaults are explicit and predictable. Callers already handle empty strings gracefully (checked before use).

## Test plan

- [ ] Verify instance config reads correctly from `vardo.yml` when present
- [ ] Verify instance config reads from DB (`system_settings`) when no file config exists
- [ ] Verify empty string defaults when neither source is set
- [ ] Confirm `VARDO_DOMAIN`, `VARDO_BASE_DOMAIN`, `VARDO_SERVER_IP` env vars no longer affect `getInstanceConfig()` output

Closes #545