### PR TITLE
fix(backups): derive safe volume.name on import, not host source path (#757)

### DIFF
--- a/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/containers/[containerId]/import/route.ts
@@ -9,6 +9,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { getContainerDetail, hasAtFileTraefikLabels, isLocalImage } from "@/lib/docker/discover";
 import { resolveContainerPort } from "@/lib/docker/resolve-port";
+import { volumeNameFromMount } from "@/lib/docker/client";
 import { generateComposeFromContainer, injectTraefikLabels, composeToYaml } from "@/lib/docker/compose";
 import { encrypt } from "@/lib/crypto/encrypt";
 import { getSslConfig, getPrimaryIssuer } from "@/lib/system-settings";
@@ -251,7 +252,7 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
               id: nanoid(),
               appId,
               organizationId: orgId,
-              name: mount.source || mount.destination.replace(/\//g, "-").replace(/^-/, ""),
+              name: volumeNameFromMount(mount),
               mountPath: mount.destination,
               type: mount.type === "bind" ? "bind" : "named",
               source: mount.source || null,

--- a/app/api/v1/organizations/[orgId]/discover/groups/[composeProject]/import/route.ts
+++ b/app/api/v1/organizations/[orgId]/discover/groups/[composeProject]/import/route.ts
@@ -10,6 +10,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { discoverContainers, getContainerDetail, hasAtFileTraefikLabels, isLocalImage } from "@/lib/docker/discover";
 import { slugify } from "@/lib/ui/slugify";
+import { volumeNameFromMount } from "@/lib/docker/client";
 import {
   generateComposeFromContainer,
   injectTraefikLabels,
@@ -422,7 +423,7 @@ async function handler(request: NextRequest, { params }: RouteParams) {
             id: nanoid(),
             appId,
             organizationId: orgId,
-            name: mount.source || mount.destination.replace(/\//g, "-").replace(/^-/, ""),
+            name: volumeNameFromMount(mount),
             mountPath: mount.destination,
             type: mount.type === "bind" ? "bind" : "named",
             source: mount.source || null,

--- a/lib/docker/client.ts
+++ b/lib/docker/client.ts
@@ -942,6 +942,28 @@ export function resolveVolumeName(mount: { name: string; source: string }): stri
   return mount.name;
 }
 
+/**
+ * Derive a safe, stable `volume.name` from a Docker mount for persistence in
+ * the volumes table. For a named, non-anonymous volume this is the friendly
+ * Docker volume name with the compose project prefix stripped (e.g.
+ * `agents_redis-data` → `redis-data`). For a bind mount or an anonymous volume
+ * it's a slug derived from the container path. Crucially it NEVER returns the
+ * mount's host `source` path — that contains slashes and fails assertSafeName,
+ * which silently breaks tar backups (#757).
+ */
+export function volumeNameFromMount(mount: {
+  name: string;
+  source: string;
+  destination: string;
+  type: string;
+}): string {
+  const isAnonymous = !mount.name || /^[0-9a-f]{64}$/.test(mount.name);
+  if (mount.type !== "bind" && mount.name && !isAnonymous) {
+    return stripDockerProjectPrefix(mount.name);
+  }
+  return mount.destination.replace(/\//g, "-").replace(/^-/, "");
+}
+
 export async function getSystemInfo(): Promise<SystemInfo> {
   const raw = await dockerRequest<{
     NCPU: number;

--- a/tests/unit/lib/docker/volume-name-from-mount.test.ts
+++ b/tests/unit/lib/docker/volume-name-from-mount.test.ts
@@ -1,0 +1,54 @@
+// #757: the container/compose import routes stored mount.source (a host path
+// with slashes) as volume.name, which fails assertSafeName and silently breaks
+// tar backups. volumeNameFromMount derives a safe name and never returns the
+// host source path.
+
+import { describe, it, expect } from "vitest";
+import { volumeNameFromMount } from "@/lib/docker/client";
+
+describe("volumeNameFromMount", () => {
+  it("strips the compose project prefix from a named volume", () => {
+    expect(
+      volumeNameFromMount({
+        name: "agents_redis-data",
+        source: "/var/lib/docker/volumes/agents_redis-data/_data",
+        destination: "/data",
+        type: "volume",
+      }),
+    ).toBe("redis-data");
+  });
+
+  it("falls back to a path slug for an anonymous (64-hex) volume — never the host source", () => {
+    const name = volumeNameFromMount({
+      name: "8d9e91b1f8bbc47ae8a9656ef4a808ef94af2eeb2beb7afedfecee6eade1c143",
+      source: "/var/lib/docker/volumes/8d9e91b1.../_data",
+      destination: "/var/lib/postgresql/data",
+      type: "volume",
+    });
+    expect(name).toBe("var-lib-postgresql-data");
+    expect(name).not.toContain("/");
+  });
+
+  it("uses a path slug for a bind mount, not the host source", () => {
+    expect(
+      volumeNameFromMount({
+        name: "",
+        source: "/mnt/docker/gitea/data",
+        destination: "/data",
+        type: "bind",
+      }),
+    ).toBe("data");
+  });
+
+  it("never produces a name that would fail assertSafeName", () => {
+    const SAFE = /^[a-zA-Z0-9._\-]+$/;
+    const mounts = [
+      { name: "agents_postgres-data", source: "/var/lib/docker/volumes/agents_postgres-data/_data", destination: "/var/lib/postgresql/data", type: "volume" },
+      { name: "", source: "/var/run/docker.sock", destination: "/var/run/docker.sock", type: "bind" },
+      { name: "a".repeat(64), source: "/var/lib/docker/volumes/x/_data", destination: "/shares", type: "volume" },
+    ];
+    for (const m of mounts) {
+      expect(volumeNameFromMount(m)).toMatch(SAFE);
+    }
+  });
+});


### PR DESCRIPTION
## What

The container-import and compose-group-import routes stored `mount.source` — the host path (e.g. `/var/lib/docker/volumes/agents_redis-data/_data`) — as `volume.name`. Slashes fail `assertSafeName`, so the backup engine's tar resolver throws and **every backup for an imported app silently fails**. On the homelab this affects the 9 named persistent volumes across the adopted apps (agents, immich, samba, syncthing, transmission, …).

## Fix

New `volumeNameFromMount()` in `lib/docker/client.ts`:
- named, non-anonymous volume → Docker volume name with compose project prefix stripped (`agents_redis-data` → `redis-data`)
- bind mount or anonymous (64-hex) volume → a slug derived from the container path
- **never** the host `source` path

Applied at both import insert sites. Mirrors the volume detection `post-deploy.ts` already uses.

## Test plan

- New `volume-name-from-mount.test.ts`: prefix stripping, anonymous fallback, bind fallback, and a guard that no output ever fails the `assertSafeName` regex.
- typecheck + eslint clean.

Existing malformed rows on the homelab are repaired separately (data fix). Note: many imported apps keep their real data in **bind mounts**, which Vardo's volume backup doesn't cover — tracked as a separate concern.