### PR TITLE
fix: preserve bind mounts in compose preview for trusted orgs

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/debug/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/debug/route.ts
@@ -82,6 +82,7 @@ async function handler(_request: NextRequest, { params }: RouteParams) {
       },
       volumesList,
       NETWORK_NAME,
+      org.organization.trusted ?? false,
     );
 
     const compose = composeParsed ? composeToYaml(composeParsed) : null;

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -1193,6 +1193,7 @@ export function buildComposePreview(
   app: ComposePreviewApp,
   volumesList: { name: string; mountPath: string }[],
   networkName: string,
+  orgTrusted?: boolean,
 ): ComposeFile | null {
   let compose: ComposeFile | null = null;
 
@@ -1200,8 +1201,12 @@ export function buildComposePreview(
     // Imported container — use stored compose
     try {
       const parsed = parseCompose(app.composeContent);
-      const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
-      compose = sanitized;
+      if (orgTrusted) {
+        compose = parsed;
+      } else {
+        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
+        compose = sanitized;
+      }
     } catch {
       return null;
     }
@@ -1217,8 +1222,12 @@ export function buildComposePreview(
     // Stored compose content (git repos with inline compose)
     try {
       const parsed = parseCompose(app.composeContent);
-      const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
-      compose = sanitized;
+      if (orgTrusted) {
+        compose = parsed;
+      } else {
+        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
+        compose = sanitized;
+      }
     } catch {
       return null;
     }

--- a/tests/unit/lib/docker/compose.test.ts
+++ b/tests/unit/lib/docker/compose.test.ts
@@ -14,6 +14,7 @@ import {
   applyDeployTransforms,
   resolveBackendProtocol,
   narrowBackendProtocol,
+  buildComposePreview,
   type ComposeFile,
   type ContainerConfig,
 } from "@/lib/docker/compose";
@@ -1749,5 +1750,139 @@ describe("injectTraefikLabels — HTTPS backend", () => {
     const result = injectTraefikLabels(baseComposeFn(), baseOpts);
     const labels = result.services.app.labels as Record<string, string>;
     expect(labels["traefik.http.services.myapp.loadbalancer.server.scheme"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildComposePreview — trusted org bind mount handling
+// ---------------------------------------------------------------------------
+
+const BASE_PREVIEW_APP = {
+  name: "myapp",
+  deployType: "compose" as const,
+  imageName: null,
+  containerPort: 3000,
+  cpuLimit: null,
+  memoryLimit: null,
+  gpuEnabled: false,
+  exposedPorts: null,
+  domains: [],
+  backendProtocol: null as "http" | "https" | null,
+};
+
+describe("buildComposePreview", () => {
+  const networkName = "vardo-network";
+
+  it("returns a preview for a compose app with a safe bind mount", () => {
+    const compose = `
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - /home/user/data:/data
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.services.app.volumes).toContain("/home/user/data:/data");
+  });
+
+  it("returns null for a denied bind mount path when org is not trusted", () => {
+    const compose = `
+services:
+  app:
+    image: myimage:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("preserves denied bind mount paths for trusted orgs", () => {
+    const compose = `
+services:
+  app:
+    image: myimage:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+      true,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.services.app.volumes).toContain(
+      "/var/run/docker.sock:/var/run/docker.sock",
+    );
+  });
+
+  it("preserves /etc bind mounts for trusted orgs", () => {
+    const compose = `
+services:
+  app:
+    image: myimage:latest
+    volumes:
+      - /etc/myconfig:/etc/myconfig:ro
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+      true,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.services.app.volumes).toContain("/etc/myconfig:/etc/myconfig:ro");
+  });
+
+  it("preserves multiple denied bind mounts for trusted orgs", () => {
+    const compose = `
+services:
+  app:
+    image: myimage:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /proc:/host/proc:ro
+      - data:/app/data
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+      true,
+    );
+    expect(result).not.toBeNull();
+    const vols = result!.services.app.volumes ?? [];
+    expect(vols).toContain("/var/run/docker.sock:/var/run/docker.sock");
+    expect(vols).toContain("/proc:/host/proc:ro");
+    expect(vols).toContain("data:/app/data");
+  });
+
+  it("applies deploy transforms (network injection) for trusted org preview", () => {
+    const compose = `
+services:
+  app:
+    image: myimage:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+      true,
+    );
+    expect(result).not.toBeNull();
+    // Network should be injected by applyDeployTransforms
+    expect(result!.networks).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- `buildComposePreview` was calling `sanitizeCompose` without awareness of the org's trusted flag, causing it to throw on DENIED_MOUNT_PATHS (e.g. `/var/run/docker.sock`, `/etc`, `/proc`, `/sys`, `/root`) and return `null`
- The debug endpoint therefore showed `compose: null` for trusted-org apps that use those paths as bind mounts, even though actual deployment worked fine (the deploy path in `parseAndSanitize` already handles trusted orgs correctly)
- Added `orgTrusted?: boolean` parameter to `buildComposePreview`; when true, the parsed compose is used directly without sanitization — matching `parseAndSanitize`'s behaviour
- Updated the debug route to forward `org.organization.trusted` (already fetched by `verifyOrgAccess`) to `buildComposePreview`

## Test plan

- [ ] All existing tests pass (`pnpm test` — 451 tests, 0 failures)
- [ ] New tests added for `buildComposePreview` covering: safe bind mounts, denied-path rejection for untrusted orgs, and preservation of denied paths for trusted orgs
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] Lint passes with no new errors (`pnpm lint`)
- [ ] Manual: deploy an app with `/var/run/docker.sock` as a bind mount on a trusted org and confirm the debug tab shows the correct compose output instead of `null`