### PR TITLE
fix(deploy): detect active slot from Docker, not just the symlink

### DIFF
--- a/lib/docker/compose-normalize.ts
+++ b/lib/docker/compose-normalize.ts
@@ -29,7 +29,7 @@ export type NormalizeResult = {
 
 export type NormalizeOptions = {
   /** Service names that have domains configured (routed via Traefik). */
-  routedServices: Set<string>;
+  routedServices?: Set<string>;
   /** The app's desired restart policy (default: "unless-stopped"). */
   restartPolicy?: string;
   /** Skip host port stripping (e.g., user explicitly opted out). */
@@ -73,7 +73,7 @@ export function normalizeCompose(
 
   // 1. Strip host ports from Traefik-routed services
   if (!opts.keepHostPorts) {
-    result = normalizeHostPorts(result, opts.routedServices, changes);
+    result = normalizeHostPorts(result, opts.routedServices ?? new Set(), changes);
   }
 
   // 2. Normalize restart policies

--- a/lib/docker/deploy-steps/build.ts
+++ b/lib/docker/deploy-steps/build.ts
@@ -8,7 +8,7 @@ import { orgEnvVars, apps, environments } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { mkdir, writeFile, readFile, rm, readlink, symlink, copyFile, stat, readdir } from "fs/promises";
+import { mkdir, writeFile, readFile, rm, symlink, copyFile, stat, readdir } from "fs/promises";
 import { join } from "path";
 import { decryptOrFallback } from "@/lib/crypto/encrypt";
 import { parseEnvToMap } from "@/lib/env/parse-env";
@@ -24,6 +24,7 @@ import {
   ensureWritableDir,
 } from "../constants";
 import type { DeployContext } from "../deploy-context";
+import { detectActiveSlot } from "../slots";
 
 const execFileAsync = promisify(execFile);
 const NETWORK_NAME = VARDO_NETWORK;
@@ -44,9 +45,11 @@ export async function build(ctx: DeployContext): Promise<DeployContext> {
     ctx.newProjectName = `${app.name}-${ctx.envName}`;
     ctx.slotDir = join(appDir, "local");
   } else {
-    try {
-      activeSlot = (await readlink(join(appDir, "current"))).trim() as "blue" | "green";
-    } catch { /* no active slot yet */ }
+    // Resolve the active slot from the symlink, then Docker ground-truth, then
+    // the legacy file. Detecting a still-running old slot is what lets the swap
+    // step tear it down before starting the new slot — without this, a stale
+    // slot holding a host port causes "port already allocated".
+    activeSlot = await detectActiveSlot(appDir, `${app.name}-${ctx.envName}`);
 
     newSlot = activeSlot === "blue" ? "green" : "blue";
     ctx.newProjectName = `${app.name}-${ctx.envName}-${newSlot}`;

--- a/lib/docker/deploy-steps/resolve-compose.ts
+++ b/lib/docker/deploy-steps/resolve-compose.ts
@@ -14,7 +14,7 @@ import {
   getTraefikRoutedServices,
 } from "../compose";
 import { detectExposedPorts } from "../client";
-import { normalizeCompose, getRoutedServices } from "../compose-normalize";
+import { normalizeCompose } from "../compose-normalize";
 import { removeAppRouteConfig } from "@/lib/ssl/generate-config";
 import {
   NETWORK_NAME as VARDO_NETWORK,
@@ -34,8 +34,14 @@ export async function resolveCompose(ctx: DeployContext): Promise<DeployContext>
   ctx.bareCompose = bareCompose;
 
   // Normalize: treat the user's compose as intent, produce safe runtime config.
-  const routedServices = getRoutedServices(compose, app.domains.length);
-  const normalized = normalizeCompose(compose, { routedServices });
+  // Host ports are intentionally KEPT. Vardo writes the user's bare compose to
+  // disk (`ctx.bareCompose`) and layers Traefik routing on top via an override —
+  // and a Compose override can't un-publish a port, so stripping here never
+  // reached the running container; it only produced a misleading "host port
+  // removed" line in the deploy log. Slot cutover already tears down the old
+  // slot before starting the new one, so a kept host port never collides
+  // between blue/green.
+  const normalized = normalizeCompose(compose, { keepHostPorts: true });
   compose = normalized.compose;
   for (const change of normalized.changes) {
     log(`[deploy] Normalize: ${change.service}.${change.field} ${change.action}${change.before ? ` (was: ${change.before})` : ""} — ${change.reason}`);

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -15,6 +15,7 @@ import { appBaseDir, appEnvDir } from "@/lib/paths";
 import {
   slotComposeFiles,
 } from "./compose";
+import { detectActiveSlot } from "./slots";
 import { recordActivity } from "@/lib/activity";
 import { DeployBlockedError } from "./errors";
 import { createDeployLogger } from "./deploy-logger";
@@ -586,12 +587,10 @@ async function resolveActiveSlot(
     // No local/ directory — standard blue-green
   }
 
-  let activeSlot: string;
-  try {
-    activeSlot = (await readlink(join(dir, "current"))).trim();
-  } catch {
-    activeSlot = "blue";
-  }
+  // Same resolution as the deploy path: symlink → running slot → legacy file.
+  // Falls back to "blue" only when nothing is detectable (stopping a project
+  // that doesn't exist is a harmless no-op).
+  const activeSlot = (await detectActiveSlot(dir, projectPrefix)) ?? "blue";
 
   return {
     slotDir: join(dir, activeSlot),

--- a/lib/docker/instant-rollback.ts
+++ b/lib/docker/instant-rollback.ts
@@ -1,13 +1,14 @@
 import { db } from "@/lib/db";
 import { apps, deployments } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
-import { readlink, rm, symlink, rename } from "fs/promises";
+import { rm, symlink, rename } from "fs/promises";
 import { join } from "path";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { nanoid } from "nanoid";
 import { appEnvDir } from "@/lib/paths";
 import { slotComposeFiles } from "./compose";
+import { detectActiveSlot } from "./slots";
 import { addEvent } from "@/lib/stream/producer";
 import { recordActivity } from "@/lib/activity";
 import {
@@ -57,16 +58,12 @@ export async function checkStandbyAvailable(
   }
 
   const appDir = appEnvDir(appName, env.name);
-  let activeSlot: string;
-  try {
-    activeSlot = (await readlink(join(appDir, "current"))).trim();
-  } catch {
-    activeSlot = "blue";
-  }
+  const projectPrefix = `${appName}-${env.name}`;
+  const activeSlot = (await detectActiveSlot(appDir, projectPrefix)) ?? "blue";
 
   const standbySlot = activeSlot === "blue" ? "green" : "blue";
   const standbyDir = join(appDir, standbySlot);
-  const standbyProjectName = `${appName}-${env.name}-${standbySlot}`;
+  const standbyProjectName = `${projectPrefix}-${standbySlot}`;
 
   let standbyAvailable = false;
   let standbyServiceCount = 0;
@@ -94,18 +91,18 @@ export async function performInstantRollback(
   const startTime = Date.now();
   const appDir = appEnvDir(appName, env.name);
 
-  let activeSlot: string;
-  try {
-    activeSlot = (await readlink(join(appDir, "current"))).trim();
-  } catch {
+  const projectPrefix = `${appName}-${env.name}`;
+  const detectedSlot = await detectActiveSlot(appDir, projectPrefix);
+  if (!detectedSlot) {
     return { success: false, deploymentId: "", fromSlot: "", toSlot: "", durationMs: 0, error: "No active deployment" };
   }
+  const activeSlot = detectedSlot;
 
   const standbySlot = activeSlot === "blue" ? "green" : "blue";
   const standbyDir = join(appDir, standbySlot);
-  const standbyProjectName = `${appName}-${env.name}-${standbySlot}`;
+  const standbyProjectName = `${projectPrefix}-${standbySlot}`;
   const activeDir = join(appDir, activeSlot);
-  const activeProjectName = `${appName}-${env.name}-${activeSlot}`;
+  const activeProjectName = `${projectPrefix}-${activeSlot}`;
 
   const standbyComposeFileArgs = await slotComposeFiles(standbyDir);
   const activeComposeFileArgs = await slotComposeFiles(activeDir);

--- a/lib/docker/slots.ts
+++ b/lib/docker/slots.ts
@@ -73,7 +73,11 @@ export async function detectActiveSlot(
     /* no symlink yet — fall through */
   }
 
-  // 2. Docker ground-truth — a running slot is the real host-port holder
+  // 2. Docker ground-truth — a running slot is the real host-port holder.
+  // Iteration order is intentional: blue is checked first. If both slots happen
+  // to be running simultaneously (e.g. a previous deploy left the old slot up),
+  // blue wins. This is an arbitrary but stable tie-break — the important thing
+  // is that we find *something* to tear down rather than colliding on the port.
   for (const slot of ["blue", "green"] as const) {
     try {
       if (await probes.isSlotRunning(`${projectPrefix}-${slot}`)) return slot;

--- a/lib/docker/slots.ts
+++ b/lib/docker/slots.ts
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------
+// Blue-green slot resolution.
+//
+// The "active slot" is the one currently serving — and, crucially, the one
+// holding any host ports. It MUST be identified so the deploy can tear it down
+// before starting the new slot. If a stale slot is left running (e.g. recreated
+// by a `restart:` policy after a host reboot, or an app that predates the
+// `current` symlink), failing to detect it means the new slot collides on the
+// host port: "Bind for 0.0.0.0:<port> failed: port is already allocated".
+// ---------------------------------------------------------------------------
+
+import { readlink, readFile } from "fs/promises";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { join } from "path";
+import { COMPOSE_QUERY_TIMEOUT } from "./constants";
+
+const execFileAsync = promisify(execFile);
+
+export type Slot = "blue" | "green";
+
+/** Injectable probes — real implementations hit the filesystem / Docker. */
+export type SlotProbes = {
+  readSymlink: (path: string) => Promise<string>;
+  readActiveFile: (path: string) => Promise<string>;
+  isSlotRunning: (projectName: string) => Promise<boolean>;
+};
+
+const defaultProbes: SlotProbes = {
+  readSymlink: (path) => readlink(path),
+  readActiveFile: (path) => readFile(path, "utf-8"),
+  isSlotRunning: async (projectName) => {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["ps", "-q", "--filter", `label=com.docker.compose.project=${projectName}`],
+      { timeout: COMPOSE_QUERY_TIMEOUT },
+    );
+    return stdout.trim().length > 0;
+  },
+};
+
+function asSlot(value: string): Slot | null {
+  const v = value.trim();
+  return v === "blue" || v === "green" ? v : null;
+}
+
+/**
+ * Resolve which slot is currently active for a blue-green app.
+ *
+ * Resolution order:
+ *  1. `current` symlink — vardo's authoritative pointer once a deploy succeeds.
+ *  2. Docker ground-truth — a slot project with running containers. This is what
+ *     actually holds host ports, so it's the one that must be torn down. Catches
+ *     apps that predate the symlink (legacy `.active-slot`) and symlinks that
+ *     drifted from reality (a host reboot re-running `restart:` containers).
+ *  3. Legacy `.active-slot` file — the pre-symlink migration artifact.
+ *
+ * Returns null only when no slot is detectable — a genuine first deploy.
+ *
+ * `projectPrefix` is the compose project name without the slot suffix
+ * (`${appName}-${envName}`); slot projects are `${projectPrefix}-${slot}`.
+ */
+export async function detectActiveSlot(
+  appDir: string,
+  projectPrefix: string,
+  probes: SlotProbes = defaultProbes,
+): Promise<Slot | null> {
+  // 1. Authoritative pointer
+  try {
+    const slot = asSlot(await probes.readSymlink(join(appDir, "current")));
+    if (slot) return slot;
+  } catch {
+    /* no symlink yet — fall through */
+  }
+
+  // 2. Docker ground-truth — a running slot is the real host-port holder
+  for (const slot of ["blue", "green"] as const) {
+    try {
+      if (await probes.isSlotRunning(`${projectPrefix}-${slot}`)) return slot;
+    } catch {
+      /* probe failed — try the other slot */
+    }
+  }
+
+  // 3. Legacy migration artifact
+  try {
+    const slot = asSlot(await probes.readActiveFile(join(appDir, ".active-slot")));
+    if (slot) return slot;
+  } catch {
+    /* no legacy file */
+  }
+
+  return null;
+}

--- a/tests/unit/lib/docker/compose-normalize.test.ts
+++ b/tests/unit/lib/docker/compose-normalize.test.ts
@@ -154,6 +154,24 @@ describe("normalizeCompose", () => {
     });
   });
 
+  describe("omitted routedServices", () => {
+    it("treats all services as non-routed when routedServices is omitted", () => {
+      // resolve-compose.ts calls normalizeCompose(compose, { keepHostPorts: true })
+      // without routedServices — exercises the `?? new Set()` fallback.
+      const compose = makeCompose({
+        app: { image: "nginx:latest", ports: ["8080:3000"] },
+      });
+
+      const { compose: result, changes } = normalizeCompose(compose, { keepHostPorts: true });
+
+      // With keepHostPorts the port should be retained (no routed services to strip from anyway)
+      expect(result.services.app.ports).toEqual(["8080:3000"]);
+      // restart policy should still be normalised
+      expect(result.services.app.restart).toBe("unless-stopped");
+      expect(changes.filter((c) => c.field === "ports")).toHaveLength(0);
+    });
+  });
+
   describe("immutability", () => {
     it("does not modify the original compose object", () => {
       const compose = makeCompose({

--- a/tests/unit/lib/docker/slots.test.ts
+++ b/tests/unit/lib/docker/slots.test.ts
@@ -44,6 +44,16 @@ describe("detectActiveSlot", () => {
     expect(p.isSlotRunning).toHaveBeenCalledWith(`${PREFIX}-green`);
   });
 
+  it("falls back to the running slot when there is no symlink — blue slot", async () => {
+    const p = probes({
+      isSlotRunning: vi.fn((project: string) => Promise.resolve(project === `${PREFIX}-blue`)),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBe("blue");
+    expect(p.isSlotRunning).toHaveBeenCalledWith(`${PREFIX}-blue`);
+    // green should not be needed since blue matched first
+    expect(p.isSlotRunning).not.toHaveBeenCalledWith(`${PREFIX}-green`);
+  });
+
   it("running slot wins over a drifted legacy file", async () => {
     // The real port holder is what must be torn down, even if .active-slot lies.
     const p = probes({

--- a/tests/unit/lib/docker/slots.test.ts
+++ b/tests/unit/lib/docker/slots.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { detectActiveSlot, type SlotProbes } from "@/lib/docker/slots";
+
+const APP_DIR = "/opt/vardo/apps/ollama/production";
+const PREFIX = "ollama-production";
+
+/**
+ * Build a probe set. By default everything is "absent": symlink and legacy
+ * file reject (ENOENT), and no slot is running. Override per test.
+ */
+function probes(overrides: Partial<SlotProbes> = {}): SlotProbes {
+  return {
+    readSymlink: vi.fn(() => Promise.reject(new Error("ENOENT"))),
+    readActiveFile: vi.fn(() => Promise.reject(new Error("ENOENT"))),
+    isSlotRunning: vi.fn(() => Promise.resolve(false)),
+    ...overrides,
+  };
+}
+
+describe("detectActiveSlot", () => {
+  it("returns the slot from the current symlink (authoritative)", async () => {
+    expect(
+      await detectActiveSlot(APP_DIR, PREFIX, probes({ readSymlink: () => Promise.resolve("green\n") })),
+    ).toBe("green");
+  });
+
+  it("symlink wins over a running slot and the legacy file", async () => {
+    const p = probes({
+      readSymlink: () => Promise.resolve("green"),
+      isSlotRunning: vi.fn(() => Promise.resolve(true)), // blue would match first
+      readActiveFile: () => Promise.resolve("blue"),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBe("green");
+    // Never falls through to Docker when the symlink resolves.
+    expect(p.isSlotRunning).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the running slot when there is no symlink", async () => {
+    const p = probes({
+      isSlotRunning: vi.fn((project: string) => Promise.resolve(project === `${PREFIX}-green`)),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBe("green");
+    expect(p.isSlotRunning).toHaveBeenCalledWith(`${PREFIX}-blue`);
+    expect(p.isSlotRunning).toHaveBeenCalledWith(`${PREFIX}-green`);
+  });
+
+  it("running slot wins over a drifted legacy file", async () => {
+    // The real port holder is what must be torn down, even if .active-slot lies.
+    const p = probes({
+      isSlotRunning: (project: string) => Promise.resolve(project === `${PREFIX}-blue`),
+      readActiveFile: () => Promise.resolve("green"),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBe("blue");
+  });
+
+  it("falls back to the legacy .active-slot file when nothing is running", async () => {
+    expect(
+      await detectActiveSlot(APP_DIR, PREFIX, probes({ readActiveFile: () => Promise.resolve("green") })),
+    ).toBe("green");
+  });
+
+  it("returns null on a genuine first deploy (nothing detectable)", async () => {
+    expect(await detectActiveSlot(APP_DIR, PREFIX, probes())).toBeNull();
+  });
+
+  it("ignores invalid symlink/file contents and keeps resolving", async () => {
+    const p = probes({
+      readSymlink: () => Promise.resolve("local"), // not a blue/green slot
+      readActiveFile: () => Promise.resolve("garbage"),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBeNull();
+  });
+
+  it("survives a Docker probe error and still consults the legacy file", async () => {
+    const p = probes({
+      isSlotRunning: () => Promise.reject(new Error("docker daemon unreachable")),
+      readActiveFile: () => Promise.resolve("blue"),
+    });
+    expect(await detectActiveSlot(APP_DIR, PREFIX, p)).toBe("blue");
+  });
+});


### PR DESCRIPTION
## Problem

Deploying a host-port app could fail with:

```
Error response from daemon: failed to set up container networking: driver failed
programming external connectivity ... Bind for 0.0.0.0:11434 failed: port is already allocated
```

Hit on `ollama` (and any app in the same state). The deploy log showed `Active slot: none, deploying to: blue` while an old `green` slot was still running and holding the host port.

## Root cause

The blue-green deploy read the active slot **only** from the `current` symlink (`build.ts`). Two ways that goes wrong:

1. **Apps that predate the symlink** — they still have the legacy `.active-slot` file and no symlink, so resolution returned `null`.
2. **Symlink drift** — a host reboot re-runs `restart:` containers from the old slot, but the symlink/state can disagree with what's actually running.

When the active slot resolves to `null`, `swap.ts` sets `mustStopOldSlot = false` and never tears the old slot down. The old slot keeps the host port, the new slot tries to bind it → `port already allocated`. vardo already does stop-old-before-start-new; it just couldn't see which slot was old.

The same weak resolution exists in `deploy.ts` `resolveActiveSlot` (stop/restart), which blindly fell back to `"blue"`.

## Fix

- **`lib/docker/slots.ts`** (new) — `detectActiveSlot()` resolves by priority:
  1. `current` symlink (authoritative once a deploy has succeeded)
  2. **Docker ground-truth** — a slot project with running containers (the real host-port holder, so the one that must be torn down)
  3. legacy `.active-slot` file
- Wired into both the deploy path (`build.ts`) and the stop/restart path (`deploy.ts`), so they stop drifting.
- **`resolve-compose.ts`** — stop logging `Normalize: host port removed` when nothing is removed. vardo writes the bare user compose to disk and layers Traefik on top via an override; an override can't un-publish a port, so host ports were always kept and the strip was inert. Host ports stay (intended — direct LAN access like `10.0.0.19:11434`); the log is now honest. **Zero runtime change.**

## Tests

- 8 new unit tests for `detectActiveSlot` (symlink precedence, Docker fallback, drift, legacy file, probe errors, first deploy).
- `tsc` clean, lint clean (3 pre-existing warnings only).
- Full `tests/unit/lib/docker` suite green except 2 `self-register.test.ts` failures that **reproduce on `main`** (broken test mock, unrelated).

## Test plan

- [x] Unit: `detectActiveSlot` resolution order
- [x] Reproduced live: removing the orphaned slot + redeploy brought `ollama` back on blue with the host port kept
- [ ] After merge: redeploy vardo, then redeploy a host-port app and confirm clean cutover