### PR TITLE
feat: validate compose and route Traefik away from host-network services

### DIFF
--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -127,7 +127,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       exposedPorts: detail.ports.filter((p) => p.external),
     });
 
-    // Inject Traefik labels if a domain was found
+    // Inject Traefik labels if a domain was found.
+    // TODO: if container import ever produces multi-service or host-network compose files,
+    // pass serviceName here (the first bridge-network service) as deploy.ts does.
     const sslConfig = await getSslConfig();
     if (detail.domain && containerPort) {
       compose = injectTraefikLabels(compose, {

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -644,13 +644,14 @@ export async function runDeployment(
       .map(([name, svc]) => `${name} (${svc.network_mode})`);
     const allServicesCustomNetwork = servicesWithCustomNetwork.length === Object.keys(compose.services).length;
 
-    // For mixed-mode compose files, route Traefik to the first bridge-network service
-    // to avoid injecting labels into a host-network service that Traefik can't reach
-    const primaryServiceName = Object.keys(compose.services).find(
-      (k) => !compose.services[k].network_mode || compose.services[k].network_mode === "bridge"
-    );
-
-    if (!allServicesCustomNetwork && primaryServiceName) {
+    if (!allServicesCustomNetwork) {
+      // Find the first bridge-network service in compose file order (Object.keys preserves
+      // insertion order for string keys, matching the order services appear in the compose file).
+      // This ensures Traefik labels target a service reachable on vardo-network rather than
+      // a host-network, service:X, or container:X service that Traefik can't reach.
+      const primaryServiceName = Object.keys(compose.services).find(
+        (k) => !compose.services[k].network_mode || compose.services[k].network_mode === "bridge"
+      );
       for (const domain of app.domains) {
         const port = domain.port || containerPort;
         compose = injectTraefikLabels(compose, {

--- a/tests/unit/lib/docker/compose.test.ts
+++ b/tests/unit/lib/docker/compose.test.ts
@@ -562,4 +562,68 @@ describe("injectTraefikLabels — serviceName", () => {
     expect(result.services.web.labels?.["traefik.enable"]).toBe("true");
     expect(result.services.worker.labels?.["traefik.enable"]).toBeUndefined();
   });
+
+  it("throws when serviceName references a service that does not exist", () => {
+    const compose: ComposeFile = {
+      services: {
+        web: { name: "web", image: "nginx" },
+      },
+    };
+
+    expect(() =>
+      injectTraefikLabels(compose, { ...baseOpts, serviceName: "nonexistent" })
+    ).toThrow('Service "nonexistent" not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// primaryServiceName logic — service:X and container:X network modes
+// ---------------------------------------------------------------------------
+
+describe("injectTraefikLabels — service:X and container:X network modes", () => {
+  const baseOpts = {
+    projectName: "myapp",
+    domain: "myapp.example.com",
+    containerPort: 3000,
+  };
+
+  it("skips a service:X service and targets the first bridge-network service", () => {
+    const compose: ComposeFile = {
+      services: {
+        vpn: { name: "vpn", image: "openvpn" },
+        proxy: { name: "proxy", image: "nginx", network_mode: "service:vpn" },
+        web: { name: "web", image: "node" },
+      },
+    };
+
+    // Simulate the primaryServiceName logic from deploy.ts
+    const primaryServiceName = Object.keys(compose.services).find(
+      (k) => !compose.services[k].network_mode || compose.services[k].network_mode === "bridge"
+    );
+
+    expect(primaryServiceName).toBe("vpn");
+    const result = injectTraefikLabels(compose, { ...baseOpts, serviceName: primaryServiceName });
+    expect(result.services.vpn.labels?.["traefik.enable"]).toBe("true");
+    expect(result.services.proxy.labels?.["traefik.enable"]).toBeUndefined();
+    expect(result.services.web.labels?.["traefik.enable"]).toBeUndefined();
+  });
+
+  it("skips a container:X service and targets the first bridge-network service", () => {
+    const compose: ComposeFile = {
+      services: {
+        db: { name: "db", image: "postgres" },
+        sidecar: { name: "sidecar", image: "alpine", network_mode: "container:db" },
+        api: { name: "api", image: "node" },
+      },
+    };
+
+    const primaryServiceName = Object.keys(compose.services).find(
+      (k) => !compose.services[k].network_mode || compose.services[k].network_mode === "bridge"
+    );
+
+    expect(primaryServiceName).toBe("db");
+    const result = injectTraefikLabels(compose, { ...baseOpts, serviceName: primaryServiceName });
+    expect(result.services.db.labels?.["traefik.enable"]).toBe("true");
+    expect(result.services.sidecar.labels?.["traefik.enable"]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #533

## Summary

- Wire `validateCompose` into the deploy pipeline (`parseAndSanitize`) so structural errors — invalid `service:X` references, circular chains, malformed service names — surface as a `DeployBlockedError` before `docker compose up` runs rather than failing at runtime with a cryptic Docker error
- Fix Traefik label injection for mixed-mode compose files: when a compose has both host-network and bridge-network services, target the first bridge-network service instead of the first service unconditionally — prevents labels landing on a host-network container that Traefik can't reach on `vardo-network`
- Add tests for `injectTraefikLabels` covering explicit `serviceName` targeting and the host-network + bridge-network mixed case

The core `network_mode: host` behavior (skipping `vardo-network` attachment, skipping Traefik for all-host-network apps) was already in place. This PR closes the remaining gaps.

## Test plan

- [x] `pnpm test` — 137 tests pass, 0 errors
- [x] New tests confirm Traefik labels target the bridge-network service in mixed-mode compose
- [x] Rebased on main cleanly