### PR TITLE
feat(image-reclaim): flag a slot candidate that is an app's rollback target

### DIFF
--- a/lib/docker/image-reclaim/slot-plan.ts
+++ b/lib/docker/image-reclaim/slot-plan.ts
@@ -15,6 +15,7 @@ import { apps } from "@/lib/db/schema";
 import { PROJECTS_DIR } from "@/lib/paths";
 import { listAllContainers, listImages, type ImageInfo } from "../client";
 import { readCurrentSlot } from "../standby-slot";
+import type { Slot } from "../slots";
 import {
   buildSlotIndex,
   classifyProject,
@@ -47,6 +48,13 @@ export interface SlotReclaimCandidate {
   images: PlannedSlotImage[];
   /** Upper bound: shared layers are counted once per image that references them. */
   estimatedBytes: number;
+  /**
+   * Set when this generation is an environment's standby. Taking it does not
+   * break rollback — the slot's compose files stay — but it turns an instant
+   * rollback into a rebuild, which is the one thing the plan otherwise does not
+   * say out loud. Advisory: it does not change what is taken.
+   */
+  rollbackTargetFor?: { appName: string; envName: string; liveSlot: Slot };
 }
 
 export interface SlotReclaimSkip {
@@ -123,12 +131,27 @@ export function selectSlotCandidates(input: SlotPlanInput): SlotReclaimPlan {
 
     let candidate = byProject.get(project);
     if (!candidate) {
+      // A slot generation only reaches here after decideSlotImage refused the
+      // live slot and the unreadable case, so anything left is the standby.
+      const liveSlot =
+        generation.kind === "slot"
+          ? currentByEnv.get(`${generation.appName}-${generation.envName}`) ?? null
+          : null;
       candidate = {
         project,
         appName: generation.appName ?? project,
         generation,
         images: [],
         estimatedBytes: 0,
+        ...(generation.kind === "slot" && liveSlot
+          ? {
+              rollbackTargetFor: {
+                appName: generation.appName,
+                envName: generation.envName,
+                liveSlot,
+              },
+            }
+          : {}),
       };
       byProject.set(project, candidate);
     }

--- a/tests/unit/lib/docker/image-reclaim/slot-plan.test.ts
+++ b/tests/unit/lib/docker/image-reclaim/slot-plan.test.ts
@@ -265,3 +265,48 @@ describe("selectSlotCandidates — determinism", () => {
     expect(planned + result.skipped.length).toBe(images.length);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rollback-target annotation (#766)
+//
+// The plan explains every refusal but said nothing about what taking a
+// candidate costs. A standby generation is still safe to take — the slot's
+// compose files stay — but rollback stops being instant.
+// ---------------------------------------------------------------------------
+
+describe("selectSlotCandidates — rollback-target annotation", () => {
+  it("flags the standby generation with the slot still serving", () => {
+    const result = plan({ images: [image("agents-production-blue", "bot")] });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0].rollbackTargetFor).toEqual({
+      appName: "agents",
+      envName: "production",
+      liveSlot: "green",
+    });
+  });
+
+  it("does not flag a legacy generation, which no symlink can name", () => {
+    const result = plan({ images: [image("agents", "bot")] });
+
+    expect(takenTags(result)).toContain("agents-bot:latest");
+    expect(result.candidates[0].rollbackTargetFor).toBeUndefined();
+  });
+
+  it("is advisory — it does not change what is taken", () => {
+    const images = [image("agents-production-blue", "bot")];
+    const result = plan({ images });
+
+    expect(takenTags(result)).toEqual(["agents-production-blue-bot:latest"]);
+    expect(result.estimatedBytes).toBe(1_000);
+  });
+
+  it("names the live slot, not the one being reclaimed", () => {
+    const result = plan({
+      images: [image("agents-production-green", "bot")],
+      environments: [env({ currentSlot: "blue" })],
+    });
+
+    expect(result.candidates[0].rollbackTargetFor?.liveSlot).toBe("blue");
+  });
+});


### PR DESCRIPTION
Refs #766.

`SlotReclaimCandidate` gains `rollbackTargetFor: { appName, envName, liveSlot }`, set when the generation is an environment's standby.

Precise by construction: `decideSlotImage` already refuses `live-slot` and `current-unreadable`, so any surviving slot-kind candidate **is** the standby. Legacy generations get nothing — no symlink can name them.

Advisory only. What gets taken is unchanged, and the field flows through `GET /api/v1/admin/maintenance/image-reclaim` since the route spreads the built plan.

## Why it matters

On the 2026-08-03 run, `lonvr-production-blue` was the largest single candidate at 27.7 GB and was `current -> green`'s standby. The plan presented it identically to 22 genuinely dead legacy images.

## Not in this PR

**The slot plan has no admin UI at all** — `maintenance-settings.tsx` renders only the idle-app plan, which is why the slot sweep has to be driven through the API with `{"slots": true}`. Surfacing this field visually needs that UI first. Noted on the issue.

## Verification
- `pnpm typecheck` clean
- `pnpm vitest run` — 4009 passed, 281 files
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean

4 new tests. Confirmed they can fail: forcing the condition false fails 2.