### PR TITLE
fix(admin): stop the reclaim dialog claiming idle apps it is not touching

### DIFF
--- a/app/(authenticated)/admin/settings/maintenance-settings.tsx
+++ b/app/(authenticated)/admin/settings/maintenance-settings.tsx
@@ -891,18 +891,25 @@ export function MaintenanceSettings() {
             </AlertDialogTrigger>
             <AlertDialogContent size="sm">
               <AlertDialogHeader>
-                <AlertDialogTitle>Reclaim images for idle apps?</AlertDialogTitle>
+                <AlertDialogTitle>
+                  {includeSlots ? "Reclaim images and old slot generations?" : "Reclaim images for idle apps?"}
+                </AlertDialogTitle>
                 <AlertDialogDescription>
-                  {images?.plan
-                    ? `This removes the images of ${images.plan.candidates.length} idle app(s). Volumes are not touched, and each app pulls its image again on next start.`
-                    : "This removes the images of idle apps. Volumes are not touched."}
-                  {includeSlots && images?.slotPlan
-                    ? ` It also removes ${images.slotPlan.candidates.length} old slot generation(s)${
-                        images.slotPlan.candidates.some((c) => c.rollbackTargetFor)
-                          ? ", including generations that are a live app's rollback target — those apps would need a rebuild to roll back"
-                          : ""
-                      }.`
-                    : ""}
+                  {[
+                    images?.plan?.candidates.length
+                      ? `Removes the images of ${images.plan.candidates.length} idle app(s), which pull again on next start.`
+                      : null,
+                    includeSlots && images?.slotPlan?.candidates.length
+                      ? `Removes ${images.slotPlan.candidates.length} old slot generation(s)${
+                          images.slotPlan.candidates.some((c) => c.rollbackTargetFor)
+                            ? ", including one that is a live app's rollback target — that app would need a rebuild to roll back"
+                            : ""
+                        }.`
+                      : null,
+                    "Volumes are not touched.",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>


### PR DESCRIPTION
Follow-up to #772, found by actually rendering it.

## The defect

With slots included and no idle apps, the confirm dialog read:

> **Reclaim images for idle apps?**
> This removes the images of 0 idle app(s). Volumes are not touched, and each app pulls its image again on next start. It also removes 2 old slot generation(s), including generations that are a live app's rollback target...

The title named the wrong subject and the lead sentence announced "0 idle app(s)" while the real action was destroying two slot generations, one of them a live app's rollback target. The thing that mattered was buried behind a clause about something that was not happening.

## After

> **Reclaim images and old slot generations?**
> Removes 2 old slot generation(s), including one that is a live app's rollback target — that app would need a rebuild to roll back. Volumes are not touched.

Title follows what the run actually covers. The idle sentence appears only when there are idle apps. The volumes note is always last.

## Verified in a browser

Rendered locally against a fixture, both paths:
- slots included → title and warning as above
- slots not included, 0 idle → **Reclaim now is correctly disabled, no dialog opens**

Screenshots in `~/working/vardo-slot-plan-*.png`.

This is the defect class `learned/vardo-dev-with-real-data` describes — invisible in the source, obvious on the page.

## Gates
- `pnpm typecheck` clean
- `pnpm vitest run` — 4009 passed
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean