### PR TITLE
feat(mcp): add create_project tool and projectId to update_app

### DIFF
--- a/lib/mcp/tools/create-project.ts
+++ b/lib/mcp/tools/create-project.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { projects } from "@/lib/db/schema";
+import { nanoid } from "nanoid";
+import type { McpAuthContext } from "../auth";
+
+export function registerCreateProject(
+  server: McpServer,
+  context: McpAuthContext
+) {
+  server.tool(
+    "vardo_create_project",
+    "Create a new project to group related apps together.",
+    {
+      name: z.string().min(1).max(100).describe("Project slug (lowercase, hyphens)"),
+      displayName: z.string().min(1).max(100).describe("Human-readable project name"),
+      description: z.string().max(500).nullable().optional().describe("Optional description"),
+      color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional().describe("Hex color (default #6366f1)"),
+    },
+    async ({ name, displayName, description, color }) => {
+      const [project] = await db
+        .insert(projects)
+        .values({
+          id: nanoid(),
+          organizationId: context.organizationId,
+          name,
+          displayName,
+          description: description ?? null,
+          color: color ?? "#6366f1",
+        })
+        .returning();
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ project }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -4,6 +4,7 @@ import { registerListApps } from "./list-apps";
 import { registerGetAppStatus } from "./get-app-status";
 import { registerGetAppLogs } from "./get-app-logs";
 import { registerListProjects } from "./list-projects";
+import { registerCreateProject } from "./create-project";
 import { registerCreatePreview } from "./create-preview";
 import { registerListPreviews } from "./list-previews";
 import { registerGetPreviewStatus } from "./get-preview-status";
@@ -31,6 +32,7 @@ export function registerAllTools(
   registerGetAppStatus(server, context);
   registerGetAppLogs(server, context);
   registerListProjects(server, context);
+  registerCreateProject(server, context);
   registerCreatePreview(server, context);
   registerListPreviews(server, context);
   registerGetPreviewStatus(server, context);

--- a/lib/mcp/tools/update-app.ts
+++ b/lib/mcp/tools/update-app.ts
@@ -13,6 +13,7 @@ const UPDATE_RATE_WINDOW_MS = 5 * 60 * 1000;
 const updateSchema = z.object({
   displayName: z.string().min(1).optional(),
   description: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
   containerPort: z.number().int().positive().nullable().optional(),
   autoTraefikLabels: z.boolean().optional(),
   autoDeploy: z.boolean().optional(),
@@ -41,7 +42,7 @@ export function registerUpdateApp(
 ) {
   server.tool(
     "vardo_update_app",
-    "Update configuration for a specific app. Pass any subset of fields to update: displayName, description, containerPort, gitBranch, deployType, resource limits, etc. Does not trigger a deploy — use vardo_deploy_app after updating if needed.",
+    "Update configuration for a specific app. Pass any subset of fields to update: displayName, description, projectId, containerPort, gitBranch, deployType, resource limits, etc. Does not trigger a deploy — use vardo_deploy_app after updating if needed.",
     {
       appId: z.string().describe("The app ID to update"),
       config: updateSchema.describe("Partial config object with fields to update"),


### PR DESCRIPTION
## Summary
- New `vardo_create_project` MCP tool — create projects without raw API calls
- Added `projectId` to `update_app` schema so apps can be moved between projects via MCP

Needed these while testing preview creation — had to fall back to curl to create a project and move an app.

## Test plan
- [ ] Create a project via `vardo_create_project`
- [ ] Move an app to it via `vardo_update_app` with `projectId`