### PR TITLE
fix(cron): match schedules at minute granularity

### DIFF
--- a/lib/cron/parse.ts
+++ b/lib/cron/parse.ts
@@ -20,7 +20,16 @@ export function shouldRunNow(schedule: string, now: Date): boolean {
   if (!schedule.trim()) return false;
   try {
     const job = new Cron(schedule.trim());
-    return job.match(now);
+    // Match at minute granularity. The schedulers tick on a 60s interval at an
+    // arbitrary sub-minute offset (whatever second the process booted on),
+    // while croner's match() is second-precise — a 5-field cron matches only at
+    // :00. Without truncating, a job fires only if a tick happens to land on
+    // second 0 of its minute, which it essentially never does, so jobs silently
+    // never run. Zero the seconds so any tick within the scheduled minute
+    // matches; the schedulers' per-minute locks prevent double-firing.
+    const atMinute = new Date(now);
+    atMinute.setSeconds(0, 0);
+    return job.match(atMinute);
   } catch {
     return false;
   }

--- a/tests/unit/lib/cron/parse.test.ts
+++ b/tests/unit/lib/cron/parse.test.ts
@@ -13,6 +13,21 @@ describe("shouldRunNow", () => {
     expect(shouldRunNow("31 14 * * *", now)).toBe(false);
   });
 
+  // Regression: the schedulers tick every 60s at an arbitrary sub-minute offset,
+  // so `now` is almost never at second 0. croner's match() is second-precise, so
+  // without minute-granularity matching, jobs silently never fired (homelab
+  // backups + crons stalled for 2 months). A tick anywhere within the scheduled
+  // minute must fire the job.
+  it("matches anywhere within the scheduled minute, not just at :00", () => {
+    for (const sec of [0, 1, 15, 30, 45, 59]) {
+      const now = new Date(2026, 2, 21, 4, 42, sec);
+      expect(shouldRunNow("42 4 * * *", now)).toBe(true);
+    }
+    // ...but still not the wrong minute
+    expect(shouldRunNow("42 4 * * *", new Date(2026, 2, 21, 4, 43, 0))).toBe(false);
+    expect(shouldRunNow("42 4 * * *", new Date(2026, 2, 21, 4, 41, 59))).toBe(false);
+  });
+
   it("matches day of week (Saturday = 6)", () => {
     const sat = new Date(2026, 2, 21, 0, 0, 0); // March 21, 2026 is Saturday
     expect(shouldRunNow("0 0 * * 6", sat)).toBe(true);


### PR DESCRIPTION
Closes 752. 

## Problem

`shouldRunNow` matched via croner's second-precise `match()` — a 5-field cron matches only at `:00`. Schedulers tick every 60s at an arbitrary sub-minute offset, so jobs fired only if a tick landed exactly on second 0, which it essentially never does. **All scheduled backups and cron jobs silently never ran** (homelab backups frozen ~2 months, 0 stored — found while prepping the #742 restore-test).

## Fix

Truncate `now` to the start of the minute before `match()`. Any tick within the scheduled minute now fires the job; the schedulers' per-minute Redis locks already prevent double-firing. Fixes both consumers (cron engine + backup tick).

## Test plan

- `pnpm typecheck` clean; `pnpm exec vitest run` — 1103 passed. New regression case asserts a job matches at `:01/:15/:30/:45/:59` (not just `:00`) — the condition the old tests never covered.
- **Owed:** deploy to homelab, confirm the stalled jobs fire and a backup actually lands, then the real restore-test (#742).