### PR TITLE
fix: pulse animation on online peer status dot (#555)

### DIFF
--- a/components/mesh/project-instances.tsx
+++ b/components/mesh/project-instances.tsx
@@ -55,16 +55,16 @@ export function ProjectInstances({
     return peers.find((p) => p.id === peerId)?.status ?? "offline";
   }
 
-  function statusColor(status: string) {
+  function statusDotClass(status: string) {
     switch (status) {
       case "running":
       case "online":
-        return "bg-green-500";
+        return "bg-status-success animate-pulse";
       case "stopped":
       case "offline":
-        return "bg-zinc-400";
+        return "bg-status-neutral";
       default:
-        return "bg-yellow-500";
+        return "bg-status-warning";
     }
   }
 
@@ -281,7 +281,7 @@ export function ProjectInstances({
                   <td className="px-4 py-3 font-medium capitalize">{inst.environment}</td>
                   <td className="px-4 py-3">
                     <span className="flex items-center gap-2">
-                      <span className={`size-2 rounded-full ${statusColor(status)}`} aria-hidden="true" />
+                      <span className={`size-2 rounded-full ${statusDotClass(status)}`} aria-hidden="true" />
                       {peerName(inst.meshPeerId)}
                       <span className="sr-only">({status})</span>
                     </span>


### PR DESCRIPTION
## What

Adds a pulse animation to the green status dot for online peers in the project instances table (`components/mesh/project-instances.tsx`).

## Why

The dot was static — using raw color classes (`bg-green-500`) with no animation. Every other status indicator in the app uses `bg-status-success animate-pulse` for online/running states (see `components/app-status.tsx`, `app/(authenticated)/admin/settings/instances-settings.tsx`).

## Changes

- Renamed `statusColor` → `statusDotClass` to reflect that it returns full class strings, not just color
- Online/running: `bg-green-500` → `bg-status-success animate-pulse`
- Offline/stopped: `bg-zinc-400` → `bg-status-neutral`
- Default/unknown: `bg-yellow-500` → `bg-status-warning`

Fixes #555