### PR TITLE
fix: use meaningful peer names in mesh instances

### DIFF
--- a/app/api/v1/admin/mesh/join/route.ts
+++ b/app/api/v1/admin/mesh/join/route.ts
@@ -6,7 +6,7 @@ import { decodeInviteToken } from "@/lib/mesh/invite";
 import { generateMeshToken } from "@/lib/mesh/auth";
 import { ensureHubConfig } from "@/lib/mesh";
 import { getInstanceId } from "@/lib/constants";
-import { getInstanceConfig } from "@/lib/system-settings";
+import { getInstanceDisplayName } from "@/lib/system-settings";
 import { hostname as osHostname } from "node:os";
 import { needsSetup } from "@/lib/setup";
 import { inheritConfigFromHub, validateHubUrl } from "@/lib/mesh/config-inheritance";
@@ -17,6 +17,20 @@ import { nanoid } from "nanoid";
 import { toCidr } from "@/lib/mesh/ip-allocator";
 
 const joinSchema = z.object({ token: z.string().min(1, "Invite token is required") }).strict();
+
+const joinResponseSchema = z.object({
+  peer: z.object({
+    instanceId: z.string(),
+    internalIp: z.string(),
+  }).passthrough(),
+  token: z.string(),
+  hub: z.object({
+    publicKey: z.string(),
+    endpoint: z.string().nullable().optional(),
+    internalIp: z.string(),
+    name: z.string().max(255).nullable().optional(),
+  }),
+});
 
 /**
  * POST /api/v1/admin/mesh/join — join a mesh using an invite token.
@@ -63,8 +77,7 @@ export async function POST(request: NextRequest) {
     const localPublicKey = await ensureHubConfig("10.99.0.254");
 
     const instanceId = await getInstanceId();
-    const instanceConfig = await getInstanceConfig();
-    const hostname = instanceConfig.instanceName || instanceConfig.domain || osHostname();
+    const hostname = (await getInstanceDisplayName()) ?? osHostname();
 
     // Generate a token the hub can use to call our API
     const { raw: ourToken, hash: ourTokenHash } = generateMeshToken();
@@ -92,13 +105,23 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const joinData = await joinRes.json();
+    const rawJoinData = await joinRes.json();
     if (!joinRes.ok) {
       return NextResponse.json(
-        { error: joinData.error || "The other instance rejected the invite." },
+        { error: rawJoinData.error || "The other instance rejected the invite." },
         { status: joinRes.status }
       );
     }
+
+    // Validate and parse the hub's response — clamps hub.name to 255 chars at the parse layer
+    const joinParsed = joinResponseSchema.safeParse(rawJoinData);
+    if (!joinParsed.success) {
+      return NextResponse.json(
+        { error: "Unexpected response from the other instance." },
+        { status: 502 }
+      );
+    }
+    const joinData = joinParsed.data;
 
     // The hub allocated an IP for us: joinData.peer.internalIp
     // The hub's own mesh IP: joinData.hub.internalIp
@@ -109,7 +132,7 @@ export async function POST(request: NextRequest) {
     await db.insert(meshPeers).values({
       id: nanoid(),
       instanceId: joinData.peer.instanceId,
-      name: (joinData.hub.name || "Hub").slice(0, 255),
+      name: joinData.hub.name || "Hub",
       type: "persistent",
       publicKey: joinData.hub.publicKey,
       endpoint: joinData.hub.endpoint,

--- a/app/api/v1/mesh/join/route.ts
+++ b/app/api/v1/mesh/join/route.ts
@@ -7,7 +7,7 @@ import { meshPeers } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { redeemInvite } from "@/lib/mesh/invite";
 import { registerPeer } from "@/lib/mesh/peers";
-import { getInstanceConfig } from "@/lib/system-settings";
+import { getInstanceDisplayName } from "@/lib/system-settings";
 
 const WG_KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
 
@@ -50,9 +50,9 @@ async function handler(request: NextRequest) {
       );
     }
 
-    const [{ peer, token }, instanceConfig] = await Promise.all([
+    const [{ peer, token }, hubName] = await Promise.all([
       registerPeer(peerInput),
-      getInstanceConfig(),
+      getInstanceDisplayName(),
     ]);
 
     // Store the joiner's outbound token so we can call their API
@@ -64,7 +64,6 @@ async function handler(request: NextRequest) {
     }
 
     const { tokenHash: _hash, ...peerWithoutHash } = peer;
-    const hubName = instanceConfig.instanceName || instanceConfig.domain || null;
     return NextResponse.json(
       {
         peer: peerWithoutHash,

--- a/lib/system-settings.ts
+++ b/lib/system-settings.ts
@@ -116,6 +116,15 @@ export async function getInstanceConfig(): Promise<InstanceConfig> {
   };
 }
 
+/**
+ * Returns the configured display name for this instance: instanceName > domain > null.
+ * Callers that always need a non-null value can provide a fallback, e.g. `os.hostname()`.
+ */
+export async function getInstanceDisplayName(): Promise<string | null> {
+  const config = await getInstanceConfig();
+  return config.instanceName || config.domain || null;
+}
+
 // ---------------------------------------------------------------------------
 // GitHub App
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Hub now sends its instance name (from Settings > General) in the join response
- Joining instance uses the hub's actual name instead of the hardcoded string `"Hub"`
- Joining instance falls back to the OS hostname (`os.hostname()`) instead of `"unknown"` when no instance name or domain is configured

## What was wrong

When two Vardo instances connected via the mesh join flow, the hub peer always appeared as `"Hub"` on the joining side regardless of what name the hub had configured. The hub's join response didn't include its name, so the joining instance had no way to know it.

On the other side, if a joining instance hadn't configured an instance name or domain, it would show up as `"unknown"` on the hub.

## Changes

`app/api/v1/mesh/join/route.ts` — hub-side join endpoint now includes the hub's configured name in the response (falls back to `null` if not configured, which lets the joining side use its own fallback).

`app/api/v1/admin/mesh/join/route.ts` — joining side now reads `joinData.hub.name` and falls back to `"Hub"` only if the hub sent nothing. The joining instance's own name now falls back to `os.hostname()` instead of the string `"unknown"`.

Closes #556