### PR TITLE
fix: run database migrations explicitly during vardo update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1485,6 +1485,10 @@ _do_rebuild() {
 
   wait_healthy 120 3 || true
 
+  step "Migrations"
+  run_with_spinner "Running database migrations" \
+    docker compose -f "$COMPOSE_FILE" exec -T frontend node scripts/migrate.mjs
+
   # Summary
   local new_version
   new_version=$(get_version)


### PR DESCRIPTION
## Problem

`vardo update` pulls the latest code and rebuilds, but didn't have an explicit migration step. The container's entrypoint runs migrations on startup, but if the container is restarted without being recreated (e.g. a crash-restart of the existing container rather than a full `docker compose up` recreation), new migration files from the updated image are never applied.

Closes #625.

## Solution

Add an explicit `Migrations` step to `_do_rebuild`, after the container is healthy. This runs `node scripts/migrate.mjs` inside the frontend container via `docker compose exec`, ensuring pending migrations are applied as a visible part of every update.

The migration script is idempotent — it's safe to run after the container has already applied migrations through the entrypoint, since it tracks applied migrations and skips anything already recorded.