### PR TITLE
fix: deploy PR branch in preview environments

### DIFF
--- a/lib/docker/preview.ts
+++ b/lib/docker/preview.ts
@@ -112,12 +112,22 @@ export async function createPreview(
     };
   }
 
+  // Build branch overrides — set the PR branch on all git-sourced apps
+  // so the deploy checks out the feature branch instead of main.
+  const appOverrides: Record<string, { gitBranch: string }> = {};
+  for (const app of matchingApps) {
+    if (app.projectId === projectId) {
+      appOverrides[app.id] = { gitBranch: opts.branch };
+    }
+  }
+
   // Create new preview environment
   const result = await createGroupEnvironment({
     projectId,
     organizationId,
     name: envName,
     type: "preview",
+    appOverrides,
     prNumber: opts.prNumber,
     prUrl: opts.prUrl,
     expiresAt: new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000),


### PR DESCRIPTION
## Summary
- Preview environments were deploying from `main` instead of the PR branch
- `createGroupEnvironment` supports `appOverrides` with `gitBranch`, but `preview.ts` never passed it
- Now sets the PR branch on all git-sourced apps in the project via `appOverrides`
- The deploy system already reads `env.gitBranch` as an override (deploy.ts:273,380) — this just wires it up

## Test plan
- [ ] Create a preview for a PR branch
- [ ] Verify the environment records have `gitBranch` set to the PR branch
- [ ] Verify the deploy checks out the PR branch, not main
- [ ] Browse the preview URL and confirm it shows the PR's changes