### PR TITLE
fix(adopt): follow the project on bind mounts, and say what was stripped

### DIFF
--- a/app/api/v1/organizations/[orgId]/adopt/route.ts
+++ b/app/api/v1/organizations/[orgId]/adopt/route.ts
@@ -9,7 +9,7 @@ import { verifyOrgAccess } from "@/lib/api/verify-access";
 import { requirePlugin } from "@/lib/api/require-plugin";
 import { withRateLimit } from "@/lib/api/with-rate-limit";
 import { db } from "@/lib/db";
-import { apps, domains, environments } from "@/lib/db/schema";
+import { apps, domains, environments, projects } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -27,6 +27,8 @@ import { recordActivity } from "@/lib/activity";
 import { encrypt } from "@/lib/crypto/encrypt";
 import { resolveProjectForImport } from "@/lib/docker/import";
 import { logger } from "@/lib/logger";
+import { isFeatureEnabled } from "@/lib/config/features";
+import { adoptAllowsBindMounts } from "@/lib/docker/adopt-policy";
 import { generateNamespace } from "@/lib/infra/app-namespace";
 
 type RouteParams = {
@@ -137,9 +139,24 @@ async function handler(request: NextRequest, { params }: RouteParams) {
       compose = excludeServices(compose, excludeList);
     }
 
-    // Sanitize (bind mounts allowed for local environments)
-    const { compose: sanitized } = sanitizeCompose(compose, {
-      allowBindMounts: data.environmentType === "local",
+    // Bind mounts follow the project, the same source the deploy path reads.
+    // Keying this on environmentType alone refused in production what deploy
+    // permits in production, for the same project (#767). A brand-new project
+    // has no row yet and takes the schema default.
+    const adoptProject = data.projectId
+      ? await db.query.projects.findFirst({
+          where: and(eq(projects.id, data.projectId), eq(projects.organizationId, orgId)),
+          columns: { allowBindMounts: true },
+        })
+      : null;
+    const bindMountsEnabled = adoptAllowsBindMounts({
+      environmentType: data.environmentType,
+      projectAllowBindMounts: adoptProject?.allowBindMounts,
+      featureEnabled: isFeatureEnabled("bindMounts"),
+    });
+
+    const { compose: sanitized, strippedMounts } = sanitizeCompose(compose, {
+      allowBindMounts: bindMountsEnabled,
     });
     compose = sanitized;
 
@@ -238,6 +255,9 @@ async function handler(request: NextRequest, { params }: RouteParams) {
         app: result.app,
         environmentType: data.environmentType,
         domain,
+        // Named even when empty, so a caller can tell "nothing was stripped"
+        // from an older response that could not say.
+        strippedMounts,
       },
       { status: 201 }
     );

--- a/lib/docker/adopt-policy.ts
+++ b/lib/docker/adopt-policy.ts
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------
+// Adoption policy
+//
+// Adoption brings an existing, running service under Vardo, so it is the path
+// most likely to carry bind mounts and the one where dropping them costs the
+// most. The rule has to match what the deploy path will do with the same
+// compose, or adopt refuses what deploy would have permitted.
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether an adopt may keep bind mounts.
+ *
+ * The project is the authority, as it is for deploy. A local environment is
+ * additionally permitted because it has no project to speak for it in the
+ * common case.
+ */
+export function adoptAllowsBindMounts(input: {
+  environmentType: string;
+  /** The project's setting, or null when adopting into a project that does not exist yet. */
+  projectAllowBindMounts: boolean | null | undefined;
+  featureEnabled: boolean;
+}): boolean {
+  return (
+    input.environmentType === "local" ||
+    (input.projectAllowBindMounts ?? false) ||
+    input.featureEnabled
+  );
+}

--- a/lib/mcp/tools/adopt-app.ts
+++ b/lib/mcp/tools/adopt-app.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { APP_NAME_TAKEN_ERROR, isTopLevelAppNameTaken } from "@/lib/db/app-name";
-import { apps, domains, environments } from "@/lib/db/schema";
+import { apps, domains, environments, projects } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import {
@@ -22,6 +22,8 @@ import { resolve, basename } from "path";
 import { slugify } from "@/lib/ui/slugify";
 import type { McpAuthContext } from "../auth";
 import { resolveProjectOrg, resolveTargetOrg } from "../scope";
+import { isFeatureEnabled } from "@/lib/config/features";
+import { adoptAllowsBindMounts } from "@/lib/docker/adopt-policy";
 import { generateNamespace } from "@/lib/infra/app-namespace";
 
 export function registerAdoptApp(
@@ -195,9 +197,23 @@ export function registerAdoptApp(
         compose = excludeServices(compose, excludeList);
       }
 
-      // Sanitize — bind mounts allowed for local
-      const { compose: sanitized } = sanitizeCompose(compose, {
-        allowBindMounts: environmentType === "local",
+      // Bind mounts follow the project, the same source the deploy path reads.
+      // Keying this on environmentType alone refused in production what deploy
+      // permits in production, for the same project (#767).
+      const adoptProject = projectId
+        ? await db.query.projects.findFirst({
+            where: and(eq(projects.id, projectId), eq(projects.organizationId, orgId)),
+            columns: { allowBindMounts: true },
+          })
+        : null;
+      const bindMountsEnabled = adoptAllowsBindMounts({
+        environmentType,
+        projectAllowBindMounts: adoptProject?.allowBindMounts,
+        featureEnabled: isFeatureEnabled("bindMounts"),
+      });
+
+      const { compose: sanitized, strippedMounts } = sanitizeCompose(compose, {
+        allowBindMounts: bindMountsEnabled,
       });
       compose = sanitized;
 
@@ -288,6 +304,9 @@ export function registerAdoptApp(
                 environmentType,
                 domain: effectiveDomain,
                 excludedServices: excludeList,
+                // Named even when empty, so a caller can tell "nothing was
+                // stripped" from an older response that could not say.
+                strippedMounts,
               },
               null,
               2

--- a/tests/unit/lib/docker/adopt-policy.test.ts
+++ b/tests/unit/lib/docker/adopt-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { adoptAllowsBindMounts } from "@/lib/docker/adopt-policy";
+
+const base = {
+  environmentType: "production",
+  projectAllowBindMounts: false,
+  featureEnabled: false,
+};
+
+describe("adoptAllowsBindMounts", () => {
+  it("allows a production adopt when the project allows bind mounts", () => {
+    // The regression: this returned false, so adopting tautulli into `media`
+    // silently dropped its config mount and would have started it empty.
+    expect(adoptAllowsBindMounts({ ...base, projectAllowBindMounts: true })).toBe(true);
+  });
+
+  it("refuses when the project does not allow them", () => {
+    expect(adoptAllowsBindMounts(base)).toBe(false);
+  });
+
+  it("still allows local, which has no project to speak for it", () => {
+    expect(adoptAllowsBindMounts({ ...base, environmentType: "local" })).toBe(true);
+  });
+
+  it("treats a project that does not exist yet as not allowing them", () => {
+    expect(adoptAllowsBindMounts({ ...base, projectAllowBindMounts: null })).toBe(false);
+    expect(adoptAllowsBindMounts({ ...base, projectAllowBindMounts: undefined })).toBe(false);
+  });
+
+  it("honors the instance feature flag", () => {
+    expect(adoptAllowsBindMounts({ ...base, featureEnabled: true })).toBe(true);
+  });
+
+  it("does not depend on which non-local environment it is", () => {
+    for (const environmentType of ["production", "staging", "preview"]) {
+      expect(adoptAllowsBindMounts({ ...base, environmentType })).toBe(false);
+      expect(
+        adoptAllowsBindMounts({ ...base, environmentType, projectAllowBindMounts: true }),
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #767.

## The bug

Both adopt paths decided bind mounts with `allowBindMounts: environmentType === "local"`. So adopting into any non-local environment stripped every bind mount, returned no warning, and reported success. The app came up empty on first deploy.

Hit for real adopting tautulli into `media` — a project with `allowBindMounts: true`, whose existing apps (plex, kometa) depend on bind mounts in production. Adopt refused what deploy permits, for the same project.

## The fix

- `adoptAllowsBindMounts()` — one helper, used by the API route and the MCP tool, which had duplicated the rule.
- The project is the authority, matching `lib/docker/deploy.ts:264-266`. `local` stays permitted, since it commonly has no project to speak for it. The instance feature flag still applies.
- Both paths return `strippedMounts`, **present even when empty** so a caller can tell "nothing was stripped" from an older response that could not say. The deploy path already logs this; adopt was discarding it.

## What this does not change

Which mounts are unsafe. `sanitizeCompose` and the deny list are untouched — this only stops adopt from being stricter than deploy about the same compose, and stops it being silent when it is strict.

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` — 4018 passed, 282 files
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean

6 new tests. Confirmed they can fail: inverting the project check fails 3 of them.
