### PR TITLE
fix: fall back to instance config baseDomain when org doesn't have one

### DIFF
--- a/lib/docker/clone.ts
+++ b/lib/docker/clone.ts
@@ -79,12 +79,19 @@ export async function createGroupEnvironment(
 
   if (!project) throw new Error("Project not found");
 
-  // Load org for base domain
+  // Load org for base domain, fall back to instance config
   const { organizations } = await import("@/lib/db/schema");
   const org = await db.query.organizations.findFirst({
     where: eq(organizations.id, opts.organizationId),
     columns: { baseDomain: true },
   });
+  if (!org?.baseDomain) {
+    const { getInstanceConfig } = await import("@/lib/system-settings");
+    const instanceConfig = await getInstanceConfig();
+    if (instanceConfig.baseDomain && org) {
+      (org as { baseDomain: string | null }).baseDomain = instanceConfig.baseDomain;
+    }
+  }
 
   // Create group environment record
   const groupEnvId = nanoid();


### PR DESCRIPTION
## Summary
- Preview/environment subdomain generation reads `org.baseDomain`, which is optional
- When null, fell back to `VARDO_BASE_DOMAIN` env var (deprecated) → `localhost`
- Now falls back to instance config's `baseDomain` (the value from admin Domain & SSL settings)

## Test plan
- [ ] Create a preview with org.baseDomain unset — should use instance baseDomain
- [ ] Create a preview with org.baseDomain set — should use that
- [ ] Verify no regression when both are set (org wins)