### PR TITLE
fix(backups): apply retention per volume, not per job (#761)

### DIFF
--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -614,6 +614,33 @@ function selectKeepers(
 }
 
 /**
+ * Apply the retention policy PER VOLUME. A job with N volumes produces N
+ * backups per run (one archive each, same timestamp); retention timelines must
+ * not be shared, or e.g. keepLast=1 would keep a single archive across all
+ * volumes and prune the rest — silently dropping every volume but one each run.
+ * Group by volumeName and union the keepers from each volume's own timeline.
+ * Entries must be sorted newest-first (selectKeepers relies on it).
+ */
+export function selectKeepersByVolume(
+  entries: { id: string; finishedAt: Date; volumeName: string | null }[],
+  policy: RetentionPolicy,
+): Set<string> {
+  const byVolume = new Map<string, { id: string; finishedAt: Date }[]>();
+  for (const e of entries) {
+    const key = e.volumeName ?? "";
+    let group = byVolume.get(key);
+    if (!group) byVolume.set(key, (group = []));
+    group.push(e);
+  }
+
+  const keepers = new Set<string>();
+  for (const group of byVolume.values()) {
+    for (const id of selectKeepers(group, policy)) keepers.add(id);
+  }
+  return keepers;
+}
+
+/**
  * Prune backups for a job according to its retention policy.
  * Deletes from storage and marks DB rows as "pruned".
  */
@@ -648,7 +675,7 @@ export async function pruneBackups(jobId: string): Promise<number> {
 
   if (eligible.length === 0) return 0;
 
-  const keepers = selectKeepers(eligible, policy);
+  const keepers = selectKeepersByVolume(eligible, policy);
   const toPrune = eligible.filter((b) => !keepers.has(b.id));
 
   if (toPrune.length === 0) return 0;

--- a/tests/unit/lib/backups/retention.test.ts
+++ b/tests/unit/lib/backups/retention.test.ts
@@ -1,0 +1,53 @@
+// Retention must be applied PER VOLUME. A multi-volume job produces one archive
+// per volume per run (same timestamp); sharing one retention timeline meant
+// keepLast=1 kept a single archive across ALL volumes and pruned the rest —
+// e.g. agents kept a 418-byte redis archive and deleted its 14.8 MB postgres
+// backup every run. selectKeepersByVolume groups by volumeName first.
+
+import { describe, it, expect } from "vitest";
+import { selectKeepersByVolume } from "@/lib/backups/engine";
+
+const T = (n: number) => new Date(2026, 0, 1, 0, 0, n); // distinct, ordered timestamps
+
+describe("selectKeepersByVolume — per-volume retention", () => {
+  it("keepLast=1 keeps the newest archive of EACH volume (the agents bug)", () => {
+    // One run, two volumes — both must survive.
+    const entries = [
+      { id: "redis", volumeName: "redis-data", finishedAt: T(6) },
+      { id: "pg", volumeName: "postgres-data", finishedAt: T(5) },
+    ];
+    const keepers = selectKeepersByVolume(entries, {
+      keepAll: false, keepLast: 1, keepHourly: null, keepDaily: null,
+      keepWeekly: null, keepMonthly: null, keepYearly: null,
+    });
+    expect(keepers).toEqual(new Set(["redis", "pg"]));
+  });
+
+  it("keepLast=1 across two runs keeps each volume's latest, prunes each volume's older", () => {
+    // newest-first, interleaved volumes
+    const entries = [
+      { id: "d2", volumeName: "data", finishedAt: T(4) },
+      { id: "p2", volumeName: "postgres", finishedAt: T(3) },
+      { id: "d1", volumeName: "data", finishedAt: T(2) },
+      { id: "p1", volumeName: "postgres", finishedAt: T(1) },
+    ];
+    const keepers = selectKeepersByVolume(entries, {
+      keepAll: false, keepLast: 1, keepHourly: null, keepDaily: null,
+      keepWeekly: null, keepMonthly: null, keepYearly: null,
+    });
+    // The newest of each volume survives; the older of each is pruned.
+    expect(keepers).toEqual(new Set(["d2", "p2"]));
+  });
+
+  it("keepAll keeps everything regardless of volume", () => {
+    const entries = [
+      { id: "a", volumeName: "data", finishedAt: T(2) },
+      { id: "b", volumeName: "postgres", finishedAt: T(1) },
+    ];
+    const keepers = selectKeepersByVolume(entries, {
+      keepAll: true, keepLast: null, keepHourly: null, keepDaily: null,
+      keepWeekly: null, keepMonthly: null, keepYearly: null,
+    });
+    expect(keepers).toEqual(new Set(["a", "b"]));
+  });
+});


### PR DESCRIPTION
## What

Fixes #761. `pruneBackups`/`selectKeepers` applied retention across all of a job's backups as one timeline, ignoring `volumeName`. A multi-volume job writes one archive per volume per run (same timestamp), so `keepLast=1` kept a single archive across **all** volumes and pruned the rest.

Found verifying the #757 regenerated jobs: `Auto: agents` backed up both volumes successfully, then retention deleted the 14.8 MB `postgres-data` archive and kept only the 418-byte `redis-data` one.

## Fix

`selectKeepersByVolume`: group eligible backups by `volumeName`, run `selectKeepers` on each volume's own timeline, union the keepers. A backup run conceptually covers all of an app's volumes, so each volume keeps its own history.

## Test plan

- New `retention.test.ts`: `keepLast=1` keeps the newest archive of *each* volume (the agents scenario); across two runs it keeps each volume's latest and prunes each volume's older; `keepAll` keeps everything.
- Full vitest green, typecheck + eslint clean.