### PR TITLE
feat(admin): maintenance mounts use source:destination pairs

### DIFF
--- a/app/(authenticated)/admin/settings/maintenance-settings.tsx
+++ b/app/(authenticated)/admin/settings/maintenance-settings.tsx
@@ -40,11 +40,13 @@ type MaintenanceStatus = {
   hasVardoDir: boolean;
 };
 
+type MountPair = { source: string; destination: string };
+
 type MountsConfig = {
-  vardoData: string | null;
-  vardoProjects: string | null;
-  vardoMount1: string | null;
-  vardoMount2: string | null;
+  vardoData: MountPair;
+  vardoProjects: MountPair;
+  vardoMount1: MountPair;
+  vardoMount2: MountPair;
 };
 
 function stateVariant(state: string): "default" | "secondary" | "destructive" | "outline" {
@@ -67,10 +69,10 @@ export function MaintenanceSettings() {
   const [loadingMounts, setLoadingMounts] = useState(true);
   const [status, setStatus] = useState<MaintenanceStatus | null>(null);
   const [mounts, setMounts] = useState<MountsConfig>({
-    vardoData: null,
-    vardoProjects: null,
-    vardoMount1: null,
-    vardoMount2: null,
+    vardoData: { source: "", destination: "" },
+    vardoProjects: { source: "", destination: "" },
+    vardoMount1: { source: "", destination: "" },
+    vardoMount2: { source: "", destination: "" },
   });
   const [restarting, setRestarting] = useState<string | null>(null);
   const [updating, setUpdating] = useState(false);
@@ -100,10 +102,10 @@ export function MaintenanceSettings() {
       if (res.ok) {
         const data = await res.json();
         setMounts({
-          vardoData: data.vardoData ?? "",
-          vardoProjects: data.vardoProjects ?? "",
-          vardoMount1: data.vardoMount1 ?? "",
-          vardoMount2: data.vardoMount2 ?? "",
+          vardoData: data.vardoData ?? { source: "", destination: "" },
+          vardoProjects: data.vardoProjects ?? { source: "", destination: "" },
+          vardoMount1: data.vardoMount1 ?? { source: "", destination: "" },
+          vardoMount2: data.vardoMount2 ?? { source: "", destination: "" },
         });
       }
     } catch {
@@ -167,12 +169,20 @@ export function MaintenanceSettings() {
     setSavingMounts(true);
     try {
       // Send all fields — empty string clears the mount, non-empty sets it.
-      // Fields that aren't absolute paths are omitted to avoid a 400.
+      // Fields that aren't valid source:destination pairs are omitted to avoid a 400.
       const payload: Record<string, string> = {};
-      if (mounts.vardoData !== null) payload.vardoData = mounts.vardoData;
-      if (mounts.vardoProjects !== null) payload.vardoProjects = mounts.vardoProjects;
-      if (mounts.vardoMount1 !== null) payload.vardoMount1 = mounts.vardoMount1;
-      if (mounts.vardoMount2 !== null) payload.vardoMount2 = mounts.vardoMount2;
+      if (mounts.vardoData.source && mounts.vardoData.destination) {
+        payload.vardoData = `${mounts.vardoData.source}:${mounts.vardoData.destination}`;
+      }
+      if (mounts.vardoProjects.source && mounts.vardoProjects.destination) {
+        payload.vardoProjects = `${mounts.vardoProjects.source}:${mounts.vardoProjects.destination}`;
+      }
+      if (mounts.vardoMount1.source && mounts.vardoMount1.destination) {
+        payload.vardoMount1 = `${mounts.vardoMount1.source}:${mounts.vardoMount1.destination}`;
+      }
+      if (mounts.vardoMount2.source && mounts.vardoMount2.destination) {
+        payload.vardoMount2 = `${mounts.vardoMount2.source}:${mounts.vardoMount2.destination}`;
+      }
 
       const res = await fetch("/api/v1/admin/maintenance/mounts", {
         method: "POST",
@@ -369,66 +379,167 @@ export function MaintenanceSettings() {
           ) : (
             <form onSubmit={(e) => void handleSaveMounts(e)} className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                Host paths to mount into the Vardo container. Changes require a stack restart to
-                take effect — the paths are written to <code className="text-xs font-mono">.env</code>.
-                Leave a field blank to clear that mount.
+                Host mounts for the Vardo container. Each mount is a source:destination pair.
+                Changes require a stack restart to take effect — the pairs are written to{" "}
+                <code className="text-xs font-mono">.env</code>.
+                Leave both fields blank to clear that mount.
               </p>
 
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="vardo-data" className="text-sm">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label className="text-sm">
                     Data directory{" "}
                     <span className="text-xs text-muted-foreground font-mono">(VARDO_DATA)</span>
                   </Label>
-                  <Input
-                    id="vardo-data"
-                    placeholder="/mnt/data"
-                    value={mounts.vardoData ?? ""}
-                    onChange={(e) => setMounts((m) => ({ ...m, vardoData: e.target.value }))}
-                    className="squircle font-mono text-sm"
-                  />
+                  <div className="grid gap-2 sm:grid-cols-2 items-start">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-data-source" className="text-xs text-muted-foreground">
+                        Source (host path)
+                      </Label>
+                      <Input
+                        id="vardo-data-source"
+                        placeholder="/mnt/data"
+                        value={mounts.vardoData.source}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoData: { source: e.target.value, destination: m.vardoData.destination },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-data-dest" className="text-xs text-muted-foreground">
+                        Destination (container path)
+                      </Label>
+                      <Input
+                        id="vardo-data-dest"
+                        placeholder="/var/lib/vardo/data"
+                        value={mounts.vardoData.destination}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoData: { source: m.vardoData.source, destination: e.target.value },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                  </div>
                 </div>
 
-                <div className="space-y-1.5">
-                  <Label htmlFor="vardo-projects" className="text-sm">
+                <div className="space-y-2">
+                  <Label className="text-sm">
                     Projects directory{" "}
                     <span className="text-xs text-muted-foreground font-mono">(VARDO_PROJECTS)</span>
                   </Label>
-                  <Input
-                    id="vardo-projects"
-                    placeholder="/home/user/projects"
-                    value={mounts.vardoProjects ?? ""}
-                    onChange={(e) => setMounts((m) => ({ ...m, vardoProjects: e.target.value }))}
-                    className="squircle font-mono text-sm"
-                  />
+                  <div className="grid gap-2 sm:grid-cols-2 items-start">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-projects-source" className="text-xs text-muted-foreground">
+                        Source (host path)
+                      </Label>
+                      <Input
+                        id="vardo-projects-source"
+                        placeholder="/home/user/projects"
+                        value={mounts.vardoProjects.source}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoProjects: { source: e.target.value, destination: m.vardoProjects.destination },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-projects-dest" className="text-xs text-muted-foreground">
+                        Destination (container path)
+                      </Label>
+                      <Input
+                        id="vardo-projects-dest"
+                        placeholder="/var/lib/vardo/projects"
+                        value={mounts.vardoProjects.destination}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoProjects: { source: m.vardoProjects.source, destination: e.target.value },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                  </div>
                 </div>
 
-                <div className="space-y-1.5">
-                  <Label htmlFor="vardo-mount-1" className="text-sm">
+                <div className="space-y-2">
+                  <Label className="text-sm">
                     Extra mount 1{" "}
                     <span className="text-xs text-muted-foreground font-mono">(VARDO_MOUNT_1)</span>
                   </Label>
-                  <Input
-                    id="vardo-mount-1"
-                    placeholder="/path/to/mount"
-                    value={mounts.vardoMount1 ?? ""}
-                    onChange={(e) => setMounts((m) => ({ ...m, vardoMount1: e.target.value }))}
-                    className="squircle font-mono text-sm"
-                  />
+                  <div className="grid gap-2 sm:grid-cols-2 items-start">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-mount-1-source" className="text-xs text-muted-foreground">
+                        Source (host path)
+                      </Label>
+                      <Input
+                        id="vardo-mount-1-source"
+                        placeholder="/path/on/host"
+                        value={mounts.vardoMount1.source}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoMount1: { source: e.target.value, destination: m.vardoMount1.destination },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-mount-1-dest" className="text-xs text-muted-foreground">
+                        Destination (container path)
+                      </Label>
+                      <Input
+                        id="vardo-mount-1-dest"
+                        placeholder="/path/in/container"
+                        value={mounts.vardoMount1.destination}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoMount1: { source: m.vardoMount1.source, destination: e.target.value },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                  </div>
                 </div>
 
-                <div className="space-y-1.5">
-                  <Label htmlFor="vardo-mount-2" className="text-sm">
+                <div className="space-y-2">
+                  <Label className="text-sm">
                     Extra mount 2{" "}
                     <span className="text-xs text-muted-foreground font-mono">(VARDO_MOUNT_2)</span>
                   </Label>
-                  <Input
-                    id="vardo-mount-2"
-                    placeholder="/path/to/mount"
-                    value={mounts.vardoMount2 ?? ""}
-                    onChange={(e) => setMounts((m) => ({ ...m, vardoMount2: e.target.value }))}
-                    className="squircle font-mono text-sm"
-                  />
+                  <div className="grid gap-2 sm:grid-cols-2 items-start">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-mount-2-source" className="text-xs text-muted-foreground">
+                        Source (host path)
+                      </Label>
+                      <Input
+                        id="vardo-mount-2-source"
+                        placeholder="/path/on/host"
+                        value={mounts.vardoMount2.source}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoMount2: { source: e.target.value, destination: m.vardoMount2.destination },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="vardo-mount-2-dest" className="text-xs text-muted-foreground">
+                        Destination (container path)
+                      </Label>
+                      <Input
+                        id="vardo-mount-2-dest"
+                        placeholder="/path/in/container"
+                        value={mounts.vardoMount2.destination}
+                        onChange={(e) => setMounts((m) => ({
+                          ...m,
+                          vardoMount2: { source: m.vardoMount2.source, destination: e.target.value },
+                        }))}
+                        className="squircle font-mono text-sm"
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
 

--- a/app/api/v1/admin/maintenance/mounts/route.ts
+++ b/app/api/v1/admin/maintenance/mounts/route.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { requireAppAdmin } from "@/lib/auth/admin";
 import { writeEnvKey } from "@/lib/env/write-env-key";
 import { handleRouteError } from "@/lib/api/error-response";
-import { mountsSchema } from "@/lib/api/admin/maintenance-schemas";
+import { mountsSchema, parseMountPair } from "@/lib/api/admin/maintenance-schemas";
 import { logger } from "@/lib/logger";
 import { VARDO_HOME_DIR } from "@/lib/paths";
 
@@ -14,23 +14,6 @@ const log = logger.child("admin:maintenance:mounts");
 // Returns the current host mount configuration from environment variables.
 // Each mount is returned as { source, destination } if set, or null if not configured.
 // Handles both new source:destination:ro format and legacy single-path format.
-function parseMountPair(value: string | undefined): { source: string; destination: string } | null {
-  if (!value || value === "/dev/null") return null;
-
-  // Strip :ro suffix if present (new format)
-  const mountValue = value.endsWith(":ro") ? value.slice(0, -3) : value;
-
-  const colonIndex = mountValue.indexOf(":");
-  if (colonIndex === -1) {
-    // Legacy single-path format — assume source = destination
-    return { source: mountValue, destination: mountValue };
-  }
-
-  const source = mountValue.slice(0, colonIndex);
-  const destination = mountValue.slice(colonIndex + 1);
-  if (!source || !destination) return null;
-  return { source, destination };
-}
 
 export async function GET() {
   try {

--- a/app/api/v1/admin/maintenance/mounts/route.ts
+++ b/app/api/v1/admin/maintenance/mounts/route.ts
@@ -12,15 +12,35 @@ const log = logger.child("admin:maintenance:mounts");
 // GET /api/v1/admin/maintenance/mounts
 //
 // Returns the current host mount configuration from environment variables.
+// Each mount is returned as { source, destination } if set, or null if not configured.
+// Handles both new source:destination:ro format and legacy single-path format.
+function parseMountPair(value: string | undefined): { source: string; destination: string } | null {
+  if (!value || value === "/dev/null") return null;
+
+  // Strip :ro suffix if present (new format)
+  const mountValue = value.endsWith(":ro") ? value.slice(0, -3) : value;
+
+  const colonIndex = mountValue.indexOf(":");
+  if (colonIndex === -1) {
+    // Legacy single-path format — assume source = destination
+    return { source: mountValue, destination: mountValue };
+  }
+
+  const source = mountValue.slice(0, colonIndex);
+  const destination = mountValue.slice(colonIndex + 1);
+  if (!source || !destination) return null;
+  return { source, destination };
+}
+
 export async function GET() {
   try {
     await requireAppAdmin();
 
     return NextResponse.json({
-      vardoData: process.env.VARDO_DATA || null,
-      vardoProjects: process.env.VARDO_PROJECTS || null,
-      vardoMount1: process.env.VARDO_MOUNT_1 || null,
-      vardoMount2: process.env.VARDO_MOUNT_2 || null,
+      vardoData: parseMountPair(process.env.VARDO_DATA),
+      vardoProjects: parseMountPair(process.env.VARDO_PROJECTS),
+      vardoMount1: parseMountPair(process.env.VARDO_MOUNT_1),
+      vardoMount2: parseMountPair(process.env.VARDO_MOUNT_2),
     });
   } catch (error) {
     return handleRouteError(error);
@@ -31,6 +51,16 @@ export async function GET() {
 //
 // Updates host mount configuration by writing to the .env file.
 // Requires a Vardo restart to take effect.
+// Each mount is sent as { source, destination } and stored as "source:destination".
+// For docker-compose compatibility, we append :ro to make it "source:destination:ro".
+function formatMountForEnv(value: string | undefined): string {
+  if (!value) return "";
+  // If already has :ro suffix, return as-is
+  if (value.endsWith(":ro")) return value;
+  // Append :ro for read-only mount
+  return `${value}:ro`;
+}
+
 export async function POST(request: Request) {
   try {
     await requireAppAdmin();
@@ -48,16 +78,16 @@ export async function POST(request: Request) {
     const updates: Array<[string, string]> = [];
 
     if (parsed.data.vardoData !== undefined) {
-      updates.push(["VARDO_DATA", parsed.data.vardoData]);
+      updates.push(["VARDO_DATA", formatMountForEnv(parsed.data.vardoData)]);
     }
     if (parsed.data.vardoProjects !== undefined) {
-      updates.push(["VARDO_PROJECTS", parsed.data.vardoProjects]);
+      updates.push(["VARDO_PROJECTS", formatMountForEnv(parsed.data.vardoProjects)]);
     }
     if (parsed.data.vardoMount1 !== undefined) {
-      updates.push(["VARDO_MOUNT_1", parsed.data.vardoMount1]);
+      updates.push(["VARDO_MOUNT_1", formatMountForEnv(parsed.data.vardoMount1)]);
     }
     if (parsed.data.vardoMount2 !== undefined) {
-      updates.push(["VARDO_MOUNT_2", parsed.data.vardoMount2]);
+      updates.push(["VARDO_MOUNT_2", formatMountForEnv(parsed.data.vardoMount2)]);
     }
 
     if (updates.length === 0) {

--- a/app/api/v1/organizations/[orgId]/apps/[appId]/deployments/[deploymentId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/deployments/[deploymentId]/route.ts
@@ -7,6 +7,8 @@ import { verifyOrgAccess } from "@/lib/api/verify-access";
 import { publishKillSignal } from "@/lib/docker/deploy-cancel";
 import { publishEvent, appChannel } from "@/lib/events";
 import { releaseConcurrencySlot, removeFromQueue } from "@/lib/docker/deploy-concurrency";
+// Container cleanup for force-cancelled deploys is handled by the sweeper
+// (lib/deploy/sweeper.ts), which can safely resolve the correct slot.
 
 type RouteParams = {
   params: Promise<{ orgId: string; appId: string; deploymentId: string }>;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,10 @@ services:
       # Additional host mounts — pre-defined slots for mounting host paths into Vardo.
       # Set VARDO_DATA or VARDO_PROJECTS in .env to enable. Unused slots default to /dev/null (no-op).
       # Each mount is a source:destination:ro pair (e.g., /mnt/data:/var/lib/vardo/data:ro).
-      - ${VARDO_DATA:-/dev/null}
-      - ${VARDO_PROJECTS:-/dev/null}
-      - ${VARDO_MOUNT_1:-/dev/null}
-      - ${VARDO_MOUNT_2:-/dev/null}
+      - ${VARDO_DATA:-/dev/null:/dev/null:ro}
+      - ${VARDO_PROJECTS:-/dev/null:/dev/null:ro}
+      - ${VARDO_MOUNT_1:-/dev/null:/dev/null:ro}
+      - ${VARDO_MOUNT_2:-/dev/null:/dev/null:ro}
       # Traefik dynamic config — shared volume for file-provider route configs.
       # Frontend writes YAML files here; Traefik watches and reloads automatically.
       - traefik_dynamic:/etc/traefik/dynamic:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,10 +81,11 @@ services:
       - ${VARDO_HOME_DIR:-${VARDO_DIR:-/opt/vardo}}:${VARDO_HOME_DIR:-${VARDO_DIR:-/opt/vardo}}
       # Additional host mounts — pre-defined slots for mounting host paths into Vardo.
       # Set VARDO_DATA or VARDO_PROJECTS in .env to enable. Unused slots default to /dev/null (no-op).
-      - ${VARDO_DATA:-/dev/null}:${VARDO_DATA:-/dev/null}:ro
-      - ${VARDO_PROJECTS:-/dev/null}:${VARDO_PROJECTS:-/dev/null}:ro
-      - ${VARDO_MOUNT_1:-/dev/null}:${VARDO_MOUNT_1:-/dev/null}:ro
-      - ${VARDO_MOUNT_2:-/dev/null}:${VARDO_MOUNT_2:-/dev/null}:ro
+      # Each mount is a source:destination:ro pair (e.g., /mnt/data:/var/lib/vardo/data:ro).
+      - ${VARDO_DATA:-/dev/null}
+      - ${VARDO_PROJECTS:-/dev/null}
+      - ${VARDO_MOUNT_1:-/dev/null}
+      - ${VARDO_MOUNT_2:-/dev/null}
       # Traefik dynamic config — shared volume for file-provider route configs.
       # Frontend writes YAML files here; Traefik watches and reloads automatically.
       - traefik_dynamic:/etc/traefik/dynamic:rw

--- a/lib/api/admin/maintenance-schemas.ts
+++ b/lib/api/admin/maintenance-schemas.ts
@@ -43,20 +43,28 @@ export const restartSchema = z.object({
     .optional(),
 });
 
-// Mount path values are written directly into .env. Empty string clears the
-// mount. Non-empty values must be absolute paths with no newline characters
-// (newlines would inject additional lines into the .env file).
-export const mountPathField = z
+// Mount values are written directly into .env. Empty string clears the
+// mount. Non-empty values must be source:destination pairs with no newline
+// characters (newlines would inject additional lines into the .env file).
+// Source must be an absolute path. Destination must be an absolute path.
+export const mountPairField = z
   .string()
   .refine(
-    (v) => v === "" || (v.startsWith("/") && !/[\n\r]/.test(v)),
-    "path must be an absolute path without newline characters, or empty to clear",
+    (v) => {
+      if (v === "") return true;
+      if (/[\n\r]/.test(v)) return false;
+      const parts = v.split(":");
+      if (parts.length !== 2) return false;
+      const [source, destination] = parts;
+      return source.startsWith("/") && destination.startsWith("/");
+    },
+    "must be a source:destination pair where both are absolute paths, or empty to clear",
   )
   .optional();
 
 export const mountsSchema = z.object({
-  vardoData: mountPathField,
-  vardoProjects: mountPathField,
-  vardoMount1: mountPathField,
-  vardoMount2: mountPathField,
+  vardoData: mountPairField,
+  vardoProjects: mountPairField,
+  vardoMount1: mountPairField,
+  vardoMount2: mountPairField,
 });

--- a/tests/unit/api/admin/maintenance.test.ts
+++ b/tests/unit/api/admin/maintenance.test.ts
@@ -164,15 +164,30 @@ describe("update — VARDO_HOME_DIR resolution", () => {
 // GET /api/v1/admin/maintenance/mounts — response shape
 //
 // Returns the current host mount configuration from process.env.
+// Each mount is returned as { source, destination } or null if not configured.
 // ---------------------------------------------------------------------------
 
 describe("mounts GET — response shape", () => {
+  function parseMountPair(value: string | undefined): { source: string; destination: string } | null {
+    if (!value || value === "/dev/null") return null;
+    const mountValue = value.endsWith(":ro") ? value.slice(0, -3) : value;
+    const colonIndex = mountValue.indexOf(":");
+    if (colonIndex === -1) {
+      // Legacy single-path format
+      return { source: mountValue, destination: mountValue };
+    }
+    const source = mountValue.slice(0, colonIndex);
+    const destination = mountValue.slice(colonIndex + 1);
+    if (!source || !destination) return null;
+    return { source, destination };
+  }
+
   function buildMountsResponse(env: Record<string, string | undefined>) {
     return {
-      vardoData: env.VARDO_DATA || null,
-      vardoProjects: env.VARDO_PROJECTS || null,
-      vardoMount1: env.VARDO_MOUNT_1 || null,
-      vardoMount2: env.VARDO_MOUNT_2 || null,
+      vardoData: parseMountPair(env.VARDO_DATA),
+      vardoProjects: parseMountPair(env.VARDO_PROJECTS),
+      vardoMount1: parseMountPair(env.VARDO_MOUNT_1),
+      vardoMount2: parseMountPair(env.VARDO_MOUNT_2),
     };
   }
 
@@ -184,24 +199,32 @@ describe("mounts GET — response shape", () => {
     expect(res.vardoMount2).toBeNull();
   });
 
-  it("returns configured mount paths", () => {
-    const res = buildMountsResponse({ VARDO_DATA: "/mnt/data", VARDO_PROJECTS: "/home/user/projects" });
-    expect(res.vardoData).toBe("/mnt/data");
-    expect(res.vardoProjects).toBe("/home/user/projects");
+  it("returns configured mount pairs (source:destination format)", () => {
+    const res = buildMountsResponse({
+      VARDO_DATA: "/mnt/data:/var/lib/vardo/data:ro",
+      VARDO_PROJECTS: "/home/user/projects:/var/lib/vardo/projects:ro",
+    });
+    expect(res.vardoData).toEqual({ source: "/mnt/data", destination: "/var/lib/vardo/data" });
+    expect(res.vardoProjects).toEqual({ source: "/home/user/projects", destination: "/var/lib/vardo/projects" });
     expect(res.vardoMount1).toBeNull();
+  });
+
+  it("handles legacy single-path format (source = destination)", () => {
+    const res = buildMountsResponse({ VARDO_DATA: "/mnt/data" });
+    expect(res.vardoData).toEqual({ source: "/mnt/data", destination: "/mnt/data" });
   });
 });
 
 // ---------------------------------------------------------------------------
-// POST /api/v1/admin/maintenance/mounts — mountPathField validation
+// POST /api/v1/admin/maintenance/mounts — mountPairField validation
 //
-// Empty string clears the mount. Non-empty values must be absolute paths
-// with no newline characters (which would inject lines into .env).
+// Empty string clears the mount. Non-empty values must be source:destination
+// pairs where both are absolute paths with no newline characters.
 // ---------------------------------------------------------------------------
 
-describe("mounts POST — mountPathField validation", () => {
-  it("accepts a valid absolute path", () => {
-    expect(mountsSchema.safeParse({ vardoData: "/mnt/data" }).success).toBe(true);
+describe("mounts POST — mountPairField validation", () => {
+  it("accepts a valid source:destination pair", () => {
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data:/var/lib/vardo/data" }).success).toBe(true);
   });
 
   it("accepts empty string to clear a mount", () => {
@@ -212,29 +235,33 @@ describe("mounts POST — mountPathField validation", () => {
     expect(mountsSchema.safeParse({}).success).toBe(true);
   });
 
-  it("rejects relative paths", () => {
-    expect(mountsSchema.safeParse({ vardoData: "mnt/data" }).success).toBe(false);
+  it("rejects single path (no colon)", () => {
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data" }).success).toBe(false);
+  });
+
+  it("rejects relative source path", () => {
+    expect(mountsSchema.safeParse({ vardoData: "mnt/data:/var/lib/vardo/data" }).success).toBe(false);
+  });
+
+  it("rejects relative destination path", () => {
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data:var/lib/vardo/data" }).success).toBe(false);
   });
 
   it("rejects newline injection in path value", () => {
-    expect(mountsSchema.safeParse({ vardoData: "/mnt/data\nMALICIOUS=1" }).success).toBe(false);
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data\nMALICIOUS=1:/var/lib/vardo/data" }).success).toBe(false);
   });
 
   it("rejects carriage-return injection", () => {
-    expect(mountsSchema.safeParse({ vardoData: "/mnt/data\rINJECTED=1" }).success).toBe(false);
-  });
-
-  it("accepts a path with spaces (valid on some systems)", () => {
-    expect(mountsSchema.safeParse({ vardoData: "/mnt/my data" }).success).toBe(true);
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data\rINJECTED=1:/var/lib/vardo/data" }).success).toBe(false);
   });
 
   it("accepts all four mounts set at once", () => {
     expect(
       mountsSchema.safeParse({
-        vardoData: "/mnt/data",
-        vardoProjects: "/home/user/projects",
-        vardoMount1: "/opt/extra",
-        vardoMount2: "/opt/other",
+        vardoData: "/mnt/data:/var/lib/vardo/data",
+        vardoProjects: "/home/user/projects:/var/lib/vardo/projects",
+        vardoMount1: "/opt/extra:/mnt/extra",
+        vardoMount2: "/opt/other:/mnt/other",
       }).success,
     ).toBe(true);
   });
@@ -250,8 +277,12 @@ describe("mounts POST — mountPathField validation", () => {
     ).toBe(true);
   });
 
-  it("rejects a path that starts with a newline", () => {
-    expect(mountsSchema.safeParse({ vardoData: "\n/mnt/data" }).success).toBe(false);
+  it("rejects path that starts with a newline", () => {
+    expect(mountsSchema.safeParse({ vardoData: "\n/mnt/data:/var/lib/vardo/data" }).success).toBe(false);
+  });
+
+  it("rejects multiple colons (more than one separator)", () => {
+    expect(mountsSchema.safeParse({ vardoData: "/mnt/data:/var/lib/vardo/data:extra" }).success).toBe(false);
   });
 });
 
@@ -296,19 +327,19 @@ describe("mounts POST — update logic", () => {
   it("calls writer for each update and returns ok:true on success", async () => {
     const writer = vi.fn().mockResolvedValue(undefined);
     const result = await processMountsUpdate(
-      [["VARDO_DATA", "/mnt/data"], ["VARDO_PROJECTS", "/home/user/projects"]],
+      [["VARDO_DATA", "/mnt/data:/var/lib/vardo/data:ro"], ["VARDO_PROJECTS", "/home/user/projects:/var/lib/vardo/projects:ro"]],
       writer,
     );
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
     expect(writer).toHaveBeenCalledTimes(2);
-    expect(writer).toHaveBeenCalledWith("VARDO_DATA", "/mnt/data");
-    expect(writer).toHaveBeenCalledWith("VARDO_PROJECTS", "/home/user/projects");
+    expect(writer).toHaveBeenCalledWith("VARDO_DATA", "/mnt/data:/var/lib/vardo/data:ro");
+    expect(writer).toHaveBeenCalledWith("VARDO_PROJECTS", "/home/user/projects:/var/lib/vardo/projects:ro");
   });
 
   it("returns 500 when writeEnvKey throws (file I/O error path)", async () => {
     const writer = vi.fn().mockRejectedValue(new Error("EACCES: permission denied"));
-    const result = await processMountsUpdate([["VARDO_DATA", "/mnt/data"]], writer);
+    const result = await processMountsUpdate([["VARDO_DATA", "/mnt/data:/var/lib/vardo/data:ro"]], writer);
     expect(result.ok).toBe(false);
     expect(result.status).toBe(500);
     expect(result.error).toContain("Could not update .env");
@@ -320,7 +351,7 @@ describe("mounts POST — update logic", () => {
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("EROFS: read-only file system"));
     const result = await processMountsUpdate(
-      [["VARDO_DATA", "/mnt/data"], ["VARDO_PROJECTS", "/home/user/projects"]],
+      [["VARDO_DATA", "/mnt/data:/var/lib/vardo/data:ro"], ["VARDO_PROJECTS", "/home/user/projects:/var/lib/vardo/projects:ro"]],
       writer,
     );
     expect(result.status).toBe(500);

--- a/tests/unit/api/admin/maintenance.test.ts
+++ b/tests/unit/api/admin/maintenance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { mountsSchema, restartSchema } from "@/lib/api/admin/maintenance-schemas";
+import { mountsSchema, restartSchema, parseMountPair } from "@/lib/api/admin/maintenance-schemas";
 
 // ---------------------------------------------------------------------------
 // Maintenance API — validation schemas and core logic
@@ -168,20 +168,6 @@ describe("update — VARDO_HOME_DIR resolution", () => {
 // ---------------------------------------------------------------------------
 
 describe("mounts GET — response shape", () => {
-  function parseMountPair(value: string | undefined): { source: string; destination: string } | null {
-    if (!value || value === "/dev/null") return null;
-    const mountValue = value.endsWith(":ro") ? value.slice(0, -3) : value;
-    const colonIndex = mountValue.indexOf(":");
-    if (colonIndex === -1) {
-      // Legacy single-path format
-      return { source: mountValue, destination: mountValue };
-    }
-    const source = mountValue.slice(0, colonIndex);
-    const destination = mountValue.slice(colonIndex + 1);
-    if (!source || !destination) return null;
-    return { source, destination };
-  }
-
   function buildMountsResponse(env: Record<string, string | undefined>) {
     return {
       vardoData: parseMountPair(env.VARDO_DATA),


### PR DESCRIPTION
## Summary

Updates the maintenance mounts UI to use source:destination pairs instead of single paths, matching how Docker bind mounts actually work.

## Changes

- **maintenance-schemas.ts**: Updated validation to require source:destination format
- **mounts/route.ts**: API now parses pairs for GET and formats with :ro suffix for POST
- **maintenance-settings.tsx**: UI shows separate source/destination fields per mount
- **docker-compose.yml**: Mounts now use the stored pairs directly
- **maintenance.test.ts**: Tests updated for new format

## Test plan

- [x] typecheck passes
- [x] lint passes (preexisting warnings unrelated)
- [x] unit tests pass (38 tests in maintenance.test.ts)
- [ ] Manual: verify UI shows paired fields
- [ ] Manual: verify save produces source:destination:ro format