### PR TITLE
fix: don't capture image-inherited env vars on import

### DIFF
--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -526,6 +526,22 @@ function stripDockerLogHeaders(raw: string): string {
 // Port detection
 // ---------------------------------------------------------------------------
 
+/**
+ * Fetch the env vars baked into a Docker image.
+ * Returns an empty array if the image cannot be inspected (e.g. the image
+ * was removed after the container was created).
+ */
+export async function inspectImageEnv(imageRef: string): Promise<string[]> {
+  try {
+    const image = await dockerRequest<{
+      Config?: { Env?: string[] | null };
+    }>("GET", `/images/${encodeURIComponent(imageRef)}/json`);
+    return image.Config?.Env ?? [];
+  } catch {
+    return [];
+  }
+}
+
 export async function detectExposedPorts(imageOrId: string): Promise<number[]> {
   // Try image inspect first, fall back to container inspect
   let exposedPorts: Record<string, unknown> | undefined;

--- a/lib/docker/discover.ts
+++ b/lib/docker/discover.ts
@@ -1,4 +1,4 @@
-import { listContainers, inspectContainer } from "./client";
+import { listContainers, inspectContainer, inspectImageEnv } from "./client";
 import type { ContainerInspect, ContainerRuntimeOptions } from "./client";
 
 // ---------------------------------------------------------------------------
@@ -175,8 +175,31 @@ export function groupByComposeProject(containers: DiscoveredContainer[]): Discov
 // ---------------------------------------------------------------------------
 
 /**
+ * Remove env vars that are identical to what the image provides.
+ *
+ * Docker containers inherit env vars from their image (PATH, LANG, etc.).
+ * During import we only want the delta — vars that were explicitly set or
+ * overridden at container run time. Capturing inherited vars causes broken
+ * containers because the values are locked to whatever was in the image at
+ * import time, overriding anything the new image version might set.
+ *
+ * Vars that share a key with the image but have a different value are kept
+ * because they represent explicit runtime overrides.
+ */
+export function filterImageInheritedEnv(
+  containerEnv: string[],
+  imageEnv: string[],
+): string[] {
+  const imageSet = new Set(imageEnv);
+  return containerEnv.filter((e) => !imageSet.has(e));
+}
+
+/**
  * Inspect a single container and return enriched detail including env vars.
  * Verifies the container is not Vardo-managed before returning.
+ *
+ * Env vars inherited from the image are filtered out — only vars that were
+ * explicitly set or overridden at runtime are included.
  */
 export async function getContainerDetail(containerId: string): Promise<ContainerDetail | null> {
   const data: ContainerInspect = await inspectContainer(containerId);
@@ -190,6 +213,12 @@ export async function getContainerDetail(containerId: string): Promise<Container
   const hasNvidiaEnv = data.env.some((e) => e.startsWith("NVIDIA_VISIBLE_DEVICES=") || e.startsWith("NVIDIA_DRIVER_CAPABILITIES="));
   const hasNvidiaDevice = data.devices.some((d) => d.hostPath.startsWith("/dev/nvidia") || d.containerPath.startsWith("/dev/nvidia"));
 
+  // Filter out env vars that come from the image itself. Only the delta
+  // (vars explicitly set or overridden at run time) is meaningful to capture.
+  // If the image inspect fails for any reason we fall back to the full list.
+  const imageEnv = await inspectImageEnv(data.image);
+  const filteredEnv = filterImageInheritedEnv(data.env, imageEnv);
+
   return {
     id: data.id,
     name: data.name,
@@ -202,7 +231,7 @@ export async function getContainerDetail(containerId: string): Promise<Container
     composeProject: data.labels["com.docker.compose.project"] ?? null,
     networkMode,
     hasGpu: detectContainerGpu(data.image, data.labels) || hasNvidiaEnv || hasNvidiaDevice,
-    env: data.env,
+    env: filteredEnv,
     networks: data.networks,
     labels: data.labels,
     capAdd: data.capAdd,

--- a/tests/unit/lib/docker/discover.test.ts
+++ b/tests/unit/lib/docker/discover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectContainerGpu } from "@/lib/docker/discover";
+import { detectContainerGpu, filterImageInheritedEnv } from "@/lib/docker/discover";
 
 // ---------------------------------------------------------------------------
 // detectContainerGpu — GPU heuristic for discovered containers
@@ -56,5 +56,55 @@ describe("detectContainerGpu", () => {
       "com.nvidia.cuda.version": "12.0",
       "com.docker.compose.service": "app",
     })).toBe(true);
+  });
+});
+
+describe("filterImageInheritedEnv", () => {
+  it("removes vars that are identical in the image", () => {
+    const imageEnv = [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "LANG=C.UTF-8",
+    ];
+    const containerEnv = [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "LANG=C.UTF-8",
+      "MY_SECRET=hunter2",
+    ];
+    expect(filterImageInheritedEnv(containerEnv, imageEnv)).toEqual([
+      "MY_SECRET=hunter2",
+    ]);
+  });
+
+  it("keeps vars with the same key but a different value (explicit override)", () => {
+    const imageEnv = ["PATH=/usr/bin:/bin"];
+    const containerEnv = ["PATH=/usr/local/bin:/usr/bin:/bin", "APP_ENV=production"];
+    expect(filterImageInheritedEnv(containerEnv, imageEnv)).toEqual([
+      "PATH=/usr/local/bin:/usr/bin:/bin",
+      "APP_ENV=production",
+    ]);
+  });
+
+  it("returns all vars when imageEnv is empty (fallback path)", () => {
+    const containerEnv = ["PATH=/usr/bin", "SECRET=abc"];
+    expect(filterImageInheritedEnv(containerEnv, [])).toEqual(containerEnv);
+  });
+
+  it("returns empty array when both lists are empty", () => {
+    expect(filterImageInheritedEnv([], [])).toEqual([]);
+  });
+
+  it("returns empty array when all container vars are inherited", () => {
+    const env = ["PATH=/usr/bin", "LANG=C"];
+    expect(filterImageInheritedEnv(env, env)).toEqual([]);
+  });
+
+  it("handles vars without an equals sign gracefully", () => {
+    const imageEnv = ["PATH=/usr/bin"];
+    const containerEnv = ["PATH=/usr/bin", "NOVALUE", "KEY=val"];
+    // "NOVALUE" is not in imageEnv set → kept
+    expect(filterImageInheritedEnv(containerEnv, imageEnv)).toEqual([
+      "NOVALUE",
+      "KEY=val",
+    ]);
   });
 });


