### PR TITLE
fix(deploy): queue deploy bursts instead of rejecting

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/deploy/route.ts
@@ -102,4 +102,9 @@ async function handler(request: NextRequest, { params }: { params: Promise<{ org
   }
 }
 
-export const POST = withRateLimit(handler, { tier: "critical", key: "deploy" });
+// Deploys use the higher-ceiling "mutation" tier rather than "critical".
+// A burst of rapid deploys must never be rejected: requestDeploy already
+// serializes them via per-app cancel-and-replace (latest commit wins) and the
+// system-level FIFO concurrency queue (#682). The limit here is only a coarse
+// abuse ceiling, not a per-deploy cooldown.
+export const POST = withRateLimit(handler, { tier: "mutation", key: "deploy" });

--- a/lib/mcp/tools/deploy-app.ts
+++ b/lib/mcp/tools/deploy-app.ts
@@ -7,10 +7,13 @@ import { createDeployment } from "@/lib/docker/deploy";
 import { slidingWindowRateLimit } from "@/lib/api/rate-limit";
 import type { McpAuthContext } from "../auth";
 
-// 5 deploys per 5 seconds per user/org pair.
-// Each deploy spins up containers — cap resource exhaustion.
-const DEPLOY_RATE_LIMIT = 5;
-const DEPLOY_RATE_WINDOW_MS = 5 * 1000;
+// Coarse abuse ceiling: 60 deploys per minute per user/org pair.
+// Bursts are never rejected as a cooldown — requestDeploy serializes rapid
+// deploys via per-app cancel-and-replace (latest commit wins) and the
+// system-level FIFO concurrency queue (#682). This limit only stops a runaway
+// loop from creating unbounded deployment records.
+const DEPLOY_RATE_LIMIT = 60;
+const DEPLOY_RATE_WINDOW_MS = 60 * 1000;
 
 export function registerDeployApp(
   server: McpServer,
@@ -39,7 +42,7 @@ export function registerDeployApp(
             {
               type: "text" as const,
               text: JSON.stringify({
-                error: `Rate limit exceeded. Try again in ${rl.retryAfterSeconds}s.`,
+                error: `Deploy rate ceiling reached (abuse protection, 60/min). Try again in ${rl.retryAfterSeconds}s.`,
               }),
             },
           ],


### PR DESCRIPTION
The front-door rate limiters rejected rapid deploys outright — HTTP `critical` tier (10/60s) returned 429, and the MCP `deploy_app` tool (5/5s) returned "Rate limit exceeded. Try again in Ns." Both short-circuit **before** the deploy reaches `requestDeploy`, which already handles bursts correctly:

- **per-app cancel-and-replace** — a new deploy supersedes the in-progress one (latest commit wins; rapid same-app fire is cheap), and
- **system-level FIFO concurrency queue** (#682) — bounds simultaneous deploys, others wait in order.

So the serialization already exists; the front-door cooldowns were redundant and hostile during iterative deploys.

## Changes

- **HTTP** `deploy/route.ts`: `critical` → `mutation` tier (10/60s → 60/60s). Left `critical` untouched — rollback, instant-rollback, and admin maintenance share it; this change is deploy-specific.
- **MCP** `deploy-app.ts`: 5/5s → 60/60s, softened error copy.

Both keep a coarse abuse ceiling (60/min) so a runaway loop can't create unbounded deployment records — just no per-deploy cooldown.

## Test plan

- `pnpm typecheck` clean; `pnpm exec vitest run` — 1089 passed (no tests asserted the old limits).
- Manual: rapid successive deploys now enqueue/supersede instead of 429-ing.