### PR TITLE
feat: ask for container port in import dialog when auto-detection fails

### DIFF
--- a/app/(authenticated)/discover/import-dialog.tsx
+++ b/app/(authenticated)/discover/import-dialog.tsx
@@ -24,6 +24,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, X, HardDrive, FolderOpen } from "lucide-react";
 import type { DiscoveredContainer, ContainerDetail } from "@/lib/docker/discover";
+import { resolveContainerPort } from "@/lib/docker/resolve-port";
 import { slugify } from "@/lib/ui/slugify";
 
 type Project = { id: string; name: string; displayName: string };
@@ -210,10 +211,8 @@ export function ImportDialog({
   const isHostNetwork = (detail?.networkMode ?? container?.networkMode) === "host";
 
   // Show the manual port field only after detail loads and auto-detection has no result.
-  // Auto-detection: Traefik label port first, then first exposed internal port.
-  const autoDetectedPort = detail
-    ? (detail.containerPort ?? detail.ports.find((p) => p.internal)?.internal ?? null)
-    : undefined;
+  // Uses the same resolution chain as the server: Traefik label → exposed port → null.
+  const autoDetectedPort = detail ? resolveContainerPort(detail) : undefined;
   const showPortField = detail !== null && autoDetectedPort === null && !isHostNetwork;
 
   return (

--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -7,6 +7,7 @@ import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { getContainerDetail, isLocalImage } from "@/lib/docker/discover";
+import { resolveContainerPort } from "@/lib/docker/resolve-port";
 import { generateComposeFromContainer, injectTraefikLabels, composeToYaml } from "@/lib/docker/compose";
 import { encrypt } from "@/lib/crypto/encrypt";
 import { getSslConfig, getPrimaryIssuer } from "@/lib/system-settings";
@@ -99,13 +100,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Determine container port — prefer Traefik-detected, then first exposed port,
-    // then user-supplied value when auto-detection yields nothing.
-    const containerPort =
-      detail.containerPort ??
-      detail.ports.find((p) => p.internal)?.internal ??
-      data.containerPort ??
-      null;
+    // Determine container port via the priority chain:
+    //   Traefik label → first exposed internal port → user-supplied → null
+    const containerPort = resolveContainerPort(detail, data.containerPort);
 
     // Resolve which mounts to import
     const selectedDests =

--- a/lib/docker/resolve-port.ts
+++ b/lib/docker/resolve-port.ts
@@ -1,0 +1,22 @@
+import type { ContainerDetail } from "./discover";
+
+/**
+ * Resolve the container port using the priority chain:
+ *   Traefik label → first exposed internal port → user-supplied → null
+ *
+ * The Traefik label port is the most specific — it is what Traefik is already
+ * routing to. The first exposed port is a reasonable fallback when no label
+ * exists. The user-supplied value is the last resort for containers with no
+ * detectable port at all.
+ */
+export function resolveContainerPort(
+  detail: Pick<ContainerDetail, "containerPort" | "ports">,
+  userSupplied?: number,
+): number | null {
+  return (
+    detail.containerPort ??
+    detail.ports.find((p) => p.internal)?.internal ??
+    userSupplied ??
+    null
+  );
+}

--- a/tests/unit/lib/docker/resolve-port.test.ts
+++ b/tests/unit/lib/docker/resolve-port.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { resolveContainerPort } from "@/lib/docker/resolve-port";
+
+// resolveContainerPort priority chain:
+//   Traefik label port → first exposed internal port → user-supplied → null
+
+describe("resolveContainerPort", () => {
+  it("returns the Traefik label port when present, ignoring other sources", () => {
+    const detail = {
+      containerPort: 8080,
+      ports: [{ internal: 3000, protocol: "tcp" }],
+    };
+    expect(resolveContainerPort(detail, 9000)).toBe(8080);
+  });
+
+  it("falls back to the first exposed internal port when there is no Traefik label", () => {
+    const detail = {
+      containerPort: null,
+      ports: [{ internal: 3000, protocol: "tcp" }, { internal: 4000, protocol: "tcp" }],
+    };
+    expect(resolveContainerPort(detail)).toBe(3000);
+  });
+
+  it("falls back to the user-supplied port when auto-detection yields nothing", () => {
+    const detail = {
+      containerPort: null,
+      ports: [],
+    };
+    expect(resolveContainerPort(detail, 5000)).toBe(5000);
+  });
+
+  it("returns null when all sources are absent", () => {
+    const detail = {
+      containerPort: null,
+      ports: [],
+    };
+    expect(resolveContainerPort(detail)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

When importing a standalone container, the dialog now shows a **Container port** field when auto-detection yields nothing — i.e., the container has no Traefik port label and no exposed ports.

The field is optional. If the user fills it in, the value is used to configure domain routing at import time. If left empty, the behavior is unchanged (no routing set up).

## Why

Containers without Traefik labels and without exposed ports currently get imported with no port recorded, so domain routing is silently skipped. This gives the user a way to specify the port during import rather than having to configure it afterward.

## How

**`import-dialog.tsx`**
- Added `manualPort` state, reset on each open.
- After detail loads, compute `autoDetectedPort` using the same chain as the backend: Traefik label port → first exposed internal port.
- Render a `Container port` input (with `aria-describedby` hint) only when `autoDetectedPort === null` and the container is not host-networked (host-network containers don't support routing anyway).
- Include `containerPort` in the POST body.

**`import/route.ts`**
- Added `containerPort` field to the Zod schema (`number().int().min(1).max(65535).optional()`).
- Extended the port resolution chain: Traefik label → first exposed port → user-supplied value → null.