### PR TITLE
fix: remove branch filter from preview creation

### DIFF
--- a/lib/docker/preview.ts
+++ b/lib/docker/preview.ts
@@ -67,15 +67,12 @@ export async function createPreview(
     where: eq(apps.gitUrl, gitUrl),
   });
 
-  // Filter to matching branch
-  const branchApps = matchingApps.filter(
-    (a) => (a.gitBranch || "main") === opts.branch
-  );
+  if (matchingApps.length === 0) return null;
 
-  if (branchApps.length === 0) return null;
-
-  // Find the first app that belongs to a project
-  const groupedApp = branchApps.find((a) => a.projectId);
+  // Find the first app that belongs to a project.
+  // The PR branch gets deployed into the preview — we don't filter by
+  // the app's configured gitBranch since any repo app can be previewed.
+  const groupedApp = matchingApps.find((a) => a.projectId);
   if (!groupedApp || !groupedApp.projectId) {
     // No project — can't create a group preview for standalone apps
     return null;


### PR DESCRIPTION
## Summary
- Preview creation was comparing the PR feature branch against the app's configured `gitBranch` (usually `main`), which always failed since they never match
- The PR branch gets deployed *into* the preview — we just need to find a matching repo app that belongs to a project
- Removes the branch filter entirely, matches on git URL + project membership only

## Test plan
- [ ] Create a preview for a PR branch on an app configured to deploy from `main`
- [ ] Verify the preview deploys the PR branch, not main