### PR TITLE
fix(backups): create auto-backup job + link atomically (#757)

### DIFF
--- a/lib/backups/auto-backup.ts
+++ b/lib/backups/auto-backup.ts
@@ -157,29 +157,31 @@ export async function ensureSystemBackupJob(targetId: string) {
     });
   }
 
-  // Create the backup job
+  // Create the backup job and link its volume atomically (see the orphan-job
+  // note in ensureAutoBackupJob — same partial-insert hazard, #757).
   const jobId = nanoid();
-  const [job] = await db
-    .insert(backupJobs)
-    .values({
-      id: jobId,
-      organizationId: null, // system-level, not org-scoped
-      targetId,
-      name: "Vardo database",
-      schedule: staggeredSchedule("vardo-system-db"),
-      enabled: true,
-      keepLast: 2,
-      keepDaily: 7,
-      keepWeekly: 4,
-      keepMonthly: 3,
-      notifyOnFailure: true,
-    })
-    .returning();
-
-  // Link the volume to the job
-  await db.insert(backupJobVolumes).values({
-    backupJobId: jobId,
-    volumeId,
+  const job = await db.transaction(async (tx) => {
+    const [created] = await tx
+      .insert(backupJobs)
+      .values({
+        id: jobId,
+        organizationId: null, // system-level, not org-scoped
+        targetId,
+        name: "Vardo database",
+        schedule: staggeredSchedule("vardo-system-db"),
+        enabled: true,
+        keepLast: 2,
+        keepDaily: 7,
+        keepWeekly: 4,
+        keepMonthly: 3,
+        notifyOnFailure: true,
+      })
+      .returning();
+    await tx.insert(backupJobVolumes).values({
+      backupJobId: jobId,
+      volumeId,
+    });
+    return created;
   });
 
   log.info("Created system backup job for Vardo database");
@@ -278,26 +280,29 @@ export async function ensureAutoBackupJob(opts: {
     return null;
   }
 
-  // Create a daily backup job with staggered schedule
+  // Create a daily backup job with staggered schedule, linking the app
+  // atomically. A partial insert (job row without its app link) would create an
+  // orphan job the dedup-by-app-link guard above can't see, so the next deploy
+  // would create yet another — the source of the duplicate "Auto:" jobs (#757).
   const jobId = nanoid();
-  await db.insert(backupJobs).values({
-    id: jobId,
-    organizationId,
-    targetId: target.id,
-    name: `Auto: ${appName}`,
-    schedule: staggeredSchedule(appId),
-    enabled: true,
-    keepLast: 1,
-    keepDaily: 7,
-    keepWeekly: 1,
-    keepMonthly: 1,
-    notifyOnFailure: true,
-  });
-
-  // Link the app to the job
-  await db.insert(backupJobApps).values({
-    backupJobId: jobId,
-    appId,
+  await db.transaction(async (tx) => {
+    await tx.insert(backupJobs).values({
+      id: jobId,
+      organizationId,
+      targetId: target.id,
+      name: `Auto: ${appName}`,
+      schedule: staggeredSchedule(appId),
+      enabled: true,
+      keepLast: 1,
+      keepDaily: 7,
+      keepWeekly: 1,
+      keepMonthly: 1,
+      notifyOnFailure: true,
+    });
+    await tx.insert(backupJobApps).values({
+      backupJobId: jobId,
+      appId,
+    });
   });
 
   return jobId;

--- a/tests/unit/lib/backups/auto-backup.test.ts
+++ b/tests/unit/lib/backups/auto-backup.test.ts
@@ -1,0 +1,106 @@
+// #757: duplicate "Auto:" backup jobs came from ensureAutoBackupJob inserting
+// the job row and its app link non-transactionally — a failed link insert left
+// an orphan job the dedup-by-app-link guard couldn't see, so the next deploy
+// made another. These tests pin the fix: job + link are created inside one
+// transaction (a link failure aborts the whole thing), the dedup guard skips
+// apps already covered, and apps without persistent volumes are skipped.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  volumesFindMany,
+  backupJobAppsFindFirst,
+  backupTargetsFindFirst,
+  transactionMock,
+  state,
+} = vi.hoisted(() => ({
+  volumesFindMany: vi.fn(),
+  backupJobAppsFindFirst: vi.fn(),
+  backupTargetsFindFirst: vi.fn(),
+  transactionMock: vi.fn(),
+  state: { inserted: [] as string[], failLinkInsert: false },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      volumes: { findMany: volumesFindMany },
+      backupJobApps: { findFirst: backupJobAppsFindFirst },
+      backupTargets: { findFirst: backupTargetsFindFirst },
+    },
+    transaction: transactionMock,
+  },
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
+}));
+vi.mock("@/lib/system-settings", () => ({ getBackupStorageConfig: vi.fn() }));
+
+import { backupJobs, backupJobApps } from "@/lib/db/schema";
+import { ensureAutoBackupJob } from "@/lib/backups/auto-backup";
+
+beforeEach(() => {
+  state.inserted = [];
+  state.failLinkInsert = false;
+  volumesFindMany.mockReset();
+  backupJobAppsFindFirst.mockReset();
+  backupTargetsFindFirst.mockReset().mockResolvedValue({ id: "tgt-1", organizationId: "o1" });
+  transactionMock.mockReset().mockImplementation(async (cb: (tx: unknown) => unknown) => {
+    const tx = {
+      insert: (table: unknown) => ({
+        values: async () => {
+          const name =
+            table === backupJobApps ? "backupJobApps" : table === backupJobs ? "backupJobs" : "other";
+          if (name === "backupJobApps" && state.failLinkInsert) throw new Error("link insert failed");
+          state.inserted.push(name);
+        },
+      }),
+    };
+    return cb(tx);
+  });
+});
+
+describe("ensureAutoBackupJob — atomic job+link creation (#757)", () => {
+  it("creates the job and its app link inside a single transaction", async () => {
+    volumesFindMany.mockResolvedValue([{ persistent: true }]);
+    backupJobAppsFindFirst.mockResolvedValue(undefined); // not yet covered
+
+    const jobId = await ensureAutoBackupJob({ appId: "a1", appName: "myapp", organizationId: "o1" });
+
+    expect(typeof jobId).toBe("string");
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(state.inserted).toEqual(["backupJobs", "backupJobApps"]);
+  });
+
+  it("rolls back (rejects) if the app-link insert fails — no orphan job", async () => {
+    volumesFindMany.mockResolvedValue([{ persistent: true }]);
+    backupJobAppsFindFirst.mockResolvedValue(undefined);
+    state.failLinkInsert = true;
+
+    await expect(
+      ensureAutoBackupJob({ appId: "a1", appName: "myapp", organizationId: "o1" }),
+    ).rejects.toThrow(/link insert failed/);
+    // The whole unit of work is the transaction callback; a real DB rolls back
+    // the job row when the link throws, so no orphan survives.
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips apps already covered by a backup job (dedup guard)", async () => {
+    volumesFindMany.mockResolvedValue([{ persistent: true }]);
+    backupJobAppsFindFirst.mockResolvedValue({ backupJobId: "existing" });
+
+    const result = await ensureAutoBackupJob({ appId: "a1", appName: "myapp", organizationId: "o1" });
+
+    expect(result).toBeNull();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("skips apps with no persistent volumes", async () => {
+    volumesFindMany.mockResolvedValue([{ persistent: false }]);
+
+    const result = await ensureAutoBackupJob({ appId: "a1", appName: "myapp", organizationId: "o1" });
+
+    expect(result).toBeNull();
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Root-cause fix for the duplicate `Auto:` backup jobs (#757). `ensureAutoBackupJob` inserted the job row and its `backup_job_app` link in two separate, non-transactional statements. If the link insert failed (or was interrupted), the job row survived as an orphan with no app link — and since the dedup guard checks for an existing app link, the next deploy of that app couldn't see the orphan and created *another* job. On the homelab this produced 7× `Auto: glitchtip` and 4× `Auto: uptime-kuma`, plus several link-less empties.

## Fix

Wrap the job-row + link inserts in a single `db.transaction`, so a failed link aborts the whole unit of work and no orphan is left behind. Same fix applied to `ensureSystemBackupJob` (job + volume-link).

## Test plan

- New `auto-backup.test.ts` (the module had no tests): job+link created inside one transaction; a failing link insert rejects the whole op; dedup guard skips already-covered apps; apps with no persistent volumes are skipped.
- Full vitest suite green (1110), typecheck + eslint clean.

Part of the #757 cleanup: this stops recurrence; the existing duplicate/empty rows get purged + regenerated separately, and the malformed `volume.name` rows (which break tar backups at `assertSafeName`) are handled in a follow-up.