### PR TITLE
feat(infra): manage BuildKit as a shared service behind a profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,24 @@ services:
     networks:
       - internal
 
+  # Railpack builds through BuildKit rather than the Docker daemon, so a
+  # railpack deploy needs this running. Opt in with `buildkit` in
+  # COMPOSE_PROFILES — it is privileged, which should be a deliberate choice
+  # rather than something every install inherits. Nixpacks does not need it.
+  buildkit:
+    container_name: vardo-buildkit
+    x-vardo-shared: true
+    image: moby/buildkit:latest
+    profiles:
+      - buildkit
+    restart: unless-stopped
+    privileged: true
+    mem_limit: ${VARDO_BUILDKIT_MEM:-2g}
+    volumes:
+      - buildkit_data:/var/lib/buildkit
+    networks:
+      - internal
+
   traefik:
     container_name: vardo-traefik
     x-vardo-shared: true
@@ -288,6 +306,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  buildkit_data:
   letsencrypt:
   wireguard_config:
   traefik_dynamic:

--- a/lib/docker/buildkit.ts
+++ b/lib/docker/buildkit.ts
@@ -17,7 +17,7 @@ const execFileAsync = promisify(execFile);
 const DOCKER_CONTAINER_PREFIX = "docker-container://";
 
 /** Where Railpack looks for BuildKit when the environment does not say. */
-export const DEFAULT_BUILDKIT_HOST = "docker-container://buildkit";
+export const DEFAULT_BUILDKIT_HOST = "docker-container://vardo-buildkit";
 
 /**
  * Container a BUILDKIT_HOST points at, or null for any other transport.
@@ -53,8 +53,8 @@ export async function assertBuildKitReachable(
 
   throw new DeployBlockedError(
     `Railpack needs BuildKit, and no running container named "${container}" was found.\n` +
-      `Start one on the Docker host:\n` +
-      `  docker run -d --name ${container} --restart unless-stopped --privileged moby/buildkit\n` +
-      `Or set BUILDKIT_HOST to an existing daemon.`,
+      `Add "buildkit" to COMPOSE_PROFILES on the Docker host and bring the stack up:\n` +
+      `  COMPOSE_PROFILES=production,buildkit docker compose up -d buildkit\n` +
+      `Or point BUILDKIT_HOST at a daemon you run yourself. Nixpacks needs none of this.`,
   );
 }

--- a/tests/unit/lib/docker/buildkit.test.ts
+++ b/tests/unit/lib/docker/buildkit.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe("buildKitContainerName", () => {
   it("reads the container out of a docker-container host", () => {
-    expect(buildKitContainerName("docker-container://buildkit")).toBe("buildkit");
+    expect(buildKitContainerName("docker-container://vardo-buildkit")).toBe("vardo-buildkit");
   });
 
   it("ignores transports it cannot check", () => {
@@ -43,7 +43,7 @@ describe("buildKitContainerName", () => {
   });
 
   it("the default host names a checkable container", () => {
-    expect(buildKitContainerName(DEFAULT_BUILDKIT_HOST)).toBe("buildkit");
+    expect(buildKitContainerName(DEFAULT_BUILDKIT_HOST)).toBe("vardo-buildkit");
   });
 });
 
@@ -65,9 +65,14 @@ describe("assertBuildKitReachable", () => {
 
   it("tells the operator exactly how to fix it", async () => {
     response = new Error("nope");
-    await expect(assertBuildKitReachable("docker-container://bk")).rejects.toThrow(
-      /docker run -d --name bk --restart unless-stopped --privileged moby\/buildkit/,
-    );
+    const err = assertBuildKitReachable("docker-container://bk");
+    await expect(err).rejects.toThrow(/no running container named "bk"/);
+    await expect(err).rejects.toThrow(/COMPOSE_PROFILES/);
+  });
+
+  it("says Nixpacks needs none of this, so the reader has an out", async () => {
+    response = new Error("nope");
+    await expect(assertBuildKitReachable(DEFAULT_BUILDKIT_HOST)).rejects.toThrow(/Nixpacks needs none of this/);
   });
 
   it("inspects the container the host names", async () => {


### PR DESCRIPTION
Follow-up to #775, which made a missing BuildKit legible. This makes it managed.

## Why

BuildKit was running on the homelab as a container I started by hand. It survives nothing, appears in no config, and would be absent on any new install — so `railpack` would silently be broken again.

## The change

- `buildkit` service in `docker-compose.yml`: `container_name: vardo-buildkit`, `x-vardo-shared: true` so it stays put across blue/green like postgres and traefik, `restart: unless-stopped`, a `buildkit_data` volume for build cache, `internal` network.
- **Behind `profiles: [buildkit]`.** The daemon is **privileged**. That should be a deliberate opt-in, not something every install inherits silently. Matches the existing profile pattern (`production`, `gpu`).
- `DEFAULT_BUILDKIT_HOST` → `docker-container://vardo-buildkit`, matching the compose name.
- The preflight error now points at the profile as the primary fix, and says plainly that **Nixpacks needs none of this** — so someone hitting it has an immediate way forward rather than being pushed into running a privileged container they may not want.

## Enabling it

Add `buildkit` to `COMPOSE_PROFILES` in the host `.env`:

```
COMPOSE_PROFILES=production,buildkit
docker compose up -d buildkit
```

## Context on the trade

Railpack is worth the daemon on measured evidence — same repo, same host: **42s / 152 MB** vs Nixpacks' **76s / 337 MB**. That tracks Railway's own reported 38–77% image reduction, and Nixpacks is now in maintenance mode with Railpack the default for new Railway projects.

But it is still a privileged container, so the profile keeps the choice explicit.

## Gates
- `pnpm typecheck` clean
- `pnpm vitest run` — **4020 passed** (11 in the buildkit suite)
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean
- `docker compose config` validates