### PR TITLE
feat(apps): deploy any public git repo by URL

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-detail.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-detail.tsx
@@ -20,6 +20,7 @@ import {
   EllipsisVertical,
   Cpu,
   Wrench,
+  GitBranch,
 } from "lucide-react";
 import { toast } from "@/lib/messenger";
 import { PageToolbar } from "@/components/page-toolbar";
@@ -467,8 +468,8 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
                   ) : (
                     <>
                       <DropdownMenuItem disabled={deploy.deploying} onClick={handleDeploy}>
-                        <Rocket className="mr-2 size-4" />
-                        Redeploy
+                        <GitBranch className="mr-2 size-4" />
+                        Pull latest & redeploy
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={handleRestart}>
                         <RotateCcw className="mr-2 size-4" />

--- a/app/(authenticated)/apps/new/new-app-flow.tsx
+++ b/app/(authenticated)/apps/new/new-app-flow.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   Globe2,
   RefreshCw,
+  ChevronDown,
 } from "lucide-react";
 import { toast } from "@/lib/messenger";
 import { PageToolbar } from "@/components/page-toolbar";
@@ -115,6 +116,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 
 const SOURCE_OPTIONS = [
   { id: "github", icon: Github, label: "GitHub", description: "From your connected account" },
+  { id: "public-git", icon: GitBranch, label: "Public Git URL", description: "Any public repo" },
   { id: "compose", icon: FileText, label: "Docker Compose", description: "Paste or from a repo" },
   { id: "image", icon: Container, label: "Image", description: "Any Docker image" },
 ] as const;
@@ -171,6 +173,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
   const [memoryLimit, setMemoryLimit] = useState("");
   const [diskWriteAlertThreshold, setDiskWriteAlertThreshold] = useState("");
   const [showComposeReview, setShowComposeReview] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Domain
   const [generateDomain, setGenerateDomain] = useState(true);
@@ -357,6 +360,10 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
       case "github":
         setSource("git"); setDeployType("compose"); setGitMode("github");
         break;
+      case "public-git":
+        setSource("git"); setDeployType("compose"); setGitMode("manual");
+        setGitUrl(""); setGitBranch("main"); setAdvancedOpen(false);
+        break;
       case "compose":
         setSource("direct"); setDeployType("compose"); setContentMode("paste");
         break;
@@ -443,6 +450,15 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
         body.composeFilePath = composeFilePath;
       }
       if (deployType === "dockerfile" && dockerfilePath && dockerfilePath !== "Dockerfile") {
+        body.dockerfilePath = dockerfilePath;
+      }
+      // Public Git URL uses compose auto-detect; still let the user pin a
+      // custom Dockerfile path for the Dockerfile fallback in the cascade.
+      if (
+        selectedSource === "public-git" &&
+        dockerfilePath &&
+        dockerfilePath !== "Dockerfile"
+      ) {
         body.dockerfilePath = dockerfilePath;
       }
       if (source === "direct" && deployType === "compose") {
@@ -809,6 +825,90 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
               </div>
             )}
 
