### PR TITLE
fix(backups): stage archives under VARDO_HOME_DIR, not /app

### DIFF
--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -21,7 +21,19 @@ const log = logger.child("backup");
 
 const execFileAsync = promisify(execFile);
 
-const BACKUPS_DIR = resolve(process.env.VARDO_BACKUPS_DIR || "./.host/backups");
+// Local staging dir for backup archives before upload. Must be writable by the
+// app user AND host-visible: the engine bind-mounts it into a one-shot `alpine`
+// container via `docker run -v`, so a path that only exists inside this
+// container (e.g. cwd /app) can't be mounted. In production the app runs as a
+// non-root user and /app is not writable, so default under VARDO_HOME_DIR — the
+// app-owned data dir that is bind-mounted at the same path on the host. Falls
+// back to ./.host/backups for local dev (where VARDO_HOME_DIR is unset).
+const BACKUPS_DIR = resolve(
+  process.env.VARDO_BACKUPS_DIR ||
+    (process.env.VARDO_HOME_DIR
+      ? join(process.env.VARDO_HOME_DIR, "backups-staging")
+      : "./.host/backups"),
+);
 
 // ---------------------------------------------------------------------------
 // Types


### PR DESCRIPTION
Closes 754.

## Problem
Backup staging defaulted to `./.host/backups` → `/app/.host` in the container. The app runs as uid 1001 and `/app` is root-owned → `mkdir` EACCES, so **backups never succeed** in the containerized deploy. The path also must be host-visible (the engine bind-mounts it into an `alpine` container via `docker run -v`).

## Fix
Default the staging dir under `VARDO_HOME_DIR` (the app-owned data dir already bind-mounted at the same path on the host) when `VARDO_BACKUPS_DIR` is unset. No installer/.env change; fixes every existing install on next deploy. Dev still falls back to `./.host/backups`.

## Test plan
- typecheck clean; vitest 1103.
- **Owed (homelab):** trigger a real backup → confirm it lands in R2 → restore-test (#742). Found while verifying #753.