### PR TITLE
feat(deploy): prefer Railpack for no-Dockerfile repos when BuildKit is up

### DIFF
--- a/lib/docker/buildkit.ts
+++ b/lib/docker/buildkit.ts
@@ -31,13 +31,16 @@ export function buildKitContainerName(host: string): string | null {
   return name.length > 0 ? name : null;
 }
 
-/** Throws a deploy-blocking error when the named BuildKit container is not running. */
-export async function assertBuildKitReachable(
-  host: string,
-  signal?: AbortSignal,
-): Promise<void> {
+/**
+ * Whether BuildKit can be reached. Never throws — for choosing a builder, where
+ * "no" is an answer rather than a failure.
+ *
+ * A transport this cannot inspect is taken at its word and reported reachable;
+ * the build will surface the truth soon enough.
+ */
+export async function isBuildKitReachable(host: string, signal?: AbortSignal): Promise<boolean> {
   const container = buildKitContainerName(host);
-  if (!container) return;
+  if (!container) return true;
 
   try {
     const { stdout } = await execFileAsync(
@@ -45,11 +48,20 @@ export async function assertBuildKitReachable(
       ["inspect", "-f", "{{.State.Running}}", container],
       { timeout: DOCKER_CLEANUP_TIMEOUT, signal },
     );
-    if (stdout.trim() === "true") return;
+    return stdout.trim() === "true";
   } catch {
-    // Absent and stopped read the same way to an operator, and the fix is the
-    // same, so both fall through to one message.
+    return false;
   }
+}
+
+/** Throws a deploy-blocking error when the named BuildKit container is not running. */
+export async function assertBuildKitReachable(
+  host: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const container = buildKitContainerName(host);
+  if (!container) return;
+  if (await isBuildKitReachable(host, signal)) return;
 
   throw new DeployBlockedError(
     `Railpack needs BuildKit, and no running container named "${container}" was found.\n` +

--- a/lib/docker/deploy-steps/prepare-repo.ts
+++ b/lib/docker/deploy-steps/prepare-repo.ts
@@ -40,7 +40,7 @@ import {
 import { isFeatureEnabled } from "@/lib/config/features";
 import { assertSafeBranch } from "../validate";
 import { DeployBlockedError } from "../errors";
-import { assertBuildKitReachable, DEFAULT_BUILDKIT_HOST } from "../buildkit";
+import { assertBuildKitReachable, isBuildKitReachable, DEFAULT_BUILDKIT_HOST } from "../buildkit";
 import { assertAppDirOwnership } from "../app-dir-owner";
 import { getInstallationToken } from "@/lib/git-integration/app";
 import {
@@ -593,8 +593,19 @@ export async function prepareRepo(ctx: DeployContext): Promise<DeployContext> {
           buildType = "dockerfile";
           log(`[deploy] No compose file, found ${dockerfileToCheck}`);
         } catch {
-          buildType = "nixpacks";
-          log(`[deploy] No compose file or Dockerfile, falling back to Nixpacks`);
+          // Railpack is the better builder on this repo shape — measurably
+          // faster and roughly half the image — but it needs BuildKit, which is
+          // opt-in because the daemon is privileged. Prefer it only when the
+          // daemon is actually there, so an instance without the profile still
+          // deploys instead of failing.
+          const buildKitHost = process.env.BUILDKIT_HOST || DEFAULT_BUILDKIT_HOST;
+          if (await isBuildKitReachable(buildKitHost, ctx.signal)) {
+            buildType = "railpack";
+            log(`[deploy] No compose file or Dockerfile — building with Railpack (BuildKit available)`);
+          } else {
+            buildType = "nixpacks";
+            log(`[deploy] No compose file or Dockerfile — building with Nixpacks (BuildKit not reachable)`);
+          }
         }
       }
 

--- a/tests/unit/lib/docker/buildkit.test.ts
+++ b/tests/unit/lib/docker/buildkit.test.ts
@@ -18,9 +18,12 @@ let response: { stdout: string } | Error = { stdout: "true\n" };
 
 vi.mock("child_process", () => ({ execFile: execFileMock }));
 
-const { assertBuildKitReachable, buildKitContainerName, DEFAULT_BUILDKIT_HOST } = await import(
-  "@/lib/docker/buildkit"
-);
+const {
+  assertBuildKitReachable,
+  isBuildKitReachable,
+  buildKitContainerName,
+  DEFAULT_BUILDKIT_HOST,
+} = await import("@/lib/docker/buildkit");
 
 beforeEach(() => {
   calls.length = 0;
@@ -82,6 +85,28 @@ describe("assertBuildKitReachable", () => {
 
   it("does not shell out for a transport it cannot check", async () => {
     await expect(assertBuildKitReachable("tcp://10.0.0.5:1234")).resolves.toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("isBuildKitReachable", () => {
+  it("is true when the container reports running", async () => {
+    response = { stdout: "true\n" };
+    await expect(isBuildKitReachable(DEFAULT_BUILDKIT_HOST)).resolves.toBe(true);
+  });
+
+  it("is false when stopped, without throwing — a builder choice, not a failure", async () => {
+    response = { stdout: "false\n" };
+    await expect(isBuildKitReachable(DEFAULT_BUILDKIT_HOST)).resolves.toBe(false);
+  });
+
+  it("is false when the container is absent", async () => {
+    response = new Error("No such object");
+    await expect(isBuildKitReachable(DEFAULT_BUILDKIT_HOST)).resolves.toBe(false);
+  });
+
+  it("takes an uninspectable transport at its word", async () => {
+    await expect(isBuildKitReachable("tcp://10.0.0.5:1234")).resolves.toBe(true);
     expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #779.

## Why

A repo with no compose file and no Dockerfile fell back to Nixpacks unconditionally. Measured on the homelab, same repo, same host:

| engine | time | image |
|---|---|---|
| nixpacks | 76s | 337 MB |
| railpack | 42s (37s warm) | **152 MB** |

[Nixpacks is in maintenance mode and Railway made Railpack its default](https://blog.railway.com/p/introducing-railpack), citing 38–77% image reduction. The measurement here is consistent.

## The constraint that shapes it

Railpack needs BuildKit, and BuildKit is **opt-in** behind a compose profile (#776) because the daemon is privileged. So the fallback cannot just switch — on an instance without the profile, defaulting to Railpack would break every no-Dockerfile deploy.

The choice is therefore made per deploy against a reachability check:

- BuildKit reachable → Railpack
- not reachable → Nixpacks, exactly as before

## `isBuildKitReachable` vs `assertBuildKitReachable`

`assertBuildKitReachable` throws — right for an explicit `deployType: railpack`, where a missing daemon is an error the user should see. Choosing a builder is different: "no" is an answer, not a failure. Hence a non-throwing sibling, with `assert` now built on it so there is one code path.

A transport that cannot be inspected (`tcp://`, `unix://`) is taken at its word and reported reachable — the build surfaces the truth soon enough, and guessing "unreachable" would silently downgrade someone's deliberately configured daemon.

## Visibility

The old log line said only `falling back to Nixpacks`. Now it names the engine **and the reason**:

```
No compose file or Dockerfile — building with Railpack (BuildKit available)
No compose file or Dockerfile — building with Nixpacks (BuildKit not reachable)
```

A build engine that changes with host configuration should say so out loud. Partial credit toward #778.

## Gates
- `pnpm typecheck` clean
- `pnpm vitest run` — all passing, 15 in the buildkit suite
- `pnpm lint` — 376 warnings / 0 errors, unchanged
- `pnpm build` clean

Confirmed the new tests can fail: forcing the running-check true fails 2.