### PR TITLE
fix: debug compose preview respects per-project bind mount permission

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/debug/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/debug/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { apps, volumes } from "@/lib/db/schema";
+import { apps, volumes, projects } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { verifyOrgAccess } from "@/lib/api/verify-access";
 import { isAdmin } from "@/lib/auth/permissions";
@@ -51,6 +51,19 @@ async function handler(_request: NextRequest, { params }: RouteParams) {
       .filter((v) => v.persistent)
       .map((v) => ({ name: v.name, mountPath: v.mountPath }));
 
+    // Resolve per-project bind mount permission so the preview matches deploy.
+    const orgTrusted = org.organization.trusted ?? false;
+    let projectAllowBindMounts = false;
+    if (orgTrusted) {
+      projectAllowBindMounts = true;
+    } else if (app.projectId) {
+      const project = await db.query.projects.findFirst({
+        where: eq(projects.id, app.projectId),
+        columns: { allowBindMounts: true },
+      });
+      projectAllowBindMounts = project?.allowBindMounts ?? false;
+    }
+
     // Resolve the effective backend protocol for the debug preview
     const resolvedProtocol = resolveBackendProtocol(
       narrowBackendProtocol(app.backendProtocol),
@@ -82,7 +95,8 @@ async function handler(_request: NextRequest, { params }: RouteParams) {
       },
       volumesList,
       NETWORK_NAME,
-      org.organization.trusted ?? false,
+      orgTrusted,
+      projectAllowBindMounts,
     );
 
     const compose = composeParsed ? composeToYaml(composeParsed) : null;

--- a/lib/docker/compose.ts
+++ b/lib/docker/compose.ts
@@ -1219,6 +1219,7 @@ export function buildComposePreview(
   volumesList: { name: string; mountPath: string }[],
   networkName: string,
   orgTrusted?: boolean,
+  allowBindMounts?: boolean,
 ): ComposeFile | null {
   let compose: ComposeFile | null = null;
 
@@ -1229,7 +1230,7 @@ export function buildComposePreview(
       if (orgTrusted) {
         compose = parsed;
       } else {
-        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
+        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: allowBindMounts ?? false });
         compose = sanitized;
       }
     } catch {
@@ -1250,7 +1251,7 @@ export function buildComposePreview(
       if (orgTrusted) {
         compose = parsed;
       } else {
-        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: true });
+        const { compose: sanitized } = sanitizeCompose(parsed, { allowBindMounts: allowBindMounts ?? false });
         compose = sanitized;
       }
     } catch {

--- a/tests/unit/lib/docker/compose.test.ts
+++ b/tests/unit/lib/docker/compose.test.ts
@@ -1824,7 +1824,28 @@ const BASE_PREVIEW_APP = {
 describe("buildComposePreview", () => {
   const networkName = "vardo-network";
 
-  it("returns a preview for a compose app with a safe bind mount", () => {
+  it("strips bind mounts in preview when allowBindMounts is false", () => {
+    const compose = `
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - /home/user/data:/data
+      - named-vol:/app/data
+`;
+    const result = buildComposePreview(
+      { ...BASE_PREVIEW_APP, composeContent: compose },
+      [],
+      networkName,
+      false,
+      false,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.services.app.volumes).not.toContain("/home/user/data:/data");
+    expect(result!.services.app.volumes).toContain("named-vol:/app/data");
+  });
+
+  it("preserves safe bind mounts in preview when allowBindMounts is true", () => {
     const compose = `
 services:
   app:
@@ -1836,12 +1857,14 @@ services:
       { ...BASE_PREVIEW_APP, composeContent: compose },
       [],
       networkName,
+      false,
+      true,
     );
     expect(result).not.toBeNull();
     expect(result!.services.app.volumes).toContain("/home/user/data:/data");
   });
 
-  it("returns null for a denied bind mount path when org is not trusted", () => {
+  it("returns null for a denied bind mount path when allowBindMounts is true", () => {
     const compose = `
 services:
   app:
@@ -1853,6 +1876,8 @@ services:
       { ...BASE_PREVIEW_APP, composeContent: compose },
       [],
       networkName,
+      false,
+      true,
     );
     expect(result).toBeNull();
   });


### PR DESCRIPTION
## Summary

- `buildComposePreview` was hardcoding `allowBindMounts: true` when sanitizing compose for non-trusted orgs, so the debug endpoint always showed bind mounts even for orgs without bind mount permissions.
- Fix adds an explicit `allowBindMounts` parameter (defaults to `false`).
- The debug route now resolves the effective permission from the project setting (or org trust) and passes it through, so the preview matches what deploy will actually produce.

## What was wrong

The debug endpoint showed administrators a compose preview that could include bind mounts that would be silently stripped at actual deploy time for non-trusted orgs without per-project bind mount permissions. This made the preview misleading.

## What changed

**`lib/docker/compose.ts`** — `buildComposePreview` now accepts `allowBindMounts?: boolean` and passes it to `sanitizeCompose` instead of hardcoding `true`.

**`app/api/v1/.../debug/route.ts`** — Resolves `projectAllowBindMounts` from the project's `allowBindMounts` column (or falls back to org trust) and passes it to `buildComposePreview`.

## Test plan

- [ ] Debug preview for an app in a non-trusted project without `allowBindMounts` strips bind mounts
- [ ] Debug preview for an app in a project with `allowBindMounts: true` preserves safe bind mounts
- [ ] Debug preview for a trusted org still shows everything
- [ ] Unit tests pass: `pnpm vitest run`