### PR TITLE
fix(backups): resolve env-scoped persistent volumes (#756)

### DIFF
--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -15,6 +15,8 @@ import { resolve, join } from "path";
 import type { BackupStorage } from "./storage-port";
 import { createBackupStorage } from "./storage-factory";
 import { assertSafeName } from "@/lib/docker/validate";
+import { listContainers, inspectContainer } from "@/lib/docker/client";
+import { resolveDefaultEnv } from "@/lib/docker/resolve-env";
 import { logger } from "@/lib/logger";
 
 const log = logger.child("backup");
@@ -53,6 +55,7 @@ export type BackupResult = {
 type VolumeToBackup = {
   id: string;
   name: string;
+  mountPath: string | null;
   appId: string | null;
   appName: string | null;
   orgSlug: string | null;
@@ -198,31 +201,71 @@ async function backupVolumeDump(
 }
 
 /**
- * Resolve the Docker volume name for a tar backup (blue/green slot pattern).
- * Returns null if neither slot exists.
+ * Resolve the real Docker volume name backing an app's volume.
+ *
+ * Persistent volumes are **env-scoped** (`${app}-${env}_${vol}`) and declared
+ * `external: true` so they're shared across blue/green slots and survive swaps —
+ * they are NOT slot-scoped. Resolution order (#756):
+ *   1. **Inspect the app's running container(s)** and return the volume actually
+ *      mounted at `mountPath`. Authoritative and naming-agnostic — backs up the
+ *      volume Docker is really using, not a guessed name.
+ *   2. **Derive the env-scoped name** `${app}-${env}_${vol}` (default env
+ *      "production") and confirm it exists — covers a stopped app / fresh
+ *      restore where there's no container to inspect.
+ *   3. **Legacy slot names** `${app}-blue_${vol}` / `${app}-green_${vol}`.
+ * Returns null if none resolve.
  */
-async function resolveDockerVolume(
+export async function resolveDockerVolume(
+  appId: string | null,
   appName: string,
   volumeName: string,
+  mountPath: string | null,
   logFn: (msg: string) => void,
 ): Promise<string | null> {
   assertSafeName(appName);
   assertSafeName(volumeName);
-  const blueVolume = `${appName}-blue_${volumeName}`;
-  const greenVolume = `${appName}-green_${volumeName}`;
 
-  try {
-    await execFileAsync("docker", ["volume", "inspect", blueVolume], { timeout: 10_000 });
-    return blueVolume;
-  } catch {
+  // 1. Authoritative: the volume Docker actually has mounted at mountPath.
+  if (mountPath) {
     try {
-      await execFileAsync("docker", ["volume", "inspect", greenVolume], { timeout: 10_000 });
-      return greenVolume;
-    } catch {
-      logFn(`No Docker volume found for ${volumeName} (tried ${blueVolume}, ${greenVolume})`);
-      return null;
+      const containers = await listContainers(appName);
+      for (const c of containers) {
+        const info = await inspectContainer(c.id);
+        const mount = info.mounts.find(
+          (m) => m.type === "volume" && m.destination === mountPath && m.name,
+        );
+        if (mount) {
+          logFn(`Resolved ${volumeName} → ${mount.name} (running container mount at ${mountPath})`);
+          return mount.name;
+        }
+      }
+    } catch (err) {
+      logFn(
+        `Container inspect for ${appName} failed, falling back to name derivation: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
+
+  // 2 + 3. Name-derived candidates, env-scoped first, slot names last.
+  const candidates: string[] = [];
+  if (appId) {
+    const env = await resolveDefaultEnv(appId);
+    candidates.push(`${appName}-${env.name}_${volumeName}`);
+  }
+  candidates.push(`${appName}-blue_${volumeName}`, `${appName}-green_${volumeName}`);
+
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync("docker", ["volume", "inspect", candidate], { timeout: 10_000 });
+      logFn(`Resolved ${volumeName} → ${candidate}`);
+      return candidate;
+    } catch {
+      // not this one
+    }
+  }
+
+  logFn(`No Docker volume found for ${volumeName} (tried ${candidates.join(", ")})`);
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +337,7 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
       volumesToBackup.push({
         id: vol.id,
         name: vol.name,
+        mountPath: vol.mountPath,
         appId: app.id,
         appName: app.name,
         orgSlug,
@@ -309,6 +353,7 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
     volumesToBackup.push({
       id: vol.id,
       name: vol.name,
+      mountPath: vol.mountPath,
       appId: vol.appId,
       appName: null,
       orgSlug: null,
@@ -369,7 +414,7 @@ export async function runBackup(jobId: string): Promise<BackupResult[]> {
         if (!vol.appName) {
           throw new Error(`Tar backup requires an app name (volume: ${vol.name})`);
         }
-        const dockerVolumeName = await resolveDockerVolume(vol.appName, vol.name, log);
+        const dockerVolumeName = await resolveDockerVolume(vol.appId, vol.appName, vol.name, vol.mountPath, log);
         if (!dockerVolumeName) {
           throw new Error(`Volume not found: ${vol.name}`);
         }
@@ -729,27 +774,28 @@ export async function restoreBackup(
       );
     } else {
       // tar restore — need app context for volume name resolution
-      if (!backup.app) {
+      if (!backup.app || !backup.appId) {
         throw new Error("Tar restore requires an app context");
       }
       assertSafeName(backup.app.name);
       assertSafeName(backup.volumeName);
-      const blueVolume = `${backup.app.name}-blue_${backup.volumeName}`;
-      const greenVolume = `${backup.app.name}-green_${backup.volumeName}`;
 
-      let dockerVolumeName: string;
-      try {
-        await execFileAsync("docker", ["volume", "inspect", blueVolume], { timeout: 10_000 });
-        dockerVolumeName = blueVolume;
-      } catch {
-        try {
-          await execFileAsync("docker", ["volume", "inspect", greenVolume], { timeout: 10_000 });
-          dockerVolumeName = greenVolume;
-        } catch {
-          log(`Creating volume ${blueVolume}`);
-          await execFileAsync("docker", ["volume", "create", blueVolume], { timeout: 10_000 });
-          dockerVolumeName = blueVolume;
-        }
+      let dockerVolumeName = await resolveDockerVolume(
+        backup.appId,
+        backup.app.name,
+        backup.volumeName,
+        vol?.mountPath ?? null,
+        log,
+      );
+      if (!dockerVolumeName) {
+        // Nothing exists yet (restoring into a fresh app) — create the canonical
+        // env-scoped volume so the running app actually reads the restored data.
+        // (NOT a blue/green slot name, which the app would never mount — #756.)
+        const env = await resolveDefaultEnv(backup.appId);
+        dockerVolumeName = `${backup.app.name}-${env.name}_${backup.volumeName}`;
+        assertSafeName(dockerVolumeName);
+        log(`Creating volume ${dockerVolumeName}`);
+        await execFileAsync("docker", ["volume", "create", dockerVolumeName], { timeout: 10_000 });
       }
 
       log(`Restoring to volume ${dockerVolumeName}`);

--- a/tests/unit/lib/backups/restore.test.ts
+++ b/tests/unit/lib/backups/restore.test.ts
@@ -26,6 +26,9 @@ const {
   volumesFindFirst,
   execFileMock,
   executeHooksMock,
+  listContainersMock,
+  inspectContainerMock,
+  resolveDefaultEnvMock,
 } = vi.hoisted(() => ({
   backupsFindFirst: vi.fn(),
   volumesFindFirst: vi.fn(),
@@ -35,13 +38,28 @@ const {
     if (typeof cb === "function") (cb as (e: unknown, r: unknown) => void)(null, { stdout: "", stderr: "" });
   }),
   executeHooksMock: vi.fn().mockResolvedValue({ allowed: true, results: [] }),
+  listContainersMock: vi.fn(),
+  inspectContainerMock: vi.fn(),
+  resolveDefaultEnvMock: vi.fn(),
 }));
+
+// Default execFile impl: every docker/bash call succeeds. Re-applied in
+// beforeEach so a per-test override (e.g. failing `volume inspect`) can't leak.
+const execSuccess = (...args: unknown[]) => {
+  const cb = args[args.length - 1];
+  if (typeof cb === "function") (cb as (e: unknown, r: unknown) => void)(null, { stdout: "", stderr: "" });
+};
 
 vi.mock("@/lib/db", () => ({
   db: { query: { backups: { findFirst: backupsFindFirst }, volumes: { findFirst: volumesFindFirst } } },
 }));
 vi.mock("child_process", () => ({ execFile: execFileMock }));
 vi.mock("@/lib/hooks/execute", () => ({ executeHooks: executeHooksMock }));
+vi.mock("@/lib/docker/client", () => ({
+  listContainers: listContainersMock,
+  inspectContainer: inspectContainerMock,
+}));
+vi.mock("@/lib/docker/resolve-env", () => ({ resolveDefaultEnv: resolveDefaultEnvMock }));
 vi.mock("@/lib/logger", () => ({
   logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
 }));
@@ -90,10 +108,15 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  execFileMock.mockClear();
+  execFileMock.mockReset();
+  execFileMock.mockImplementation(execSuccess);
   backupsFindFirst.mockReset();
   volumesFindFirst.mockReset();
   executeHooksMock.mockResolvedValue({ allowed: true, results: [] });
+  // Default: no running container (resolver falls through to name derivation).
+  listContainersMock.mockReset().mockResolvedValue([]);
+  inspectContainerMock.mockReset().mockResolvedValue({ mounts: [] });
+  resolveDefaultEnvMock.mockReset().mockResolvedValue({ name: "production", type: "production", id: "env-1" });
 });
 
 describe("restoreBackup — volume (tar) round-trip", () => {
@@ -151,5 +174,81 @@ describe("restoreBackup — corrupted/mismatched archive is rejected", () => {
 
     await expect(restoreBackup("bk-1")).rejects.toThrow(/blocked by hook/i);
     expect(restoreCommandRan()).toBe(false);
+  });
+});
+
+// #756: persistent volumes are env-scoped (`${app}-${env}_${vol}`), shared
+// across blue/green slots. The resolver must target the volume the app actually
+// uses — never a blue/green slot name the app would never mount.
+describe("#756 — volume resolution targets the real env-scoped volume", () => {
+  /** All docker volume args across every execFile call, flattened. */
+  function allDockerArgs(): string[] {
+    return execFileMock.mock.calls
+      .filter(([file]) => file === "docker")
+      .map(([, args]) => (args as string[]).join(" "));
+  }
+
+  it("restores into the volume Docker actually has mounted (env-scoped), not a slot name", async () => {
+    backupsFindFirst.mockResolvedValue(backupRow({ appId: "app-1", volumeName: "data" }));
+    volumesFindFirst.mockResolvedValue({ backupStrategy: "tar", backupMeta: null, mountPath: "/app/data" });
+    listContainersMock.mockResolvedValue([{ id: "c1" }]);
+    inspectContainerMock.mockResolvedValue({
+      mounts: [{ type: "volume", name: "myapp-production_data", destination: "/app/data", source: "" }],
+    });
+
+    const result = await restoreBackup("bk-1");
+
+    expect(result.success).toBe(true);
+    const runCall = execFileMock.mock.calls.find(
+      ([file, args]) => file === "docker" && (args as string[]).includes("run"),
+    );
+    expect((runCall![1] as string[]).join(" ")).toContain("myapp-production_data:/data");
+    // The data-integrity guarantee: never touch a blue/green slot volume.
+    expect(allDockerArgs().some((a) => /-blue_|-green_/.test(a))).toBe(false);
+  });
+
+  it("ignores a container mount at a different path", async () => {
+    backupsFindFirst.mockResolvedValue(backupRow({ appId: "app-1", volumeName: "data" }));
+    volumesFindFirst.mockResolvedValue({ backupStrategy: "tar", backupMeta: null, mountPath: "/app/data" });
+    listContainersMock.mockResolvedValue([{ id: "c1" }]);
+    inspectContainerMock.mockResolvedValue({
+      mounts: [{ type: "volume", name: "myapp-production_cache", destination: "/app/cache", source: "" }],
+    });
+
+    const result = await restoreBackup("bk-1");
+
+    expect(result.success).toBe(true);
+    // No mount matched /app/data → derives env-scoped name, which inspect confirms.
+    const runCall = execFileMock.mock.calls.find(
+      ([file, args]) => file === "docker" && (args as string[]).includes("run"),
+    );
+    expect((runCall![1] as string[]).join(" ")).toContain("myapp-production_data:/data");
+    expect((runCall![1] as string[]).join(" ")).not.toContain("myapp-production_cache");
+  });
+
+  it("creates the env-scoped volume (never a blue slot) when nothing exists yet", async () => {
+    backupsFindFirst.mockResolvedValue(backupRow({ appId: "app-1", volumeName: "data" }));
+    volumesFindFirst.mockResolvedValue({ backupStrategy: "tar", backupMeta: null, mountPath: "/app/data" });
+    listContainersMock.mockResolvedValue([]); // no running container
+    // Every `docker volume inspect` fails → resolver finds nothing → create path.
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, r: unknown) => void;
+      const dockerArgs = args[1] as string[];
+      if (Array.isArray(dockerArgs) && dockerArgs.includes("inspect")) {
+        cb(new Error("no such volume"), null);
+        return;
+      }
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    const result = await restoreBackup("bk-1");
+
+    expect(result.success).toBe(true);
+    const dockerArgs = allDockerArgs();
+    expect(dockerArgs.some((a) => a.includes("volume create myapp-production_data"))).toBe(true);
+    // It may *probe* slot names (read-only inspect), but must never create or
+    // restore into one — that's the data-integrity guarantee.
+    const mutating = dockerArgs.filter((a) => a.includes("volume create") || a.includes("run"));
+    expect(mutating.some((a) => /-blue_|-green_/.test(a))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Third and final stacked bug in the backup subsystem (after #753 scheduler and #755 staging dir). `resolveDockerVolume` only tried slot-scoped names `${app}-blue_${vol}` / `${app}-green_${vol}`, but **persistent volumes are env-scoped** (`${app}-${env}_${vol}`, e.g. `uptime-kuma-production_data`) so they're shared across blue/green and survive swaps. The resolver never found them → every persistent-volume backup failed with "Volume not found", and no backup has ever landed in this deployment.

## Fix

One shared resolver, used by both the backup and restore paths, resolves in order:

1. **Inspect the app's running container** and return the volume actually mounted at the volume's `mount_path` — authoritative and naming-agnostic (reuses `listContainers` + `inspectContainer`).
2. **Derive the env-scoped name** `${app}-${env}_${vol}` (default env `production`) and confirm it exists — covers a stopped app / fresh restore.
3. **Legacy blue/green slot names** as last resort.

The restore path was the more dangerous half: on a miss it *created* `${app}-blue_${vol}` and restored into it — a volume the running app never mounts, silently dropping recovered data. It now creates the canonical env-scoped volume.

## Test plan

- New #756 coverage in `restore.test.ts`: restores into the container's actual env-scoped mount (not a slot name); ignores mounts at other paths; creates the env-scoped volume (never blue/green) when nothing exists.
- Full vitest suite green (1106 tests), typecheck clean, eslint clean on touched files.
- Homelab end-to-end verification (real backup → R2, then restore-test) to follow on `main`.