### PR TITLE
fix(deploy): default and preflight BuildKit so railpack stops failing blind

### DIFF
--- a/lib/docker/buildkit.ts
+++ b/lib/docker/buildkit.ts
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// BuildKit
+//
+// Railpack builds through BuildKit rather than the Docker daemon. When it can't
+// reach one it exits non-zero with only a hint, after the deploy has already
+// cloned and staged — so the check belongs before the build starts.
+// ---------------------------------------------------------------------------
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import { DOCKER_CLEANUP_TIMEOUT } from "./constants";
+import { DeployBlockedError } from "./errors";
+
+const execFileAsync = promisify(execFile);
+
+const DOCKER_CONTAINER_PREFIX = "docker-container://";
+
+/** Where Railpack looks for BuildKit when the environment does not say. */
+export const DEFAULT_BUILDKIT_HOST = "docker-container://buildkit";
+
+/**
+ * Container a BUILDKIT_HOST points at, or null for any other transport.
+ *
+ * Only `docker-container://` can be checked from here. A tcp:// or unix://
+ * daemon is somebody's deliberate configuration and is left to Railpack.
+ */
+export function buildKitContainerName(host: string): string | null {
+  if (!host.startsWith(DOCKER_CONTAINER_PREFIX)) return null;
+  const name = host.slice(DOCKER_CONTAINER_PREFIX.length).trim();
+  return name.length > 0 ? name : null;
+}
+
+/** Throws a deploy-blocking error when the named BuildKit container is not running. */
+export async function assertBuildKitReachable(
+  host: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const container = buildKitContainerName(host);
+  if (!container) return;
+
+  try {
+    const { stdout } = await execFileAsync(
+      "docker",
+      ["inspect", "-f", "{{.State.Running}}", container],
+      { timeout: DOCKER_CLEANUP_TIMEOUT, signal },
+    );
+    if (stdout.trim() === "true") return;
+  } catch {
+    // Absent and stopped read the same way to an operator, and the fix is the
+    // same, so both fall through to one message.
+  }
+
+  throw new DeployBlockedError(
+    `Railpack needs BuildKit, and no running container named "${container}" was found.\n` +
+      `Start one on the Docker host:\n` +
+      `  docker run -d --name ${container} --restart unless-stopped --privileged moby/buildkit\n` +
+      `Or set BUILDKIT_HOST to an existing daemon.`,
+  );
+}

