### PR TITLE
feat(mcp): add Tier 1 and Tier 2 app management tools

### DIFF
--- a/lib/mcp/tools/deploy-app.ts
+++ b/lib/mcp/tools/deploy-app.ts
@@ -1,0 +1,115 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { createDeployment } from "@/lib/docker/deploy";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 5 deploys per 10 minutes per user/org pair.
+// Each deploy spins up containers — cap resource exhaustion.
+const DEPLOY_RATE_LIMIT = 5;
+const DEPLOY_RATE_WINDOW_MS = 10 * 60 * 1000;
+
+export function registerDeployApp(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_deploy_app",
+    "Trigger a deployment for an app. The API endpoint returns an SSE stream, so this tool starts the deploy asynchronously and returns the deploymentId for polling with vardo_get_deploy_status. Does not block waiting for completion.",
+    {
+      appId: z.string().describe("The app ID to deploy"),
+      environmentId: z
+        .string()
+        .optional()
+        .describe("Optional environment ID to deploy to (defaults to production)"),
+    },
+    async ({ appId, environmentId }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:deploy-app",
+        DEPLOY_RATE_LIMIT,
+        DEPLOY_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, name: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Create the deployment record. The deploy worker picks it up
+      // asynchronously — we return the ID immediately for polling.
+      const deploymentId = await createDeployment({
+        appId,
+        organizationId: context.organizationId,
+        trigger: "api",
+        triggeredBy: context.userId,
+        environmentId,
+      });
+
+      // Fire the actual deploy in the background. Import requestDeploy
+      // to handle cancel-and-replace semantics.
+      const { requestDeploy } = await import("@/lib/docker/deploy-cancel");
+      requestDeploy({
+        appId,
+        organizationId: context.organizationId,
+        trigger: "api",
+        triggeredBy: context.userId,
+        deploymentId,
+        environmentId,
+      }).catch(() => {
+        // Deploy failures are recorded on the deployment record — the
+        // caller polls vardo_get_deploy_status to observe them.
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                deploymentId,
+                appId,
+                appName: app.name,
+                status: "queued",
+                message: "Deploy started. Use vardo_get_deploy_status to poll for progress.",
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/get-app-config.ts
+++ b/lib/mcp/tools/get-app-config.ts
@@ -1,0 +1,58 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import type { McpAuthContext } from "../auth";
+
+export function registerGetAppConfig(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_get_app_config",
+    "Get the full configuration for a specific app. Returns all settings including deploy type, git config, resource limits, domains, env var keys (not values), and recent deployments.",
+    {
+      appId: z.string().describe("The app ID to get config for"),
+    },
+    async ({ appId }) => {
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        with: {
+          deployments: {
+            orderBy: (d, { desc }) => [desc(d.startedAt)],
+            limit: 10,
+          },
+          domains: true,
+          envVars: {
+            columns: { id: true, key: true, isSecret: true, createdAt: true, updatedAt: true },
+          },
+        },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ app }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/get-deploy-status.ts
+++ b/lib/mcp/tools/get-deploy-status.ts
@@ -1,0 +1,92 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { deployments, apps } from "@/lib/db/schema";
+import { eq, and, sql } from "drizzle-orm";
+import type { McpAuthContext } from "../auth";
+import { scrubEnvValues } from "./get-deploy-logs";
+
+// Tail the last 10KB of the log for status checks — enough context
+// without bloating the MCP response payload.
+const LOG_TAIL = 10 * 1024;
+
+export function registerGetDeployStatus(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_get_deploy_status",
+    "Get the status of a specific deployment. Returns status, timestamps, duration, git info, and the tail of the build log. Use after vardo_deploy_app to poll for completion.",
+    {
+      appId: z.string().describe("The app ID the deployment belongs to"),
+      deploymentId: z.string().describe("The deployment ID to check"),
+    },
+    async ({ appId, deploymentId }) => {
+      const result = await db
+        .select({
+          id: deployments.id,
+          status: deployments.status,
+          trigger: deployments.trigger,
+          gitSha: deployments.gitSha,
+          gitMessage: deployments.gitMessage,
+          logTail: sql<string | null>`right(${deployments.log}, ${LOG_TAIL})`,
+          logLength: sql<number | null>`length(${deployments.log})`,
+          durationMs: deployments.durationMs,
+          startedAt: deployments.startedAt,
+          finishedAt: deployments.finishedAt,
+          appId: apps.id,
+          appName: apps.name,
+        })
+        .from(deployments)
+        .innerJoin(apps, eq(deployments.appId, apps.id))
+        .where(
+          and(
+            eq(deployments.id, deploymentId),
+            eq(deployments.appId, appId),
+            eq(apps.organizationId, context.organizationId)
+          )
+        )
+        .then((rows) => rows[0] ?? null);
+
+      if (!result) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Deployment not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                deployment: {
+                  id: result.id,
+                  status: result.status,
+                  trigger: result.trigger,
+                  gitSha: result.gitSha,
+                  gitMessage: result.gitMessage,
+                  durationMs: result.durationMs,
+                  startedAt: result.startedAt,
+                  finishedAt: result.finishedAt,
+                  appId: result.appId,
+                  appName: result.appName,
+                },
+                logTail: result.logTail ? scrubEnvValues(result.logTail) : null,
+                logTruncated: result.logLength != null && result.logLength > LOG_TAIL,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/get-env-vars.ts
+++ b/lib/mcp/tools/get-env-vars.ts
@@ -1,0 +1,87 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { decryptOrFallback, encrypt } from "@/lib/crypto/encrypt";
+import type { McpAuthContext } from "../auth";
+
+export function registerGetEnvVars(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_get_env_vars",
+    "Get the decrypted environment variables for an app. Returns the full env file content as a string.",
+    {
+      appId: z.string().describe("The app ID to get env vars for"),
+    },
+    async ({ appId }) => {
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, envContent: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (!app.envContent) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ content: "" }),
+            },
+          ],
+        };
+      }
+
+      const { content: decrypted, wasEncrypted } = decryptOrFallback(
+        app.envContent,
+        context.organizationId
+      );
+
+      if (!decrypted && !wasEncrypted) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                content: "",
+                error: "Failed to decrypt env vars — check ENCRYPTION_MASTER_KEY",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // If data was plaintext (unmigrated), encrypt it on read
+      if (!wasEncrypted && decrypted) {
+        const encrypted = encrypt(decrypted, context.organizationId);
+        await db.update(apps).set({ envContent: encrypted }).where(eq(apps.id, appId));
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ content: decrypted }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -10,6 +10,15 @@ import { registerGetPreviewStatus } from "./get-preview-status";
 import { registerGetPreviewUrl } from "./get-preview-url";
 import { registerDestroyPreview } from "./destroy-preview";
 import { registerGetDeployLogs } from "./get-deploy-logs";
+import { registerDeployApp } from "./deploy-app";
+import { registerGetDeployStatus } from "./get-deploy-status";
+import { registerGetAppConfig } from "./get-app-config";
+import { registerUpdateApp } from "./update-app";
+import { registerGetEnvVars } from "./get-env-vars";
+import { registerSetEnvVars } from "./set-env-vars";
+import { registerRestartApp } from "./restart-app";
+import { registerStopApp } from "./stop-app";
+import { registerRollbackApp } from "./rollback-app";
 
 /**
  * Register all MCP tools on the server instance.
@@ -28,4 +37,13 @@ export function registerAllTools(
   registerGetPreviewUrl(server, context);
   registerDestroyPreview(server, context);
   registerGetDeployLogs(server, context);
+  registerDeployApp(server, context);
+  registerGetDeployStatus(server, context);
+  registerGetAppConfig(server, context);
+  registerUpdateApp(server, context);
+  registerGetEnvVars(server, context);
+  registerSetEnvVars(server, context);
+  registerRestartApp(server, context);
+  registerStopApp(server, context);
+  registerRollbackApp(server, context);
 }

--- a/lib/mcp/tools/restart-app.ts
+++ b/lib/mcp/tools/restart-app.ts
@@ -1,0 +1,81 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { restartContainers } from "@/lib/docker/deploy";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 10 restarts per 10 minutes per user/org pair.
+const RESTART_RATE_LIMIT = 10;
+const RESTART_RATE_WINDOW_MS = 10 * 60 * 1000;
+
+export function registerRestartApp(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_restart_app",
+    "Restart all containers for an app. Does a graceful restart without rebuilding — useful after config changes or to recover from a stuck state.",
+    {
+      appId: z.string().describe("The app ID to restart"),
+    },
+    async ({ appId }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:restart-app",
+        RESTART_RATE_LIMIT,
+        RESTART_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, name: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const result = await restartContainers(app.name);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { appId, appName: app.name, ...result },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/rollback-app.ts
+++ b/lib/mcp/tools/rollback-app.ts
@@ -1,0 +1,174 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps, deployments } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { createDeployment } from "@/lib/docker/deploy";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 3 rollbacks per 10 minutes per user/org pair.
+const ROLLBACK_RATE_LIMIT = 3;
+const ROLLBACK_RATE_WINDOW_MS = 10 * 60 * 1000;
+
+export function registerRollbackApp(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_rollback_app",
+    "Roll back an app to a previous successful deployment. Triggers a new deploy using the config and code from the target deployment. Returns the new deploymentId for polling with vardo_get_deploy_status.",
+    {
+      appId: z.string().describe("The app ID to roll back"),
+      deploymentId: z
+        .string()
+        .describe("The deployment ID to roll back to (must be a successful deployment)"),
+      includeEnvVars: z
+        .boolean()
+        .default(false)
+        .describe("Whether to also restore the env vars from the target deployment (default false)"),
+    },
+    async ({ appId, deploymentId, includeEnvVars }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:rollback-app",
+        ROLLBACK_RATE_LIMIT,
+        ROLLBACK_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, name: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Verify the target deployment exists, belongs to this app, and was successful
+      const targetDeployment = await db.query.deployments.findFirst({
+        where: and(
+          eq(deployments.id, deploymentId),
+          eq(deployments.appId, appId)
+        ),
+        columns: { id: true, status: true, gitSha: true, gitMessage: true },
+      });
+
+      if (!targetDeployment) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Target deployment not found" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (targetDeployment.status !== "success") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Can only roll back to a successful deployment" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Create the rollback deployment record and fire it asynchronously
+      const newDeploymentId = await createDeployment({
+        appId,
+        organizationId: context.organizationId,
+        trigger: "rollback",
+        triggeredBy: context.userId,
+      });
+
+      const { requestDeploy } = await import("@/lib/docker/deploy-cancel");
+      requestDeploy({
+        appId,
+        organizationId: context.organizationId,
+        trigger: "rollback",
+        triggeredBy: context.userId,
+        deploymentId: newDeploymentId,
+      }).then(async (result) => {
+        // Tag the new deployment with rollback source
+        try {
+          await db
+            .update(deployments)
+            .set({ rollbackFromId: deploymentId })
+            .where(eq(deployments.id, newDeploymentId));
+        } catch { /* best-effort */ }
+
+        // Apply env restore after successful deploy
+        if (result.success && includeEnvVars) {
+          try {
+            const target = await db.query.deployments.findFirst({
+              where: eq(deployments.id, deploymentId),
+              columns: { envSnapshot: true },
+            });
+            if (target?.envSnapshot) {
+              const { decrypt, encrypt } = await import("@/lib/crypto/encrypt");
+              const plainEnv = decrypt(target.envSnapshot, context.organizationId);
+              const encrypted = encrypt(plainEnv, context.organizationId);
+              await db.update(apps).set({ envContent: encrypted }).where(eq(apps.id, appId));
+            }
+          } catch { /* env restore is best-effort */ }
+        }
+      }).catch(() => {
+        // Failures recorded on the deployment record
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                deploymentId: newDeploymentId,
+                appId,
+                appName: app.name,
+                rollingBackTo: {
+                  deploymentId: targetDeployment.id,
+                  gitSha: targetDeployment.gitSha,
+                  gitMessage: targetDeployment.gitMessage,
+                },
+                includeEnvVars,
+                status: "queued",
+                message: "Rollback deploy started. Use vardo_get_deploy_status to poll for progress.",
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/set-env-vars.ts
+++ b/lib/mcp/tools/set-env-vars.ts
@@ -1,0 +1,87 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { encrypt } from "@/lib/crypto/encrypt";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 10 env updates per 5 minutes per user/org pair.
+const ENV_RATE_LIMIT = 10;
+const ENV_RATE_WINDOW_MS = 5 * 60 * 1000;
+
+export function registerSetEnvVars(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_set_env_vars",
+    "Set the environment variables for an app. Takes the full env file content as a string (KEY=VALUE format, one per line). Overwrites all existing env vars. Sets needsRedeploy flag — use vardo_deploy_app after to apply changes.",
+    {
+      appId: z.string().describe("The app ID to set env vars for"),
+      content: z.string().describe("Full env file content (KEY=VALUE per line)"),
+    },
+    async ({ appId, content }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:set-env-vars",
+        ENV_RATE_LIMIT,
+        ENV_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const encrypted = content.trim() ? encrypt(content, context.organizationId) : null;
+
+      await db
+        .update(apps)
+        .set({
+          envContent: encrypted,
+          needsRedeploy: true,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(apps.id, appId), eq(apps.organizationId, context.organizationId)));
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ saved: true, needsRedeploy: true }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/stop-app.ts
+++ b/lib/mcp/tools/stop-app.ts
@@ -1,0 +1,81 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { stopProject } from "@/lib/docker/deploy";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 10 stops per 10 minutes per user/org pair.
+const STOP_RATE_LIMIT = 10;
+const STOP_RATE_WINDOW_MS = 10 * 60 * 1000;
+
+export function registerStopApp(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_stop_app",
+    "Stop all containers for an app. The app will be offline until restarted or redeployed.",
+    {
+      appId: z.string().describe("The app ID to stop"),
+    },
+    async ({ appId }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:stop-app",
+        STOP_RATE_LIMIT,
+        STOP_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const app = await db.query.apps.findFirst({
+        where: and(
+          eq(apps.id, appId),
+          eq(apps.organizationId, context.organizationId)
+        ),
+        columns: { id: true, name: true },
+      });
+
+      if (!app) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const result = await stopProject(appId, app.name);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { appId, appName: app.name, ...result },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/update-app.ts
+++ b/lib/mcp/tools/update-app.ts
@@ -1,0 +1,122 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { apps } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
+import type { McpAuthContext } from "../auth";
+
+// 10 updates per 5 minutes per user/org pair.
+const UPDATE_RATE_LIMIT = 10;
+const UPDATE_RATE_WINDOW_MS = 5 * 60 * 1000;
+
+const updateSchema = z.object({
+  displayName: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+  containerPort: z.number().int().positive().nullable().optional(),
+  autoTraefikLabels: z.boolean().optional(),
+  autoDeploy: z.boolean().optional(),
+  gitBranch: z.string().nullable().optional(),
+  rootDirectory: z.string().nullable().optional(),
+  source: z.enum(["git", "direct"]).optional(),
+  deployType: z.enum(["compose", "dockerfile", "image", "static", "nixpacks", "railpack"]).optional(),
+  composeContent: z.string().max(512000).nullable().optional(),
+  composeFilePath: z.string().nullable().optional(),
+  dockerfilePath: z.string().nullable().optional(),
+  gitUrl: z.string().nullable().optional(),
+  imageName: z.string().nullable().optional(),
+  restartPolicy: z.string().nullable().optional(),
+  cpuLimit: z.number().positive().max(64).nullable().optional(),
+  memoryLimit: z.number().int().min(64).max(65536).nullable().optional(),
+  backendProtocol: z.enum(["http", "https"]).nullable().optional(),
+  healthCheckTimeout: z.number().int().min(10).max(600).nullable().optional(),
+  autoRollback: z.boolean().optional(),
+  rollbackGracePeriod: z.number().int().min(10).max(600).optional(),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+}).strict();
+
+export function registerUpdateApp(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_update_app",
+    "Update configuration for a specific app. Pass any subset of fields to update: displayName, description, containerPort, gitBranch, deployType, resource limits, etc. Does not trigger a deploy — use vardo_deploy_app after updating if needed.",
+    {
+      appId: z.string().describe("The app ID to update"),
+      config: updateSchema.describe("Partial config object with fields to update"),
+    },
+    async ({ appId, config }) => {
+      const rl = await slidingWindowRateLimit(
+        `${context.userId}:${context.organizationId}`,
+        "mcp:update-app",
+        UPDATE_RATE_LIMIT,
+        UPDATE_RATE_WINDOW_MS
+      );
+      if (rl.limited) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Verify app exists, belongs to org, and is not system-managed
+      const existingApp = await db.query.apps.findFirst({
+        where: and(eq(apps.id, appId), eq(apps.organizationId, context.organizationId)),
+        columns: { id: true },
+      });
+
+      if (!existingApp) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "App not found or access denied" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const [updated] = await db
+        .update(apps)
+        .set({ ...config, updatedAt: new Date() })
+        .where(
+          and(eq(apps.id, appId), eq(apps.organizationId, context.organizationId))
+        )
+        .returning();
+
+      if (!updated) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Update failed" }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { app: updated, updatedFields: Object.keys(config) },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+}


### PR DESCRIPTION
## Summary
Adds 9 MCP tools for app management, closing the gap between read-only and full CRUD coverage. Refs #669.

**Tier 1 — deploy + config:**
- `deploy_app` — trigger deploy, returns deploymentId for async polling
- `get_deploy_status` — check deployment progress/completion
- `get_app_config` — full app record
- `update_app` — partial config updates
- `get_env_vars` / `set_env_vars` — environment variable management

**Tier 2 — lifecycle:**
- `restart_app`, `stop_app`, `rollback_app`

All follow existing tool patterns — DB-direct, org-scoped, rate-limited on mutations.

## Test plan
- [ ] `deploy_app` triggers a deploy and returns deploymentId
- [ ] `get_deploy_status` returns correct status for running/completed deploys
- [ ] `get_app_config` returns full app record
- [ ] `update_app` modifies app settings
- [ ] `get_env_vars` returns decrypted content
- [ ] `set_env_vars` updates and triggers redeploy
- [ ] `restart_app`, `stop_app`, `rollback_app` work as expected
- [ ] Rate limiting prevents rapid-fire mutations