### PR DESCRIPTION
## Changes

- Added `inspectImageEnv` to `lib/docker/client.ts` — fetches the env vars baked into a Docker image via the image inspect API. Returns empty array on any error (safe fallback).
- Added `filterImageInheritedEnv` to `lib/docker/discover.ts` — pure function that subtracts image-inherited env entries from a container's env list. Vars with the same key but a different value (explicit runtime overrides) are kept.
- Updated `getContainerDetail` to call both functions and return only the delta env. This fixes both import paths:
  - **Single-container import**: the `GET /discover/containers/{id}` endpoint now returns filtered env, so the import dialog pre-fills only user-set vars.
  - **Compose group import**: `parseContainerEnvVars` receives the already-filtered env from `getContainerDetail` — no change needed in the group import route.
- Added `tests/unit/lib/docker/discover.test.ts` with coverage for `filterImageInheritedEnv`.

## Why

Docker's container inspect returns all env vars including ones baked into the image at build time — `PATH`, `LANG`, `NGINX_VERSION`, `DEBIAN_FRONTEND`, etc. Capturing those vars during import causes broken containers: the values get locked to whatever was in the image at import time and override what a new image version might set on redeploy.

The right set to capture is the delta — only vars that were explicitly passed at `docker run` time or set in the compose file.

Closes #629