--- a/lib/docker/deploy-steps/prepare-repo.ts
+++ b/lib/docker/deploy-steps/prepare-repo.ts
@@ -40,6 +40,7 @@ import {
 import { isFeatureEnabled } from "@/lib/config/features";
 import { assertSafeBranch } from "../validate";
 import { DeployBlockedError } from "../errors";
+import { assertBuildKitReachable, DEFAULT_BUILDKIT_HOST } from "../buildkit";
 import { assertAppDirOwnership } from "../app-dir-owner";
 import { getInstallationToken } from "@/lib/git-integration/app";
 import {
@@ -269,6 +270,13 @@ async function buildFromRepo(
   }
 
   if (deployType === "railpack") {
+    // Railpack builds through BuildKit rather than the Docker daemon, and exits
+    // non-zero with only a hint if it cannot find one. Default to the daemon
+    // Vardo documents, and check it is actually there before spending a deploy
+    // on discovering it is not.
+    if (!buildEnv.BUILDKIT_HOST) buildEnv.BUILDKIT_HOST = DEFAULT_BUILDKIT_HOST;
+    await assertBuildKitReachable(buildEnv.BUILDKIT_HOST, signal);
+
     logs.push(`[build] Building with Railpack...`);
     const args = ["build", "--name", imageName];
     if (envVars) {

--- a/tests/unit/lib/docker/buildkit.test.ts
+++ b/tests/unit/lib/docker/buildkit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { promisify } from "util";
+
+// `promisify(execFile)` resolves through the promisify.custom symbol, the same
+// as the real child_process export. Setting it here keeps the mock independent
+// of callback arity.
+const { execFileMock, calls } = vi.hoisted(() => ({
+  execFileMock: vi.fn() as unknown as Record<symbol, unknown> & { mock: { calls: unknown[][] } },
+  calls: [] as unknown[][],
+}));
+
+let response: { stdout: string } | Error = { stdout: "true\n" };
+
+(execFileMock as Record<symbol, unknown>)[promisify.custom] = (...args: unknown[]) => {
+  calls.push(args);
+  return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+};
+
+vi.mock("child_process", () => ({ execFile: execFileMock }));
+
+const { assertBuildKitReachable, buildKitContainerName, DEFAULT_BUILDKIT_HOST } = await import(
+  "@/lib/docker/buildkit"
+);
+
+beforeEach(() => {
+  calls.length = 0;
+  response = { stdout: "true\n" };
+});
+
+describe("buildKitContainerName", () => {
+  it("reads the container out of a docker-container host", () => {
+    expect(buildKitContainerName("docker-container://buildkit")).toBe("buildkit");
+  });
+
+  it("ignores transports it cannot check", () => {
+    expect(buildKitContainerName("tcp://10.0.0.5:1234")).toBeNull();
+    expect(buildKitContainerName("unix:///run/buildkit/buildkitd.sock")).toBeNull();
+  });
+
+  it("treats an empty container name as no container", () => {
+    expect(buildKitContainerName("docker-container://")).toBeNull();
+    expect(buildKitContainerName("docker-container://   ")).toBeNull();
+  });
+
+  it("the default host names a checkable container", () => {
+    expect(buildKitContainerName(DEFAULT_BUILDKIT_HOST)).toBe("buildkit");
+  });
+});
+
+describe("assertBuildKitReachable", () => {
+  it("passes when the container reports running", async () => {
+    response = { stdout: "true\n" };
+    await expect(assertBuildKitReachable(DEFAULT_BUILDKIT_HOST)).resolves.toBeUndefined();
+  });
+
+  it("blocks the deploy when the container is stopped", async () => {
+    response = { stdout: "false\n" };
+    await expect(assertBuildKitReachable(DEFAULT_BUILDKIT_HOST)).rejects.toThrow(/needs BuildKit/);
+  });
+
+  it("blocks the deploy when the container does not exist", async () => {
+    response = new Error("No such object: buildkit");
+    await expect(assertBuildKitReachable(DEFAULT_BUILDKIT_HOST)).rejects.toThrow(/needs BuildKit/);
+  });
+
+  it("tells the operator exactly how to fix it", async () => {
+    response = new Error("nope");
+    await expect(assertBuildKitReachable("docker-container://bk")).rejects.toThrow(
+      /docker run -d --name bk --restart unless-stopped --privileged moby\/buildkit/,
+    );
+  });
+
+  it("inspects the container the host names", async () => {
+    await assertBuildKitReachable("docker-container://custom-bk");
+    expect(calls[0][1]).toEqual(["inspect", "-f", "{{.State.Running}}", "custom-bk"]);
+  });
+
+  it("does not shell out for a transport it cannot check", async () => {
+    await expect(assertBuildKitReachable("tcp://10.0.0.5:1234")).resolves.toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #774.

## The problem

Railpack builds through BuildKit, not the Docker daemon. With no `BUILDKIT_HOST` set it exits non-zero with only a hint — **after** the repo has been cloned and staged. Every railpack deploy on this instance failed that way, which is every railpack deploy ever attempted (zero apps used the type; zero deployments contained a build marker).

## The change

- `lib/docker/buildkit.ts` — `DEFAULT_BUILDKIT_HOST`, `buildKitContainerName()`, `assertBuildKitReachable()`.
- The railpack branch defaults `BUILDKIT_HOST` to `docker-container://buildkit` and verifies the container is running **before** the build starts.
- A missing daemon now raises `DeployBlockedError` naming the exact command to fix it, instead of a spent deploy and a cryptic tail.
- Only `docker-container://` is checked. A `tcp://` or `unix://` host is deliberate configuration and is left to Railpack — verified by a test that asserts nothing is shelled out.

Extracted to its own module rather than inlined, because `prepare-repo.ts` pulls in the db and crypto and is impractical to test against.

## Proven on the homelab

Both engines, same repo (`heroku/node-js-getting-started`, no Dockerfile, no compose):

| engine | result | image |
|---|---|---|
| nixpacks | built, deployed, **HTTP 200** in 76s | 337 MB |
| railpack, no BuildKit | **failed in 2.9s** — the bug | — |
| railpack, BuildKit running | built, deployed, **HTTP 200** in 42s | **152 MB** |

Railpack produces a notably smaller image for the same app. All three throwaways were torn down — no leftover containers, images, volumes or directories.

## Operational note

This needs a BuildKit daemon on the Docker host:

```
docker run -d --name buildkit --restart unless-stopped --privileged moby/buildkit
```

It is **privileged** — a deliberate decision, not a detail. One is now running on the homelab. If that trade is unwelcome, the alternative is dropping `railpack` from the enum, and this PR at least makes the failure legible either way.

## Gates
- `pnpm typecheck` clean
- `pnpm vitest run` — **4019 passed** (10 new)
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean

Confirmed the new tests can fail: removing the `stdout === "true"` check fails one.