### PR TITLE
fix(mesh): use ip route replace and wait for WireGuard before frontend starts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      wireguard:
+        condition: service_healthy
     env_file: .env
     environment:
       DATABASE_URL: postgresql://host:${DB_PASSWORD:-host}@vardo-postgres:5432/host

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,8 +2,10 @@
 set -e
 
 # Set up mesh routing if WireGuard gateway is configured.
+# ip route replace is idempotent — adds or updates the route without failing
+# if it already exists (e.g. on a warm container restart).
 if [ -n "${WIREGUARD_GATEWAY:-}" ]; then
-  ip route add 10.99.0.0/24 via "$WIREGUARD_GATEWAY" 2>/dev/null || true
+  ip route replace 10.99.0.0/24 via "$WIREGUARD_GATEWAY"
 fi
 
 # Ensure nextjs user has access to the Docker socket.


### PR DESCRIPTION
## Summary

- Switch from `ip route add ... 2>/dev/null || true` to `ip route replace` in `scripts/entrypoint.sh` — idempotent, no silent swallowing of real errors
- Add `wireguard: condition: service_healthy` to the frontend's `depends_on` so the WireGuard tunnel interface is confirmed up before the frontend starts routing `10.99.0.0/24` through it

The mesh route itself (`10.99.0.0/24 via $WIREGUARD_GATEWAY`) and the surrounding infrastructure (NET_ADMIN cap, iproute2, WIREGUARD_GATEWAY env var) were already in place. These two changes make it more robust.

Closes #547

## Test plan

- [ ] `docker compose up -d` — frontend starts after WireGuard is healthy
- [ ] `docker exec vardo-frontend ip route show` confirms `10.99.0.0/24 via 10.88.0.2` is present
- [ ] Heartbeat reaches peer at `10.99.0.x:3000` — peer shows online in mesh dashboard