### PR TITLE
feat: ask for container port when auto-detection fails on import

### DIFF
--- a/app/(authenticated)/discover/import-dialog.tsx
+++ b/app/(authenticated)/discover/import-dialog.tsx
@@ -24,7 +24,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, X, HardDrive, FolderOpen } from "lucide-react";
 import type { DiscoveredContainer, ContainerDetail } from "@/lib/docker/discover";
-import { resolveContainerPort } from "@/lib/docker/resolve-port";
 import { slugify } from "@/lib/ui/slugify";
 
 type Project = { id: string; name: string; displayName: string };
@@ -61,7 +60,7 @@ export function ImportDialog({
   const [envVars, setEnvVars] = useState<EnvVar[]>([]);
   // Per-mount toggles: keyed by destination path
   const [mountToggles, setMountToggles] = useState<Record<string, boolean>>({});
-  const [manualPort, setManualPort] = useState("");
+  const [containerPort, setContainerPort] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
 
   // Load container detail when dialog opens
@@ -76,7 +75,7 @@ export function ImportDialog({
     setNewProjectName("");
     setEnvVars([]);
     setMountToggles({});
-    setManualPort("");
+    setContainerPort("");
     setDetail(null);
     setDetailError(false);
 
@@ -141,18 +140,16 @@ export function ImportDialog({
   async function handleSubmit() {
     if (!container) return;
 
-    const parsedManualPort = manualPort ? parseInt(manualPort, 10) : undefined;
-
-    if (parsedManualPort !== undefined && (isNaN(parsedManualPort) || parsedManualPort < 1 || parsedManualPort > 65535)) {
-      toast.error("Port must be between 1 and 65535");
-      return;
-    }
-
     setSubmitting(true);
     try {
       const selectedMountDestinations = (detail?.mounts ?? [])
         .filter((m) => mountToggles[m.destination])
         .map((m) => m.destination);
+
+      const portOverride =
+        !portAutoDetected && containerPort !== ""
+          ? parseInt(containerPort, 10)
+          : undefined;
 
       const body = {
         displayName,
@@ -161,7 +158,7 @@ export function ImportDialog({
         newProjectName: projectId === "new" ? newProjectName : undefined,
         envVars,
         selectedMountDestinations,
-        containerPort: parsedManualPort,
+        containerPort: portOverride,
       };
 
       const res = await fetch(
@@ -210,10 +207,14 @@ export function ImportDialog({
   const selectedCount = selectedMounts.length;
   const isHostNetwork = (detail?.networkMode ?? container?.networkMode) === "host";
 
-  // Show the manual port field only after detail loads and auto-detection has no result.
-  // Uses the same resolution chain as the server: Traefik label → exposed port → null.
-  const autoDetectedPort = detail ? resolveContainerPort(detail) : undefined;
-  const showPortField = detail !== null && autoDetectedPort === null && !isHostNetwork;
+  // Port auto-detection fails when there's no Traefik label and no exposed ports.
+  // Only relevant for non-host-network containers since host networking has no port routing.
+  const portAutoDetected =
+    !detail ||
+    isHostNetwork ||
+    detail.containerPort !== null ||
+    detail.ports.some((p) => p.internal);
+  const portFieldValid = portAutoDetected || (containerPort !== "" && /^\d+$/.test(containerPort) && parseInt(containerPort, 10) > 0 && parseInt(containerPort, 10) <= 65535);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -284,6 +285,24 @@ export function ImportDialog({
               </Select>
             </div>
 
+            {!portAutoDetected && (
+              <div className="space-y-1.5">
+                <Label htmlFor="containerPort">Container port</Label>
+                <Input
+                  id="containerPort"
+                  type="number"
+                  min={1}
+                  max={65535}
+                  value={containerPort}
+                  onChange={(e) => setContainerPort(e.target.value)}
+                  placeholder="e.g. 3000"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Port could not be detected automatically. Enter the port your container listens on for HTTP traffic.
+                </p>
+              </div>
+            )}
+
             {projectId === "new" && (
               <div className="space-y-1.5">
                 <Label htmlFor="newProjectName">New project name</Label>
@@ -293,25 +312,6 @@ export function ImportDialog({
                   onChange={(e) => setNewProjectName(e.target.value)}
                   placeholder="My Project"
                 />
-              </div>
-            )}
-
-            {showPortField && (
-              <div className="space-y-1.5">
-                <Label htmlFor="containerPort">Container port</Label>
-                <Input
-                  id="containerPort"
-                  type="number"
-                  min={1}
-                  max={65535}
-                  value={manualPort}
-                  onChange={(e) => setManualPort(e.target.value)}
-                  placeholder="e.g. 3000"
-                  aria-describedby="container-port-hint"
-                />
-                <p id="container-port-hint" className="text-xs text-muted-foreground">
-                  No port was detected automatically. Specify the port your app listens on to enable domain routing.
-                </p>
               </div>
             )}
 
@@ -457,7 +457,7 @@ export function ImportDialog({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={submitting || loadingDetail || detailError || !name || !displayName}
+            disabled={submitting || loadingDetail || detailError || !name || !displayName || !portFieldValid}
           >
             {submitting ? "Importing..." : "Import"}
           </Button>

--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -52,7 +52,7 @@ const importSchema = z.object({
   selectedMountDestinations: z.array(z.string().max(4096, "Mount destination too long")).max(100, "Too many mount destinations").optional(),
   // Deprecated: use selectedMountDestinations. Kept for backward compatibility.
   importVolumes: z.boolean().default(true),
-  // User-supplied port when auto-detection (Traefik labels + exposed ports) yields nothing.
+  // User-supplied port when auto-detection fails (no Traefik labels, no exposed ports).
   containerPort: z.number().int().min(1).max(65535).optional(),
 });
 


### PR DESCRIPTION
Closes #632

## What

When importing a container that has no Traefik routing labels and no exposed ports, port detection returns null. Previously the import dialog would proceed silently with no port set, leaving Traefik routing unconfigured.

Now the dialog detects this case and surfaces a required "Container port" input field so the user can supply the HTTP port manually before importing.

## Changes

**`app/(authenticated)/discover/import-dialog.tsx`**
- Added `containerPort` state (string, for controlled input)
- Reset it on dialog open
- Computed `portAutoDetected` — false when `detail` is loaded, container isn't host-network, `detail.containerPort` is null, and no ports are exposed
- Shows a "Container port" field with hint text when `portAutoDetected` is false
- `portFieldValid` gates the submit button — user must enter a valid 1–65535 port before importing
- Passes `containerPort` override in the request body when applicable

**`app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts`**
- Added optional `containerPort` field to `importSchema` (int, 1–65535)
- Used as a final fallback in the port resolution chain after Traefik labels and exposed ports

## Behavior

- Containers with Traefik labels or exposed ports: no change, field not shown
- Host-network containers: no change, field not shown (host networking has no port routing)
- Containers with no detectable port: port field appears, submit blocked until a valid port is entered