### PR TITLE
fix(permissions): self-heal data directory ownership on startup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -998,8 +998,9 @@ clone_repo() {
     migrate_to_slots
   else
     # Fresh install — clone into blue slot
-    mkdir -p "$VARDO_DIR/apps/vardo/env"
-    chown -R 1001:1001 "$VARDO_DIR/apps"
+    mkdir -p "$VARDO_DIR/apps/vardo/env" "$VARDO_DIR/images"
+    chown 1001:1001 "$VARDO_DIR" "$VARDO_DIR/apps" "$VARDO_DIR/images"
+    chown -R 1001:1001 "$VARDO_DIR/apps/vardo"
     info "Cloning to $slot_dir..."
     run_cmd git clone --depth 1 "$REPO_URL" "$slot_dir"
     VARDO_SLOT_DIR="$slot_dir"

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -10,6 +10,17 @@ export async function register() {
     // Dedup guard — prevents duplicate schedulers on hot reload
     if (globalForInit.__vardo_initialized) return;
     globalForInit.__vardo_initialized = true;
+    // Verify data directories are writable — must run first so deploys don't
+    // fail with cryptic EACCES errors later.
+    const { ensureDataDirs } = await import("./lib/paths");
+    const badDirs = await ensureDataDirs();
+    if (badDirs.length > 0) {
+      log.error(
+        `Data directories not writable: ${badDirs.join(", ")}. ` +
+        `Deploys will fail. Fix ownership: chown -R 1001:1001 ${badDirs.join(" ")}`,
+      );
+    }
+
     // Load feature flags into sync cache — must run early so isFeatureEnabled()
     // returns real values instead of defaults for the rest of startup
     const { loadFeatureFlags } = await import("./lib/config/features");

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -322,7 +322,17 @@ export async function runDeployment(
     // App-level dir holds the repo; env-level dir holds slots
     const appBase = appBaseDir(app.name);
     const appDir = appEnvDir(app.name, envName);
-    await mkdir(appDir, { recursive: true });
+    try {
+      await mkdir(appDir, { recursive: true });
+    } catch (err: unknown) {
+      if (err && typeof err === "object" && "code" in err && err.code === "EACCES") {
+        throw new Error(
+          `Permission denied creating ${appDir}. ` +
+          `Fix ownership on the host: sudo chown -R 1001:1001 ${appBase}`,
+        );
+      }
+      throw err;
+    }
 
     // Load volumes from the volumes table
     const appVolumes = await db.query.volumes.findMany({

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -15,7 +15,8 @@
 // ---------------------------------------------------------------------------
 
 import { resolve, join } from "path";
-import { accessSync } from "fs";
+import { accessSync, constants } from "fs";
+import { mkdir, access, writeFile, unlink } from "fs/promises";
 
 /** Root directory for all Vardo data. */
 export const VARDO_HOME_DIR = resolve(
@@ -84,6 +85,44 @@ export const VARDO_COMPOSE_FILE = join(VARDO_CURRENT_DIR, "docker-compose.yml");
 /** Resolve a specific slot directory (blue or green). */
 export function vardoSlotDir(slot: "blue" | "green"): string {
   return join(VARDO_ENV_DIR, slot);
+}
+
+// ---------------------------------------------------------------------------
+// Startup directory verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure required data directories exist and are writable.
+ *
+ * Called once at startup from instrumentation.ts. Returns a list of
+ * directories that failed — empty means everything is fine.
+ *
+ * Cannot fix ownership (we don't run as root), but creates missing dirs
+ * if the parent is writable and reports clear errors when not.
+ */
+export async function ensureDataDirs(): Promise<string[]> {
+  const dirs = [VARDO_HOME_DIR, PROJECTS_DIR, IMAGES_DIR];
+  const failures: string[] = [];
+
+  for (const dir of dirs) {
+    try {
+      await mkdir(dir, { recursive: true });
+    } catch {
+      // mkdir failed — parent not writable
+    }
+
+    try {
+      await access(dir, constants.W_OK);
+      // Verify actual write capability (NFS/FUSE mounts can lie about W_OK)
+      const probe = join(dir, `.vardo-write-probe-${process.pid}`);
+      await writeFile(probe, "");
+      await unlink(probe);
+    } catch {
+      failures.push(dir);
+    }
+  }
+
+  return failures;
 }
 
 /**

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -16,6 +16,14 @@ if [ -n "${DOCKER_GID:-}" ]; then
   adduser nextjs "$(getent group "$DOCKER_GID" | cut -d: -f1)" 2>/dev/null || true
 fi
 
+# Ensure the app user can write to the Vardo home directory (host-mounted volume).
+# Without this, deploys fail with EACCES when creating app directories.
+# Only chown the top-level dirs — NOT recursive, to avoid slow startup and
+# breaking apps that need root-owned files internally.
+VARDO_HOME="${VARDO_HOME_DIR:-${VARDO_DIR:-/opt/vardo}}"
+mkdir -p "$VARDO_HOME/apps" "$VARDO_HOME/images"
+chown nextjs:nodejs "$VARDO_HOME" "$VARDO_HOME/apps" "$VARDO_HOME/images"
+
 # Ensure the Traefik dynamic config directory is owned by the app user.
 # Docker named volumes are initialised as root — chown here so writes succeed
 # after privilege drop. Traefik (running as root) can still read/watch the dir.


### PR DESCRIPTION
## Summary

- Entrypoint now chowns the top-level data dirs (`/opt/vardo`, `apps/`, `images/`) before dropping to the app user — automatic self-heal, no user action needed
- Startup check in `instrumentation.ts` verifies dirs are writable with a real write probe and logs the exact `chown` command if not
- Deploy catches `EACCES` on `mkdir` and returns an actionable error instead of a raw Node stack trace
- `install.sh` fixed to chown `/opt/vardo` itself on fresh installs, not just the subtree

## Test plan

- [ ] Fresh install: verify `/opt/vardo`, `apps/`, `images/` are owned by 1001:1001
- [ ] Simulate bad perms (`sudo chown root:root /opt/vardo/apps`), restart container, confirm entrypoint self-heals
- [ ] With bad perms and old entrypoint, confirm startup log shows clear error message
- [ ] Deploy an app and confirm no EACCES errors