### PR TITLE
feat: ask for container port in import dialog when auto-detection fails

### DIFF
--- a/app/(authenticated)/discover/import-dialog.tsx
+++ b/app/(authenticated)/discover/import-dialog.tsx
@@ -58,6 +58,7 @@ export function ImportDialog({
   const [projectId, setProjectId] = useState<string>("none");
   const [newProjectName, setNewProjectName] = useState("");
   const [envVars, setEnvVars] = useState<EnvVar[]>([]);
+  const [manualPort, setManualPort] = useState("");
   // Per-mount toggles: keyed by destination path
   const [mountToggles, setMountToggles] = useState<Record<string, boolean>>({});
   const [submitting, setSubmitting] = useState(false);
@@ -73,6 +74,7 @@ export function ImportDialog({
     setProjectId(validDefault ? defaultProjectId : "none");
     setNewProjectName("");
     setEnvVars([]);
+    setManualPort("");
     setMountToggles({});
     setDetail(null);
     setDetailError(false);
@@ -144,6 +146,8 @@ export function ImportDialog({
         .filter((m) => mountToggles[m.destination])
         .map((m) => m.destination);
 
+      const parsedManualPort = manualPort ? parseInt(manualPort, 10) : null;
+
       const body = {
         displayName,
         name,
@@ -151,6 +155,7 @@ export function ImportDialog({
         newProjectName: projectId === "new" ? newProjectName : undefined,
         envVars,
         selectedMountDestinations,
+        containerPort: parsedManualPort && !isNaN(parsedManualPort) ? parsedManualPort : null,
       };
 
       const res = await fetch(
@@ -198,6 +203,12 @@ export function ImportDialog({
   const hasSelectedBindMounts = selectedMounts.some((m) => m.type === "bind");
   const selectedCount = selectedMounts.length;
   const isHostNetwork = (detail?.networkMode ?? container?.networkMode) === "host";
+
+  // Show manual port input when auto-detection fails: no Traefik port and no exposed ports.
+  // Skip for host-network containers — they don't use port mapping.
+  const portAutoDetected =
+    detail !== null && (detail.containerPort !== null || detail.ports.some((p) => p.internal));
+  const showPortInput = detail !== null && !isHostNetwork && !portAutoDetected;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -249,6 +260,26 @@ export function ImportDialog({
                 <p id="slug-hint" className="text-xs text-muted-foreground">Lowercase letters, numbers, and hyphens only.</p>
               </div>
             </div>
+
+            {showPortInput && (
+              <div className="space-y-1.5">
+                <Label htmlFor="containerPort">Container port</Label>
+                <Input
+                  id="containerPort"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={manualPort}
+                  onChange={(e) => setManualPort(e.target.value)}
+                  placeholder="e.g. 3000"
+                  className="font-mono text-sm"
+                  aria-describedby="containerPort-hint"
+                />
+                <p id="containerPort-hint" className="text-xs text-muted-foreground">
+                  The port this container listens on. Used for domain routing — leave blank to configure later.
+                </p>
+              </div>
+            )}
 
             <div className="space-y-1.5">
               <Label htmlFor="project">Project</Label>

--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -51,6 +51,8 @@ const importSchema = z.object({
   selectedMountDestinations: z.array(z.string().max(4096, "Mount destination too long")).max(100, "Too many mount destinations").optional(),
   // Deprecated: use selectedMountDestinations. Kept for backward compatibility.
   importVolumes: z.boolean().default(true),
+  // User-supplied container port — used when auto-detection (Traefik labels + exposed ports) fails.
+  containerPort: z.number().int().min(1).max(65535).nullable().optional(),
 });
 
 // POST /api/v1/organizations/[orgId]/discover/containers/[containerId]/import
@@ -97,10 +99,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Determine container port — prefer Traefik-detected, then first exposed port
+    // Determine container port — prefer Traefik-detected, then first exposed port,
+    // then fall back to the port supplied by the user in the import form.
     const containerPort =
       detail.containerPort ??
       detail.ports.find((p) => p.internal)?.internal ??
+      data.containerPort ??
       null;
 
     // Resolve which mounts to import


### PR DESCRIPTION
Closes #632

## What changed

When a container has no Traefik port labels and no exposed ports, the import dialog now shows a **Container port** input field. The user can enter the port their container listens on to enable domain routing, or leave it blank and configure routing later.

### Dialog
- Port input appears only when both Traefik-label detection and exposed-port fallback produce nothing
- Hidden for host-network containers (they don't use port mapping)
- Field is optional — leaving it blank imports without a domain record, same as before
- Port is placed between the name/slug row and the project selector

### API
- `containerPort` added to the import schema (`z.number().int().min(1).max(65535).nullable().optional()`)
- Resolution order: Traefik label → first exposed port → user-supplied → null
- Fully backward-compatible — existing clients that omit the field behave identically