+            {/* Public Git URL */}
+            {selectedSource === "public-git" && (
+              <div className="grid gap-4">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="grid gap-2 sm:col-span-2">
+                    <Label htmlFor="git-url">
+                      Git URL <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                      id="git-url"
+                      placeholder="https://github.com/user/repo.git"
+                      value={gitUrl}
+                      onChange={(e) => setGitUrl(e.target.value)}
+                      className={gitUrl && !gitUrl.startsWith("https://") ? "border-destructive" : ""}
+                      autoFocus
+                    />
+                    {gitUrl && !gitUrl.startsWith("https://") && (
+                      <p className="text-xs text-destructive">Must be an https:// URL</p>
+                    )}
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="git-branch">Branch</Label>
+                    <Input
+                      id="git-branch"
+                      placeholder="main"
+                      value={gitBranch}
+                      onChange={(e) => setGitBranch(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <p className="text-xs text-muted-foreground">
+                  Public repositories only — no connection needed. Private repos need a
+                  connected provider or deploy key.
+                </p>
+
+                <div className="grid gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setAdvancedOpen((v) => !v)}
+                    className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground w-fit"
+                  >
+                    <ChevronDown
+                      className={`size-4 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                    />
+                    Advanced
+                  </button>
+                  {advancedOpen && (
+                    <div className="grid gap-4 sm:grid-cols-3">
+                      <div className="grid gap-2">
+                        <Label htmlFor="adv-compose-file-path">Compose File</Label>
+                        <Input
+                          id="adv-compose-file-path"
+                          placeholder="docker-compose.yml"
+                          value={composeFilePath}
+                          onChange={(e) => setComposeFilePath(e.target.value)}
+                          className="font-mono text-sm"
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="adv-dockerfile-path">Dockerfile</Label>
+                        <Input
+                          id="adv-dockerfile-path"
+                          placeholder="Dockerfile"
+                          value={dockerfilePath}
+                          onChange={(e) => setDockerfilePath(e.target.value)}
+                          className="font-mono text-sm"
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <Label htmlFor="adv-root-dir">Root Directory</Label>
+                        <Input
+                          id="adv-root-dir"
+                          placeholder="./ (default)"
+                          value={rootDirectory}
+                          onChange={(e) => setRootDirectory(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
             {/* Compose */}
             {selectedSource === "compose" && (
               <div className="grid gap-3">
@@ -1073,7 +1173,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
                   handleSubmit();
                 }
               }}
-              disabled={creating || !displayName.trim() || !name.trim() || !parentId || hasRequiredEnvVars}
+              disabled={creating || !displayName.trim() || !name.trim() || !parentId || hasRequiredEnvVars || (selectedSource === "public-git" && !gitUrl.startsWith("https://"))}
             >
               {creating ? (
                 <><Loader2 className="mr-2 size-4 animate-spin" />Creating...</>

--- a/app/(authenticated)/apps/new/new-app-flow.tsx
+++ b/app/(authenticated)/apps/new/new-app-flow.tsx
@@ -363,6 +363,9 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
       case "public-git":
         setSource("git"); setDeployType("compose"); setGitMode("manual");
         setGitUrl(""); setGitBranch("main"); setAdvancedOpen(false);
+        // Clear shared path state so a stale value from a prior source isn't
+        // silently submitted when the Advanced panel is never opened.
+        setComposeFilePath("docker-compose.yml"); setDockerfilePath("Dockerfile"); setRootDirectory("");
         break;
       case "compose":
         setSource("direct"); setDeployType("compose"); setContentMode("paste");
@@ -441,24 +444,18 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
           return;
         }
       } else if (source === "git") {
-        body.gitUrl = gitUrl;
-        body.gitBranch = gitBranch;
+        body.gitUrl = gitUrl.trim();
+        body.gitBranch = gitBranch.trim();
       }
 
       if (deployType === "image") body.imageName = imageName;
-      if (deployType === "compose" && composeFilePath && composeFilePath !== "docker-compose.yml") {
+      // Send a custom compose / Dockerfile path whenever the user set one. The
+      // server defaults both, so this is safe for any source — and the
+      // public-git compose cascade can fall back to the pinned Dockerfile path.
+      if (composeFilePath && composeFilePath !== "docker-compose.yml") {
         body.composeFilePath = composeFilePath;
       }
-      if (deployType === "dockerfile" && dockerfilePath && dockerfilePath !== "Dockerfile") {
-        body.dockerfilePath = dockerfilePath;
-      }
-      // Public Git URL uses compose auto-detect; still let the user pin a
-      // custom Dockerfile path for the Dockerfile fallback in the cascade.
-      if (
-        selectedSource === "public-git" &&
-        dockerfilePath &&
-        dockerfilePath !== "Dockerfile"
-      ) {
+      if (dockerfilePath && dockerfilePath !== "Dockerfile") {
         body.dockerfilePath = dockerfilePath;
       }
       if (source === "direct" && deployType === "compose") {

--- a/lib/mcp/tools/create-app.ts
+++ b/lib/mcp/tools/create-app.ts
@@ -52,7 +52,10 @@ export function registerCreateApp(
         .default("main")
         .describe("Branch to deploy (default 'main')"),
       deployType: z
-        .enum(["compose", "dockerfile", "image", "static", "nixpacks", "railpack"])
+        // The tool always creates a git-sourced app, so only build-from-repo
+        // strategies are coherent. "image" is excluded — it needs an imageName
+        // (which this tool does not accept) and would ignore the git source.
+        .enum(["compose", "dockerfile", "static", "nixpacks", "railpack"])
         .default("compose")
         .describe(
           "Build/deploy strategy (default 'compose' = auto-detect compose → Dockerfile → Nixpacks)"

--- a/lib/mcp/tools/create-app.ts
+++ b/lib/mcp/tools/create-app.ts
@@ -19,7 +19,7 @@ export function registerCreateApp(
 ) {
   server.tool(
     "vardo_create_app",
-    "Create a new standalone compose app inside a project, deployed from a git repository. Creates the app record plus its default production environment and returns the new app id. Does NOT deploy — set env/volumes/domains as needed, then call vardo_deploy_app. Compose services are decomposed into child apps automatically on first deploy.",
+    "Create a new standalone app inside a project, deployed from a git repository. Works with any PUBLIC HTTPS git repo — no provider connection needed. Defaults to 'compose' deployType, which auto-detects a compose file, then a Dockerfile, then Nixpacks; pass a different deployType to pin the build. Creates the app record plus its default production environment and returns the new app id. Does NOT deploy — set env/volumes/domains as needed, then call vardo_deploy_app. Compose services are decomposed into child apps automatically on first deploy.",
     {
       projectId: z.string().min(1).describe("The project ID to create the app in"),
       name: z
@@ -51,6 +51,12 @@ export function registerCreateApp(
         .regex(/^[a-zA-Z0-9._\-/]+$/, "Invalid branch name")
         .default("main")
         .describe("Branch to deploy (default 'main')"),
+      deployType: z
+        .enum(["compose", "dockerfile", "image", "static", "nixpacks", "railpack"])
+        .default("compose")
+        .describe(
+          "Build/deploy strategy (default 'compose' = auto-detect compose → Dockerfile → Nixpacks)"
+        ),
       composeFilePath: z
         .string()
         .regex(/^[a-zA-Z0-9._-][a-zA-Z0-9._\-/]*$/, "Invalid file path")
@@ -72,6 +78,7 @@ export function registerCreateApp(
       description,
       gitUrl,
       gitBranch,
+      deployType,
       composeFilePath,
       rootDirectory,
       env,
@@ -161,7 +168,7 @@ export function registerCreateApp(
             displayName: displayName ?? name,
             description: description ?? null,
             source: "git",
-            deployType: "compose",
+            deployType,
             gitUrl,
             gitBranch,
             composeFilePath,

--- a/tests/unit/api/apps/public-git.test.ts
+++ b/tests/unit/api/apps/public-git.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Public Git URL apps — create schema validation
+// ---------------------------------------------------------------------------
+// A git-sourced app pointing at a PUBLIC repo needs only an HTTPS gitUrl —
+// there is no GitHub-connection / installation requirement in the create
+// schema. This mirrors the engine, which clones public repos without auth.
+//
+// Extracted from:
+//   app/api/v1/organizations/[orgId]/apps/route.ts  (create schema + refine)
+
+const createSchema = z
+  .object({
+    source: z.enum(["git", "direct"]),
+    deployType: z.enum([
+      "compose",
+      "dockerfile",
+      "image",
+      "static",
+      "nixpacks",
+      "railpack",
+    ]),
+    gitUrl: z
+      .string()
+      .url()
+      .refine((url) => url.startsWith("https://"), {
+        message: "Only HTTPS git URLs are allowed",
+      })
+      .optional(),
+    gitBranch: z
+      .string()
+      .regex(/^[a-zA-Z0-9._\-/]+$/, "Invalid branch name")
+      .optional(),
+    imageName: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.source === "git") return !!data.gitUrl;
+      if (data.deployType === "image") return !!data.imageName;
+      return true;
+    },
+    { message: "Required fields missing for the selected configuration" }
+  );
+
+describe("public git URL app creation", () => {
+  it("accepts source=git with a public gitUrl and no GitHub connection", () => {
+    const result = createSchema.safeParse({
+      source: "git",
+      deployType: "compose",
+      gitUrl: "https://github.com/vercel/next.js.git",
+      gitBranch: "main",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("does not require any connection/installation field", () => {
+    // The schema has no `installationId` or connection key — a bare public
+    // gitUrl is sufficient.
+    const result = createSchema.safeParse({
+      source: "git",
+      deployType: "compose",
+      gitUrl: "https://gitlab.com/some/public-repo.git",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects source=git without a gitUrl", () => {
+    const result = createSchema.safeParse({
+      source: "git",
+      deployType: "compose",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-HTTPS gitUrl", () => {
+    const result = createSchema.safeParse({
+      source: "git",
+      deployType: "compose",
+      gitUrl: "git@github.com:user/repo.git",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/lib/mcp/create-app-deploy-type.test.ts
+++ b/tests/unit/lib/mcp/create-app-deploy-type.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// vardo_create_app — deployType param
+// ---------------------------------------------------------------------------
+// The MCP create-app tool exposes an optional deployType that is passed
+// straight through to the app record instead of the old hardcoded "compose".
+// It must default to "compose" (auto-detect cascade) and honor a passed value.
+//
+// Extracted from:
+//   lib/mcp/tools/create-app.ts  (deployType zod param)
+
+const deployTypeSchema = z
+  .enum(["compose", "dockerfile", "image", "static", "nixpacks", "railpack"])
+  .default("compose");
+
+describe("create-app deployType param", () => {
+  it("defaults to compose when omitted", () => {
+    expect(deployTypeSchema.parse(undefined)).toBe("compose");
+  });
+
+  it("honors a passed deployType", () => {
+    expect(deployTypeSchema.parse("nixpacks")).toBe("nixpacks");
+    expect(deployTypeSchema.parse("dockerfile")).toBe("dockerfile");
+  });
+
+  it("rejects an unknown deployType", () => {
+    expect(deployTypeSchema.safeParse("bogus").success).toBe(false);
+  });
+});

--- a/tests/unit/lib/mcp/create-app-deploy-type.test.ts
+++ b/tests/unit/lib/mcp/create-app-deploy-type.test.ts
@@ -11,8 +11,11 @@ import { z } from "zod";
 // Extracted from:
 //   lib/mcp/tools/create-app.ts  (deployType zod param)
 
+// Note: "image" is intentionally NOT valid here — the tool only creates
+// git-sourced apps, and an image deploy needs an imageName the tool does not
+// accept. Keep this enum in sync with lib/mcp/tools/create-app.ts.
 const deployTypeSchema = z
-  .enum(["compose", "dockerfile", "image", "static", "nixpacks", "railpack"])
+  .enum(["compose", "dockerfile", "static", "nixpacks", "railpack"])
   .default("compose");
 
 describe("create-app deployType param", () => {
@@ -27,5 +30,9 @@ describe("create-app deployType param", () => {
 
   it("rejects an unknown deployType", () => {
     expect(deployTypeSchema.safeParse("bogus").success).toBe(false);
+  });
+
+  it("rejects 'image' — not coherent for a git-sourced app", () => {
+    expect(deployTypeSchema.safeParse("image").success).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #746.

First §4 backlog feature after stabilization. Paste a **public** HTTPS git repo → Vardo clones and deploys it, with no fork / GitHub App / OAuth. The engine already supported public clone + build, so this is mostly UI exposure plus light wiring.

## Changes

- **New "Public Git URL" source** in the new-app flow (`source=git`, `deployType=compose`, manual git mode). Required HTTPS URL with inline validation, branch (default `main`), public-only auth-boundary messaging, and an Advanced disclosure for compose path / Dockerfile path / root dir. No deploy-type picker — auto-detect only (compose → Dockerfile → Nixpacks).
- **"Pull latest & redeploy"** — relabels the existing git-source Redeploy action (it already re-clones branch HEAD, so this just makes it explicit). No backend change.
- **MCP `vardo_create_app`** gains an optional `deployType` param (default `compose`) so public Dockerfile/Nixpacks repos can be created via MCP, not only compose.

## Out of scope (v1)

Private repos by URL, push-webhook auto-deploy for URL apps, a standalone pull-latest button, dedicated GitLab/Gitea connectors (generic public clone already works).

## Test plan

- `pnpm typecheck` — clean.
- `pnpm exec vitest run` — 1096 passed (1089 baseline + 7 new: public-URL API path with no GitHub connection; MCP deployType default/honor/reject).
- eslint clean on changed files.
- **Owed at review/merge:** homelab deploy of a real public repo — one Dockerfile-only, one Nixpacks-only (no compose), one non-GitHub host — to prove the `compose` auto-detect cascade end-to-end.

Spec: `projects/vardo/specs/deploy-public-git-url-v1` on the knowledge server.