### PR TITLE
fix(deploy): skip pre-pull of locally-built images

### DIFF
--- a/lib/docker/deploy-context.ts
+++ b/lib/docker/deploy-context.ts
@@ -132,6 +132,14 @@ export type DeployContext = {
   /** Whether the image was built locally (Nixpacks/Railpack/Dockerfile). */
   builtLocally: boolean;
 
+  /**
+   * Image refs that were built locally this deploy (e.g. `host/<app>:<sha>`).
+   * These exist only in the local Docker daemon, never in a registry, so the
+   * swap pre-pull must skip them — otherwise `docker compose pull` 404s and
+   * aborts the deploy. Empty unless a Nixpacks/Railpack/Dockerfile build ran.
+   */
+  builtImageRefs: string[];
+
   /** host.toml config from repo root. */
   hostConfig: HostConfig | null;
 

--- a/lib/docker/deploy-steps/classify-services.ts
+++ b/lib/docker/deploy-steps/classify-services.ts
@@ -1,0 +1,30 @@
+import type { ComposeFile } from "../compose-types";
+
+/**
+ * Split compose services into those that build locally (have a `build:`
+ * directive) and those whose image must be pulled from a registry.
+ *
+ * Build and pull are complementary, not exclusive: a compose file can mix
+ * services that build locally (the user's own app) with services pulled from a
+ * registry (sidecars like postgres, traefik). Pull only the services that have
+ * no `build:` directive so we don't ask the registry for an image compose
+ * intends to build.
+ *
+ * `builtImageRefs` lists images this deploy built locally (e.g.
+ * `host/<app>:<sha>` from a Dockerfile/Nixpacks/Railpack build). They exist
+ * only in the local daemon, referenced via `image:` with no `build:`, so they
+ * must be excluded from the pull set — pulling them 404s and aborts the deploy.
+ */
+export function classifyComposeServices(
+  services: ComposeFile["services"],
+  builtImageRefs: string[] = [],
+): { buildServices: string[]; pullServices: string[] } {
+  const builtLocally = new Set(builtImageRefs);
+  const buildServices = Object.entries(services)
+    .filter(([, svc]) => svc.build)
+    .map(([name]) => name);
+  const pullServices = Object.entries(services)
+    .filter(([, svc]) => svc.image && !svc.build && !builtLocally.has(svc.image))
+    .map(([name]) => name);
+  return { buildServices, pullServices };
+}

--- a/lib/docker/deploy-steps/prepare-repo.ts
+++ b/lib/docker/deploy-steps/prepare-repo.ts
@@ -577,6 +577,10 @@ export async function prepareRepo(ctx: DeployContext): Promise<DeployContext> {
       }
 
       ctx.builtLocally = true;
+      // Record the locally-built image so the swap pre-pull skips it — it lives
+      // only in the local daemon (no registry), and the generated compose
+      // references it via `image:` with no `build:` directive.
+      ctx.builtImageRefs.push(imageName);
       compose = generateComposeForImage({
         projectName: app.name,
         imageName,

--- a/lib/docker/deploy-steps/swap.ts
+++ b/lib/docker/deploy-steps/swap.ts
@@ -25,6 +25,7 @@ import {
   HTTP_PROBE_TIMEOUT,
 } from "../constants";
 import type { DeployContext } from "../deploy-context";
+import { classifyComposeServices } from "./classify-services";
 
 const execFileAsync = promisify(execFile);
 const NETWORK_NAME = VARDO_NETWORK;
@@ -171,15 +172,13 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
   //
   // Build and pull are complementary, not exclusive: a compose file can mix
   // services that build locally (the user's own app) with services that pull
-  // from a registry (sidecars like go2rtc, traefik, postgres). Run both
-  // phases — pull only the services that don't have a build directive so we
-  // don't ask the registry for an image that compose intends to build.
-  const buildServices = Object.entries(compose.services)
-    .filter(([, svc]) => svc.build)
-    .map(([name]) => name);
-  const pullServices = Object.entries(compose.services)
-    .filter(([, svc]) => svc.image && !svc.build)
-    .map(([name]) => name);
+  // from a registry (sidecars like go2rtc, traefik, postgres). Run both phases.
+  // Images this deploy built locally (ctx.builtImageRefs) are excluded from the
+  // pull set — they live only in the local daemon, so pulling them 404s.
+  const { buildServices, pullServices } = classifyComposeServices(
+    compose.services,
+    ctx.builtImageRefs,
+  );
   try {
     if (buildServices.length > 0) {
       log(`[deploy] Pre-building ${newSlot} slot images (old slot still serving)...`);

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -306,6 +306,7 @@ export async function runDeployment(
       bareCompose: { services: {} },
       serviceConfig: {},
       builtLocally: false,
+      builtImageRefs: [],
       hostConfig: null,
       repoDir: null,
 

--- a/tests/unit/lib/docker/deploy-steps/classify-services.test.ts
+++ b/tests/unit/lib/docker/deploy-steps/classify-services.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { classifyComposeServices } from "@/lib/docker/deploy-steps/classify-services";
+import type { ComposeFile } from "@/lib/docker/compose-types";
+
+// ---------------------------------------------------------------------------
+// classifyComposeServices — swap build/pull split
+// ---------------------------------------------------------------------------
+// Regression for the bug where a Dockerfile/Nixpacks-only repo (deployType
+// "compose" with no compose file) was pre-built into host/<app>:<sha> and
+// referenced via image: with no build: directive. The swap pre-pull then tried
+// to `docker compose pull` the locally-built image and 404'd.
+
+function services(map: Record<string, { image?: string; build?: unknown }>): ComposeFile["services"] {
+  return map as unknown as ComposeFile["services"];
+}
+
+describe("classifyComposeServices", () => {
+  it("pulls a registry image with no build directive", () => {
+    const { buildServices, pullServices } = classifyComposeServices(
+      services({ db: { image: "postgres:16" } }),
+    );
+    expect(buildServices).toEqual([]);
+    expect(pullServices).toEqual(["db"]);
+  });
+
+  it("builds a service with a build directive (never pulls it)", () => {
+    const { buildServices, pullServices } = classifyComposeServices(
+      services({ app: { build: { context: "." }, image: "host/app:abc" } }),
+    );
+    expect(buildServices).toEqual(["app"]);
+    expect(pullServices).toEqual([]);
+  });
+
+  it("excludes a locally-built image from the pull set", () => {
+    const built = "host/app:abc1234";
+    const { buildServices, pullServices } = classifyComposeServices(
+      services({ app: { image: built } }),
+      [built],
+    );
+    // No build: directive, but it was built locally — so neither build nor pull.
+    expect(buildServices).toEqual([]);
+    expect(pullServices).toEqual([]);
+  });
+
+  it("pulls registry sidecars while skipping the locally-built app image", () => {
+    const built = "host/app:abc1234";
+    const { buildServices, pullServices } = classifyComposeServices(
+      services({
+        app: { image: built },
+        db: { image: "postgres:16" },
+        cache: { image: "redis:7" },
+      }),
+      [built],
+    );
+    expect(buildServices).toEqual([]);
+    expect(pullServices).toEqual(["db", "cache"]);
+  });
+
+  it("still pulls a registry image even if an unrelated ref was built locally", () => {
+    const { pullServices } = classifyComposeServices(
+      services({ db: { image: "postgres:16" } }),
+      ["host/other-app:deadbeef"],
+    );
+    expect(pullServices).toEqual(["db"]);
+  });
+});


### PR DESCRIPTION
Closes #750. Found while homelab-verifying #748 (deploy-public-git-url).

## Problem

A `deployType=compose` app whose repo has **no compose file** falls back to a Dockerfile/Nixpacks/Railpack build. The image is pre-built locally and the generated slot compose references it via `image: host/<app>:<sha>` with **no `build:` directive**. The swap pre-pull step then classified it as a registry image and ran `docker compose pull`, which 404s for a local-only tag and aborted the deploy at cutover:

```
[deploy] No compose file, found Dockerfile
[build] Docker build complete: host/pubgit-smoke:FMgyFLWa
[deploy] Pre-pulling blue slot images ...
[deploy] ERROR: ... pull access denied for host/pubgit-smoke, repository does not exist
```

## Fix

- Record locally-built image refs on the deploy context (`ctx.builtImageRefs`), set in `prepare-repo` when a build runs.
- Exclude them from the swap pre-pull set. `up --pull never` (swap.ts) already runs the local image correctly — only the pre-pull optimization was wrong.
- Build-type agnostic: fixes Dockerfile, Nixpacks, and Railpack alike (Nixpacks has no Dockerfile, so a `build:` directive couldn't express it — this is why the fix is on the pull side, not the compose-generation side).
- Extracted the build/pull split into a pure, unit-tested `classifyComposeServices` helper.

## Safety

For every existing deploy `builtImageRefs` is empty, so the classification is **byte-identical** to the old inline filter — a no-op except on the exact broken cascade path.

## Test plan

- `pnpm typecheck` clean; `pnpm exec vitest run` — 1102 passed (1097 + 5 new in `classify-services.test.ts`: registry pull, build directive, locally-built exclusion, mixed sidecars, unrelated built ref).
- **Owed:** homelab re-deploy of the same public Dockerfile repo (+ a Nixpacks repo) to confirm cutover now succeeds.