### PR TITLE
fix: run database migrations explicitly during vardo update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1480,6 +1480,13 @@ _do_rebuild() {
   export GIT_SHA=$(git -C "$VARDO_DIR" rev-parse --short HEAD 2>/dev/null || true)
   run_with_spinner "Building containers" docker compose -f "$COMPOSE_FILE" build
 
+  # Run pending database migrations using the freshly built image, before starting the app.
+  # This is explicit and reliable — doesn't depend on whether the container is recreated.
+  if ! is_dev; then
+    run_with_spinner "Running database migrations" \
+      docker compose -f "$COMPOSE_FILE" run --rm --no-deps -T --entrypoint gosu frontend nextjs node scripts/migrate.mjs
+  fi
+
   info "Restarting services..."
   run_cmd docker compose -f "$COMPOSE_FILE" up -d
 


### PR DESCRIPTION
## Problem

Closes #625.

`vardo update` rebuilds the frontend image and calls `docker compose up -d`, expecting that container recreation will trigger the entrypoint — which runs `migrate.mjs` before starting the app. If the container isn't recreated (e.g. cached image digest, or Docker Compose deciding nothing changed), migrations are silently skipped. This caused a missing column at runtime after an update that included a schema change.

## Solution

Add an explicit migration step to `_do_rebuild()` that runs `migrate.mjs` in a one-off container using the freshly built image, before services are restarted:

```bash
docker compose run --rm --no-deps -T --entrypoint gosu frontend nextjs node scripts/migrate.mjs
```

Skipped in dev mode — no frontend container in that profile.

Migrations are still run in the entrypoint on startup as well, so the behavior is idempotent (already-applied migrations are no-ops). The explicit step just makes it reliable and visible in the update output.