### PR TITLE
fix: expose selfManagement and bindMounts in feature flags UI

### DIFF
--- a/app/(authenticated)/admin/settings/feature-flags-settings.tsx
+++ b/app/(authenticated)/admin/settings/feature-flags-settings.tsx
@@ -6,14 +6,14 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Loader2 } from "lucide-react";
 import { toast } from "@/lib/messenger";
+import { ADMIN_FLAGS } from "@/lib/config/features";
+
 type FlagState = {
   flag: string;
   label: string;
   description: string;
   enabled: boolean;
 };
-
-const ALL_FLAGS = ["terminal", "environments", "backups", "cron", "mesh", "passwordAuth", "bindMounts", "selfManagement"];
 
 export function FeatureFlagsSettings() {
   const [loading, setLoading] = useState(true);
@@ -84,7 +84,7 @@ export function FeatureFlagsSettings() {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {flags
-          .filter((f) => ALL_FLAGS.includes(f.flag))
+          .filter((f) => (ADMIN_FLAGS as string[]).includes(f.flag))
           .map((f) => (
             <div key={f.flag} className="flex items-center justify-between rounded-lg border p-4">
               <div className="space-y-0.5">

--- a/app/api/setup/feature-flags/route.ts
+++ b/app/api/setup/feature-flags/route.ts
@@ -3,34 +3,15 @@ import { z } from "zod";
 import { requireAdminAuth } from "@/lib/auth/admin";
 import { getFeatureFlagsConfig, setSystemSetting } from "@/lib/system-settings";
 import {
-  type FeatureFlag,
+  ADMIN_FLAGS,
   getFlagConfig,
   isFeatureEnabledAsync,
 } from "@/lib/config/features";
 
-/** Flags exposed in the admin UI (skip "ui" — it's a hard kill switch). */
-const ADMIN_FLAGS: FeatureFlag[] = [
-  "terminal",
-  "environments",
-  "backups",
-  "cron",
-  "passwordAuth",
-  "mesh",
-  "bindMounts",
-  "selfManagement",
-];
-
-/** Only accept known feature flag keys (excluding "ui" kill switch). */
-const flagsSchema = z.object({
-  terminal: z.boolean().optional(),
-  environments: z.boolean().optional(),
-  backups: z.boolean().optional(),
-  cron: z.boolean().optional(),
-  passwordAuth: z.boolean().optional(),
-  mesh: z.boolean().optional(),
-  bindMounts: z.boolean().optional(),
-  selfManagement: z.boolean().optional(),
-}).strict();
+/** Only accept known admin feature flag keys. Derived from ADMIN_FLAGS. */
+const flagsSchema = z.object(
+  Object.fromEntries(ADMIN_FLAGS.map((f) => [f, z.boolean().optional()]))
+).strict();
 
 export async function GET(request: NextRequest) {
   await requireAdminAuth(request);

--- a/lib/config/features.ts
+++ b/lib/config/features.ts
@@ -145,6 +145,14 @@ export async function getFeatureFlags(): Promise<FeatureFlags> {
   return { terminal, cron, backups };
 }
 
+/**
+ * Flags exposed in the admin settings UI.
+ * Excludes "ui" — that's a hard kill switch, not a user-facing toggle.
+ */
+export const ADMIN_FLAGS: FeatureFlag[] = (
+  Object.keys(FLAG_CONFIG) as FeatureFlag[]
+).filter((f) => f !== "ui");
+
 export type FeatureFlagInfo = {
   flag: FeatureFlag;
   enabled: boolean;


### PR DESCRIPTION
## Summary

- The feature flags API route (`/api/setup/feature-flags`) had its own `ADMIN_FLAGS` array and zod schema that didn't include `selfManagement` or `bindMounts`
- Both flags were registered in `lib/config/features.ts` and the client-side `ALL_FLAGS`, but the API never returned them — so the settings UI never showed them
- Adds both flags to the API's `ADMIN_FLAGS` array, zod schema, and client-side `ALL_FLAGS`

## Test plan

- [ ] Go to Admin > Settings > Feature Flags
- [ ] "Self-Management" and "Bind Mounts" toggles should now appear
- [ ] Both should default to off
- [ ] Toggling and saving should persist