### PR TITLE
fix: lazy Redis clients to silence build-time ECONNREFUSED noise

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -14,18 +14,22 @@ const WARN_THRESHOLD = 180;
 // Publish client — shared, reused across all publishEvent calls
 // ---------------------------------------------------------------------------
 const globalForPub = globalThis as unknown as { redisPub: Redis | undefined };
-const publishClient =
-  globalForPub.redisPub ??
-  new Redis(url, { maxRetriesPerRequest: 3, lazyConnect: true });
-if (process.env.NODE_ENV !== "production") {
-  globalForPub.redisPub = publishClient;
+
+function getPublishClient(): Redis {
+  if (!globalForPub.redisPub) {
+    globalForPub.redisPub = new Redis(url, {
+      maxRetriesPerRequest: 3,
+      lazyConnect: true,
+    });
+  }
+  return globalForPub.redisPub;
 }
 
 export async function publishEvent(
   channel: string,
   data: Record<string, unknown>,
 ) {
-  await publishClient.publish(channel, JSON.stringify(data));
+  await getPublishClient().publish(channel, JSON.stringify(data));
 }
 
 // ---------------------------------------------------------------------------
@@ -200,7 +204,10 @@ function cleanup() {
     state.subscriberCount = 0;
     globalForSub.redisSubState = undefined;
   }
-  publishClient.disconnect();
+  if (globalForPub.redisPub) {
+    globalForPub.redisPub.disconnect();
+    globalForPub.redisPub = undefined;
+  }
 }
 
 process.once("SIGTERM", cleanup);

--- a/lib/metrics/store.ts
+++ b/lib/metrics/store.ts
@@ -6,8 +6,27 @@ const url = process.env.REDIS_URL || "redis://localhost:7200";
 
 // Dedicated connection for time-series operations
 const globalForTS = globalThis as unknown as { tsRedis: Redis | undefined };
-const tsRedis = globalForTS.tsRedis ?? new Redis(url, { maxRetriesPerRequest: 3 });
-if (process.env.NODE_ENV !== "production") globalForTS.tsRedis = tsRedis;
+
+function getTsClient(): Redis {
+  if (!globalForTS.tsRedis) {
+    globalForTS.tsRedis = new Redis(url, {
+      maxRetriesPerRequest: 3,
+      lazyConnect: true,
+    });
+  }
+  return globalForTS.tsRedis;
+}
+
+const tsRedis = new Proxy({} as Redis, {
+  get(_, prop: string | symbol) {
+    const client = getTsClient();
+    const value = (client as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof value === "function") {
+      return (value as (...args: unknown[]) => unknown).bind(client);
+    }
+    return value;
+  },
+});
 
 // Retention: 7 days in ms
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -2,7 +2,7 @@ import Redis from "ioredis";
 
 const globalForRedis = globalThis as unknown as { redis: Redis | undefined };
 
-function createRedisClient() {
+function createRedisClient(): Redis {
   const url = process.env.REDIS_URL || "redis://localhost:7200";
   return new Redis(url, {
     maxRetriesPerRequest: 3,
@@ -10,8 +10,20 @@ function createRedisClient() {
   });
 }
 
-export const redis = globalForRedis.redis ?? createRedisClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalForRedis.redis = redis;
+function getClient(): Redis {
+  if (!globalForRedis.redis) {
+    globalForRedis.redis = createRedisClient();
+  }
+  return globalForRedis.redis;
 }
+
+export const redis = new Proxy({} as Redis, {
+  get(_, prop: string | symbol) {
+    const client = getClient();
+    const value = (client as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof value === "function") {
+      return (value as (...args: unknown[]) => unknown).bind(client);
+    }
+    return value;
+  },
+});


### PR DESCRIPTION
## What

During `docker build`, Next.js static page generation imports redis modules before Redis is available. This caused dozens of `[ioredis] Unhandled error event: connect ECONNREFUSED 127.0.0.1:7200` errors on every build — noisy but harmless.

## Why it happened

Three files created Redis client instances at module load time:

- `lib/redis.ts` — `new Redis()` on the exported `redis` constant
- `lib/events.ts` — `publishClient` created eagerly at module level
- `lib/metrics/store.ts` — `tsRedis` created eagerly with no `lazyConnect` at all

Even with `lazyConnect: true`, instantiating ioredis at import time means the client exists and will attempt to connect the moment any command is issued — including during static generation.

## Fix

Replaced all three with lazy proxy getters. The Redis client is not instantiated until the first method call, so importing these modules during build has zero side effects. All existing callers work unchanged.

Also added `lazyConnect: true` to `lib/metrics/store.ts` which was missing it.

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors