### PR TITLE
fix: SSH keepalive output during long builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -352,6 +352,9 @@ run_with_spinner() {
     local exit_code=0
     "$@" || exit_code=$?
     kill $keepalive_pid 2>/dev/null; wait $keepalive_pid 2>/dev/null
+    if [ $exit_code -ne 0 ]; then
+      fail "$label — failed (exit $exit_code). Check ${INSTALL_LOG:-/var/log/vardo-install.log} for details."
+    fi
     return $exit_code
   fi
 


### PR DESCRIPTION
## What

When running `vardo update` over SSH without a controlling terminal (e.g. `ssh host 'sudo bash /opt/vardo/install.sh update'`), long docker builds ran silently with no output. SSH sessions with server-side idle timeouts would drop the connection mid-build.

## Why

`run_with_spinner` combined the `VERBOSE` and `! has_tty` cases into one branch that just ran the command with no ongoing output. In `VERBOSE` mode that's fine — the command streams output itself. But in the no-TTY path, any silent period (e.g. a long layer download or `pnpm install` inside the Dockerfile) could trigger an SSH idle timeout and kill the session.

## How

Split the two cases. The no-TTY path now spawns a background keepalive loop that prints a status line every 30 seconds:

```
  · Building containers (this may take a few minutes) (30s)
  · Building containers (this may take a few minutes) (60s)
```

The loop is killed once the command finishes. The command's own output still flows through normally — the keepalive only fires during silent gaps.

Closes #525