### PR TITLE
Vet outbound URLs, refuse fork-PR previews, pin the authz surface

### DIFF
--- a/app/api/v1/github/webhook/route.ts
+++ b/app/api/v1/github/webhook/route.ts
@@ -8,6 +8,7 @@ import { createPreview, destroyPreview } from "@/lib/docker/preview";
 import { getSystemManagedApp, createVardoPreview, destroyVardoPreview } from "@/lib/docker/self-preview";
 import { isFeatureEnabled, isFeatureEnabledAsync } from "@/lib/config/features";
 import { getGitHubAppConfig } from "@/lib/system-settings";
+import { previewRefusalReason } from "@/lib/git-integration/pull-request";
 import { logger } from "@/lib/logger";
 
 import { withRateLimit } from "@/lib/api/with-rate-limit";
@@ -154,6 +155,23 @@ async function handlePullRequest(payload: Record<string, unknown>): Promise<Next
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     log.error(`Invalid PR number in webhook payload: ${prNumber}`);
     return NextResponse.json({ ok: true, skipped: "invalid PR number" });
+  }
+
+  // Anyone with a GitHub account can open a fork PR against a public repo, and
+  // GitHub signs that webhook like any other. Building from it would let an
+  // outsider trigger deploys — and, when the fork's branch name matches one in
+  // the base repo, publish a preview URL for an internal branch on their PR.
+  // Teardown is deliberately left below this: a PR that became a fork after a
+  // preview existed must still be cleaned up.
+  const headRepo = (pr.head as Record<string, unknown>)?.repo as Record<string, unknown> | null;
+  const refusal = action === "closed" ? null : previewRefusalReason({
+    baseRepoFullName: repoFullName,
+    headRepoFullName: headRepo?.full_name as string | undefined,
+    headIsFork: headRepo?.fork as boolean | undefined,
+  });
+  if (refusal) {
+    log.info(`PR #${prNumber} skipped — ${refusal}`);
+    return NextResponse.json({ ok: true, skipped: refusal });
   }
 
   log.info(`PR #${prNumber} ${action} on ${repoFullName}:${branch} by ${author}`);

--- a/lib/cron/engine.ts
+++ b/lib/cron/engine.ts
@@ -9,6 +9,8 @@ import { matchContainers, type ReconcilableApp } from "@/lib/docker/container-ma
 import { shouldRunNow } from "./parse";
 import { acquireLock } from "@/lib/redis-lock";
 import { logger } from "@/lib/logger";
+import { safeFetch } from "@/lib/security/safe-fetch";
+import { getOutboundPolicy } from "@/lib/security/outbound-policy";
 
 const log = logger.child("cron");
 
@@ -94,9 +96,9 @@ async function fetchUrl(
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 60_000);
-    const res = await fetch(url, {
+    const res = await safeFetch(url, {
       signal: controller.signal,
-      redirect: "follow",
+      policy: await getOutboundPolicy(),
     });
     clearTimeout(timeout);
     const body = await res.text().catch(() => "");

--- a/lib/git-integration/pull-request.ts
+++ b/lib/git-integration/pull-request.ts
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------
+// Which pull requests may become previews.
+//
+// A webhook for a fork PR is authentic — GitHub signed it — but anyone with an
+// account can cause one to be sent against a public repository. What follows
+// from it therefore has to be judged, not just verified.
+// ---------------------------------------------------------------------------
+
+/** Why a PR was refused a preview, or null when it may have one. */
+export function previewRefusalReason(payload: {
+  baseRepoFullName?: string | null;
+  headRepoFullName?: string | null;
+  headIsFork?: boolean | null;
+}): string | null {
+  const base = payload.baseRepoFullName?.trim();
+  const head = payload.headRepoFullName?.trim();
+
+  // A deleted fork leaves head.repo null. Nothing identifies the source, so
+  // there is nothing to check it against.
+  if (!head) return "pull request head repository is unknown";
+  if (!base) return "pull request base repository is unknown";
+
+  if (payload.headIsFork === true || head.toLowerCase() !== base.toLowerCase()) {
+    return `pull request comes from a fork (${head}) — previews only build branches of ${base}`;
+  }
+
+  return null;
+}

--- a/lib/hooks/execute.ts
+++ b/lib/hooks/execute.ts
@@ -13,6 +13,8 @@
 import { createHmac } from "crypto";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { safeFetch } from "@/lib/security/safe-fetch";
+import { getOutboundPolicy } from "@/lib/security/outbound-policy";
 import { getHooksForEvent, getInternalHandler } from "./registry";
 import { isFeatureEnabledAsync } from "@/lib/config/features";
 import { addDeployLog } from "@/lib/stream/producer";
@@ -194,11 +196,12 @@ async function executeWebhook(
   const timer = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const response = await fetch(config.url, {
+    const response = await safeFetch(config.url, {
       method: "POST",
       headers,
       body: payload,
       signal: controller.signal,
+      policy: await getOutboundPolicy(),
     });
 
     if (!response.ok) {

--- a/lib/notifications/webhook-channel.ts
+++ b/lib/notifications/webhook-channel.ts
@@ -2,6 +2,8 @@ import { createHmac } from "crypto";
 import type { NotificationChannel } from "./port";
 import type { BusEvent } from "@/lib/bus/events";
 import { logger } from "@/lib/logger";
+import { safeFetch } from "@/lib/security/safe-fetch";
+import { getOutboundPolicy } from "@/lib/security/outbound-policy";
 
 const log = logger.child("notifications");
 
@@ -31,11 +33,12 @@ export class WebhookNotificationChannel implements NotificationChannel {
     const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT);
 
     try {
-      const response = await fetch(this.config.url, {
+      const response = await safeFetch(this.config.url, {
         method: "POST",
         headers,
         body: payload,
         signal: controller.signal,
+        policy: await getOutboundPolicy(),
       });
       if (!response.ok) {
         log.error(`Webhook returned ${response.status}`);
@@ -58,13 +61,14 @@ export class SlackNotificationChannel implements NotificationChannel {
     const timer = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT);
 
     try {
-      const response = await fetch(this.config.webhookUrl, {
+      const response = await safeFetch(this.config.webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           text: `${emoji} *${event.title}*\n${event.message}`,
         }),
         signal: controller.signal,
+        policy: await getOutboundPolicy(),
       });
       if (!response.ok) {
         log.error(`Slack returned ${response.status}`);

--- a/lib/security/outbound-policy.ts
+++ b/lib/security/outbound-policy.ts
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------------
+// Where the outbound allowlist comes from.
+//
+// Reaching an internal service on purpose is a legitimate thing to want on a
+// homelab, so the block is escapable — but only by naming the host, never by
+// turning the check off.
+// ---------------------------------------------------------------------------
+
+import { getSystemSettingRaw } from "@/lib/system-settings";
+import type { OutboundPolicy } from "./ssrf";
+
+/** Comma or newline separated hostnames. A leading "." matches subdomains. */
+const ENV_KEY = "VARDO_OUTBOUND_ALLOWLIST";
+const SETTING_KEY = "outbound_allowlist";
+
+export function parseAllowlist(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/** Env first so an operator can restore access without a working console. */
+export async function getOutboundPolicy(): Promise<OutboundPolicy> {
+  const fromEnv = parseAllowlist(process.env[ENV_KEY]);
+  if (fromEnv.length > 0) return { allowlist: fromEnv };
+
+  try {
+    return { allowlist: parseAllowlist(await getSystemSettingRaw(SETTING_KEY)) };
+  } catch {
+    return { allowlist: [] };
+  }
+}

--- a/lib/security/safe-fetch.ts
+++ b/lib/security/safe-fetch.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// Outbound fetch
+//
+// Vetting a URL once is not enough when redirects are followed: a public host
+// answering 302 to http://169.254.169.254/ walks straight through a check that
+// only looked at what the operator typed. Redirects are followed here instead,
+// one hop at a time, each vetted like the first.
+// ---------------------------------------------------------------------------
+
+import { assertOutboundUrlAllowed, BlockedUrlError, type OutboundPolicy } from "./ssrf";
+
+const MAX_REDIRECTS = 5;
+
+/** Headers that must not survive a hop to a different host. */
+const SENSITIVE_HEADERS = ["authorization", "cookie", "x-signature-256", "x-vardo-signature"];
+
+function stripSensitive(headers: Headers): Headers {
+  const next = new Headers(headers);
+  for (const name of SENSITIVE_HEADERS) next.delete(name);
+  return next;
+}
+
+export type SafeFetchOptions = RequestInit & {
+  policy?: OutboundPolicy;
+  maxRedirects?: number;
+};
+
+/**
+ * fetch() that refuses to reach private, loopback or link-local addresses, on
+ * the first request and on every redirect it follows.
+ *
+ * A redirect that changes host drops credentials and signatures — the new host
+ * was not who the payload was signed for.
+ */
+export async function safeFetch(
+  rawUrl: string,
+  options: SafeFetchOptions = {},
+): Promise<Response> {
+  const { policy, maxRedirects = MAX_REDIRECTS, ...init } = options;
+
+  let url = await assertOutboundUrlAllowed(rawUrl, policy);
+  let method = init.method ?? "GET";
+  let body = init.body;
+  let headers = new Headers(init.headers);
+
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const response = await fetch(url.toString(), { ...init, method, body, headers, redirect: "manual" });
+
+    const location = response.headers.get("location");
+    if (response.status < 300 || response.status > 399 || !location) {
+      return response;
+    }
+
+    if (hop === maxRedirects) {
+      throw new BlockedUrlError(`Too many redirects from ${rawUrl} (stopped after ${maxRedirects})`);
+    }
+
+    let next: URL;
+    try {
+      next = new URL(location, url);
+    } catch {
+      throw new BlockedUrlError(`Redirect to an unreadable location: ${location}`);
+    }
+
+    const validated = await assertOutboundUrlAllowed(next.toString(), policy);
+
+    if (validated.host !== url.host) headers = stripSensitive(headers);
+
+    // 303 always becomes GET; 301 and 302 do so for anything that was not one,
+    // matching what every other client does. 307 and 308 keep method and body.
+    if (response.status === 303 || ((response.status === 301 || response.status === 302) && method !== "GET" && method !== "HEAD")) {
+      method = "GET";
+      body = undefined;
+      headers.delete("content-type");
+      headers.delete("content-length");
+    }
+
+    url = validated;
+  }
+
+  // The loop returns or throws; this satisfies the compiler.
+  throw new BlockedUrlError(`Too many redirects from ${rawUrl}`);
+}

--- a/lib/security/ssrf.ts
+++ b/lib/security/ssrf.ts
@@ -1,0 +1,252 @@
+// ---------------------------------------------------------------------------
+// Outbound URL policy
+//
+// Webhooks, url-type cron jobs and hook callbacks all fetch a URL somebody
+// typed into a form. Without a check that reaches the cloud metadata service
+// and every host on the internal network — a boundary the person setting the
+// URL has no account on.
+//
+// Addresses are judged after DNS resolution, so decimal, octal and hex host
+// encodings (http://2130706433/) need no special handling: they resolve to the
+// address they always meant, and the address is what gets checked.
+// ---------------------------------------------------------------------------
+
+import { lookup } from "dns/promises";
+
+/** An outbound request that policy refuses to make. */
+export class BlockedUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BlockedUrlError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Address parsing
+// ---------------------------------------------------------------------------
+
+/** Parse dotted-quad IPv4 into 4 bytes, or null if it is not one. */
+export function parseIPv4(address: string): number[] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  const bytes: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    bytes.push(n);
+  }
+  return bytes;
+}
+
+/**
+ * Parse IPv6 into 16 bytes, expanding `::`. Returns null if it is not one.
+ *
+ * IPv4-mapped and NAT64 forms keep their trailing dotted quad, which lands in
+ * the last four bytes — exactly where the mapped-address check looks for it.
+ */
+export function parseIPv6(address: string): number[] | null {
+  let text = address;
+  const zone = text.indexOf("%");
+  if (zone !== -1) text = text.slice(0, zone);
+
+  const halves = text.split("::");
+  if (halves.length > 2) return null;
+
+  const expand = (part: string): number[] | null => {
+    if (part === "") return [];
+    const bytes: number[] = [];
+    for (const group of part.split(":")) {
+      const quad = parseIPv4(group);
+      if (quad) {
+        bytes.push(...quad);
+        continue;
+      }
+      if (!/^[0-9a-fA-F]{1,4}$/.test(group)) return null;
+      const n = Number.parseInt(group, 16);
+      bytes.push((n >> 8) & 0xff, n & 0xff);
+    }
+    return bytes;
+  };
+
+  const head = expand(halves[0]);
+  const tail = halves.length === 2 ? expand(halves[1]) : [];
+  if (head === null || tail === null) return null;
+
+  if (halves.length === 1) return head.length === 16 ? head : null;
+
+  const gap = 16 - head.length - tail.length;
+  if (gap < 1) return null;
+  return [...head, ...new Array(gap).fill(0), ...tail];
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+/** [first byte(s), prefix length, why] — IPv4 ranges that must not be reached. */
+const BLOCKED_V4: { cidr: string; reason: string }[] = [
+  { cidr: "0.0.0.0/8", reason: "this network" },
+  { cidr: "10.0.0.0/8", reason: "private network" },
+  { cidr: "100.64.0.0/10", reason: "carrier-grade NAT (Tailscale)" },
+  { cidr: "127.0.0.0/8", reason: "loopback" },
+  { cidr: "169.254.0.0/16", reason: "link-local — cloud instance metadata" },
+  { cidr: "172.16.0.0/12", reason: "private network" },
+  { cidr: "192.0.0.0/24", reason: "IETF protocol assignments" },
+  { cidr: "192.0.2.0/24", reason: "documentation range" },
+  { cidr: "192.168.0.0/16", reason: "private network" },
+  { cidr: "198.18.0.0/15", reason: "benchmarking range" },
+  { cidr: "198.51.100.0/24", reason: "documentation range" },
+  { cidr: "203.0.113.0/24", reason: "documentation range" },
+  { cidr: "224.0.0.0/4", reason: "multicast" },
+  { cidr: "240.0.0.0/4", reason: "reserved" },
+];
+
+const BLOCKED_V6: { cidr: string; reason: string }[] = [
+  { cidr: "::/128", reason: "unspecified address" },
+  { cidr: "::1/128", reason: "loopback" },
+  { cidr: "fc00::/7", reason: "unique local address" },
+  { cidr: "fe80::/10", reason: "link-local" },
+  { cidr: "ff00::/8", reason: "multicast" },
+  { cidr: "2001:db8::/32", reason: "documentation range" },
+];
+
+function bytesFromCidr(cidr: string): { bytes: number[]; bits: number } {
+  const [addr, len] = cidr.split("/");
+  const bytes = addr.includes(":") ? parseIPv6(addr) : parseIPv4(addr);
+  return { bytes: bytes ?? [], bits: Number(len) };
+}
+
+const V4_RULES = BLOCKED_V4.map((r) => ({ ...r, ...bytesFromCidr(r.cidr) }));
+const V6_RULES = BLOCKED_V6.map((r) => ({ ...r, ...bytesFromCidr(r.cidr) }));
+
+/** Whether `bytes` falls inside the network described by `net`/`bits`. */
+export function inRange(bytes: number[], net: number[], bits: number): boolean {
+  if (bytes.length !== net.length) return false;
+  let remaining = bits;
+  for (let i = 0; i < bytes.length && remaining > 0; i++) {
+    const take = Math.min(8, remaining);
+    const mask = take === 8 ? 0xff : (0xff << (8 - take)) & 0xff;
+    if ((bytes[i] & mask) !== (net[i] & mask)) return false;
+    remaining -= take;
+  }
+  return true;
+}
+
+// Full 16 bytes — inRange compares equal-length arrays, and only the first 96
+// bits are examined. The trailing zeros are padding, not part of the prefix.
+const V4_MAPPED_PREFIX = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0];
+const NAT64_PREFIX = [0, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+/**
+ * Why this address is refused, or null when it may be reached.
+ *
+ * IPv4-mapped (`::ffff:169.254.169.254`) and NAT64 forms are unwrapped and
+ * judged as the IPv4 address they carry. Skipping that unwrap is the standard
+ * way these filters get walked through.
+ */
+export function blockedAddressReason(address: string): string | null {
+  const v4 = parseIPv4(address);
+  if (v4) {
+    for (const rule of V4_RULES) {
+      if (inRange(v4, rule.bytes, rule.bits)) return rule.reason;
+    }
+    return null;
+  }
+
+  const v6 = parseIPv6(address);
+  if (!v6) return "unrecognized address format";
+
+  if (inRange(v6, V4_MAPPED_PREFIX, 96) || inRange(v6, NAT64_PREFIX, 96)) {
+    return blockedAddressReason(v6.slice(12).join("."));
+  }
+
+  for (const rule of V6_RULES) {
+    if (inRange(v6, rule.bytes, rule.bits)) return rule.reason;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// URL checking
+// ---------------------------------------------------------------------------
+
+export type OutboundPolicy = {
+  /**
+   * Hostnames permitted to resolve into a blocked range. Exact match, or a
+   * leading "." for a suffix match. For deliberately reaching an internal
+   * service, which is a legitimate thing to want on a homelab.
+   */
+  allowlist?: string[];
+};
+
+function isAllowlisted(hostname: string, allowlist: string[] | undefined): boolean {
+  if (!allowlist?.length) return false;
+  const host = hostname.toLowerCase();
+  return allowlist.some((entry) => {
+    const e = entry.trim().toLowerCase();
+    if (!e) return false;
+    return e.startsWith(".") ? host === e.slice(1) || host.endsWith(e) : host === e;
+  });
+}
+
+/**
+ * Parse and vet a URL for an outbound request.
+ *
+ * Throws BlockedUrlError for a non-HTTP scheme, a host that will not resolve,
+ * or any resolved address inside a blocked range. **Every** address the host
+ * resolves to is checked — a name with one public and one private record
+ * cannot be used to slip past a first-record-only check.
+ */
+export async function assertOutboundUrlAllowed(
+  raw: string,
+  policy: OutboundPolicy = {},
+): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new BlockedUrlError(`Not a valid URL: ${raw}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new BlockedUrlError(
+      `Refusing ${url.protocol} — only http and https may be requested`,
+    );
+  }
+
+  if (isAllowlisted(url.hostname, policy.allowlist)) return url;
+
+  // A bare address needs no lookup, and passing one to the resolver would only
+  // add a way for it to answer differently.
+  const literal = url.hostname.replace(/^\[|\]$/g, "");
+  if (parseIPv4(literal) || parseIPv6(literal)) {
+    const reason = blockedAddressReason(literal);
+    if (reason) {
+      throw new BlockedUrlError(`Refusing to reach ${literal} — ${reason}`);
+    }
+    return url;
+  }
+
+  let resolved: { address: string }[];
+  try {
+    resolved = await lookup(url.hostname, { all: true });
+  } catch {
+    throw new BlockedUrlError(`Could not resolve ${url.hostname}`);
+  }
+
+  if (resolved.length === 0) {
+    throw new BlockedUrlError(`${url.hostname} resolved to no addresses`);
+  }
+
+  for (const { address } of resolved) {
+    const reason = blockedAddressReason(address);
+    if (reason) {
+      throw new BlockedUrlError(
+        `Refusing to reach ${url.hostname} — it resolves to ${address} (${reason})`,
+      );
+    }
+  }
+
+  return url;
+}

--- a/tests/unit/api/route-authorization.test.ts
+++ b/tests/unit/api/route-authorization.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+// ---------------------------------------------------------------------------
+// Every org-scoped route must establish who is asking before it answers.
+//
+// This is a guard against drift, not a proof of correctness — it checks that a
+// check exists, not that it guards the right thing. A new route under
+// /organizations that forgets one fails here rather than in production.
+// ---------------------------------------------------------------------------
+
+const ROUTES_DIR = join(process.cwd(), "app/api/v1/organizations");
+
+const ACCESS_CHECKS = [
+  "verifyOrgAccess",
+  "verifyAppAccess",
+  "verifyProjectAccess",
+  "verifyAccess",
+  "requireAdmin",
+];
+
+/**
+ * Routes that legitimately have no orgId to check, with the reason each is
+ * safe. Adding to this list should take an argument, not a shrug.
+ */
+const EXEMPT: Record<string, string> = {
+  "route.ts": "lists the caller's own organizations — scoped by session, not by a path param",
+  "switch/route.ts": "verifies membership inline before setting the active-org cookie",
+};
+
+function routeFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...routeFiles(full));
+    else if (entry === "route.ts") found.push(full);
+  }
+  return found;
+}
+
+describe("org-scoped API routes", () => {
+  const files = routeFiles(ROUTES_DIR);
+
+  it("finds routes to check, so a bad path cannot make this vacuously pass", () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it.each(files.map((f) => [relative(ROUTES_DIR, f), f]))(
+    "%s establishes access",
+    (rel, full) => {
+      if (rel in EXEMPT) {
+        expect(EXEMPT[rel]).toBeTruthy();
+        return;
+      }
+      const source = readFileSync(full, "utf8");
+      const hasCheck = ACCESS_CHECKS.some((fn) => source.includes(fn));
+      expect(hasCheck, `${rel} calls none of: ${ACCESS_CHECKS.join(", ")}`).toBe(true);
+    },
+  );
+
+  it("keeps the exemption list from outliving the routes it describes", () => {
+    const present = new Set(files.map((f) => relative(ROUTES_DIR, f)));
+    for (const rel of Object.keys(EXEMPT)) {
+      expect(present.has(rel), `${rel} is exempted but no longer exists`).toBe(true);
+    }
+  });
+});

--- a/tests/unit/lib/git-integration/pull-request.test.ts
+++ b/tests/unit/lib/git-integration/pull-request.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { previewRefusalReason } from "@/lib/git-integration/pull-request";
+
+describe("previewRefusalReason", () => {
+  it("allows a branch of the base repository", () => {
+    expect(
+      previewRefusalReason({
+        baseRepoFullName: "joeyyax/vardo",
+        headRepoFullName: "joeyyax/vardo",
+        headIsFork: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses a fork, which anyone with an account can open", () => {
+    expect(
+      previewRefusalReason({
+        baseRepoFullName: "joeyyax/vardo",
+        headRepoFullName: "outsider/vardo",
+        headIsFork: true,
+      }),
+    ).toMatch(/comes from a fork/);
+  });
+
+  it("refuses on the repo names alone when the fork flag is absent", () => {
+    expect(
+      previewRefusalReason({
+        baseRepoFullName: "joeyyax/vardo",
+        headRepoFullName: "outsider/vardo",
+      }),
+    ).toMatch(/outsider\/vardo/);
+  });
+
+  it("trusts the fork flag over matching names", () => {
+    expect(
+      previewRefusalReason({
+        baseRepoFullName: "joeyyax/vardo",
+        headRepoFullName: "joeyyax/vardo",
+        headIsFork: true,
+      }),
+    ).toMatch(/comes from a fork/);
+  });
+
+  it("compares repository names case-insensitively", () => {
+    expect(
+      previewRefusalReason({
+        baseRepoFullName: "JoeyYax/Vardo",
+        headRepoFullName: "joeyyax/vardo",
+        headIsFork: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses when the head repository is gone, since nothing identifies the source", () => {
+    expect(previewRefusalReason({ baseRepoFullName: "joeyyax/vardo", headRepoFullName: null })).toMatch(
+      /head repository is unknown/,
+    );
+  });
+
+  it("refuses when the base repository is missing", () => {
+    expect(previewRefusalReason({ baseRepoFullName: "", headRepoFullName: "joeyyax/vardo" })).toMatch(
+      /base repository is unknown/,
+    );
+  });
+});

--- a/tests/unit/lib/hooks/execute.test.ts
+++ b/tests/unit/lib/hooks/execute.test.ts
@@ -62,6 +62,12 @@ vi.mock("util", async (importOriginal) => {
 // Global fetch mock
 vi.stubGlobal("fetch", mockFetch);
 
+// executeWebhook now vets the URL before fetching. Resolve every test host to a
+// public address so these stay tests of hook behavior, not of the SSRF guard.
+vi.mock("dns/promises", () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
+}));
+
 // ---------------------------------------------------------------------------
 // Subject under test
 // ---------------------------------------------------------------------------
@@ -300,8 +306,8 @@ describe("executeHooks", () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toBe("https://hooks.example.com/check");
       expect(opts.method).toBe("POST");
-      expect(opts.headers["Content-Type"]).toBe("application/json");
-      expect(opts.headers["X-Hook-Signature-256"]).toMatch(/^sha256=[a-f0-9]{64}$/);
+      expect(new Headers(opts.headers).get("content-type")).toBe("application/json");
+      expect(new Headers(opts.headers).get("x-hook-signature-256")).toMatch(/^sha256=[a-f0-9]{64}$/);
       expect(JSON.parse(opts.body)).toEqual(context);
     });
 
@@ -314,7 +320,7 @@ describe("executeHooks", () => {
       await executeHooks("before.deploy", {});
 
       const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["X-Hook-Signature-256"]).toBeUndefined();
+      expect(new Headers(opts.headers).get("x-hook-signature-256")).toBeNull();
     });
   });
 

--- a/tests/unit/lib/security/safe-fetch.test.ts
+++ b/tests/unit/lib/security/safe-fetch.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+vi.mock("dns/promises", () => ({ lookup: lookupMock }));
+
+const { safeFetch } = await import("@/lib/security/safe-fetch");
+const { BlockedUrlError } = await import("@/lib/security/ssrf");
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+/** A redirect response the way undici hands one back in manual mode. */
+function redirect(status: number, location: string): Response {
+  return new Response(null, { status, headers: { location } });
+}
+
+beforeEach(() => {
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  fetchMock.mockReset();
+});
+
+describe("safeFetch", () => {
+  it("passes a plain request through", async () => {
+    fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    const res = await safeFetch("https://example.com/hook", { method: "POST", body: "{}" });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never lets fetch follow redirects itself", async () => {
+    fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/");
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual" });
+  });
+
+  it("refuses the request outright when the first URL is blocked", async () => {
+    await expect(safeFetch("http://169.254.169.254/")).rejects.toThrow(BlockedUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks a redirect into link-local — the bypass a one-time check misses", async () => {
+    fetchMock.mockResolvedValueOnce(redirect(302, "http://169.254.169.254/latest/meta-data/"));
+    await expect(safeFetch("https://example.com/")).rejects.toThrow(/metadata/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a redirect to a name that resolves privately", async () => {
+    fetchMock.mockResolvedValueOnce(redirect(301, "https://internal.example.com/"));
+    lookupMock.mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }]);
+    lookupMock.mockResolvedValueOnce([{ address: "10.0.0.19", family: 4 }]);
+    await expect(safeFetch("https://example.com/")).rejects.toThrow(/private/);
+  });
+
+  it("follows a permitted redirect", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(302, "https://elsewhere.example.com/x"))
+      .mockResolvedValueOnce(new Response("landed", { status: 200 }));
+    const res = await safeFetch("https://example.com/");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("landed");
+  });
+
+  it("resolves a relative redirect against the current URL", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(302, "/next"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/first");
+    expect(String(fetchMock.mock.calls[1][0])).toBe("https://example.com/next");
+  });
+
+  it("drops the signature when a redirect changes host", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(307, "https://other.example.com/"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/", {
+      method: "POST",
+      body: "{}",
+      headers: { "X-Signature-256": "sha256=secret", "Content-Type": "application/json" },
+    });
+    const forwarded = fetchMock.mock.calls[1][1].headers as Headers;
+    expect(forwarded.get("x-signature-256")).toBeNull();
+    expect(forwarded.get("content-type")).toBe("application/json");
+  });
+
+  it("keeps the signature on a same-host redirect", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(307, "https://example.com/moved"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/", {
+      method: "POST",
+      headers: { "X-Signature-256": "sha256=secret" },
+    });
+    const forwarded = fetchMock.mock.calls[1][1].headers as Headers;
+    expect(forwarded.get("x-signature-256")).toBe("sha256=secret");
+  });
+
+  it("turns a redirected POST into a GET for 303, dropping the body", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(303, "https://example.com/done"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/", { method: "POST", body: "{}" });
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: "GET", body: undefined });
+  });
+
+  it("keeps method and body across a 307", async () => {
+    fetchMock
+      .mockResolvedValueOnce(redirect(307, "https://example.com/done"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    await safeFetch("https://example.com/", { method: "POST", body: "{}" });
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: "POST", body: "{}" });
+  });
+
+  it("gives up rather than looping forever", async () => {
+    fetchMock.mockResolvedValue(redirect(302, "https://example.com/again"));
+    await expect(safeFetch("https://example.com/", { maxRedirects: 3 })).rejects.toThrow(/Too many redirects/);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns a 3xx that carries no Location rather than treating it as a redirect", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 304 }));
+    const res = await safeFetch("https://example.com/");
+    expect(res.status).toBe(304);
+  });
+});

--- a/tests/unit/lib/security/ssrf.test.ts
+++ b/tests/unit/lib/security/ssrf.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+vi.mock("dns/promises", () => ({ lookup: lookupMock }));
+
+const { parseIPv4, parseIPv6, blockedAddressReason, assertOutboundUrlAllowed, BlockedUrlError } =
+  await import("@/lib/security/ssrf");
+
+beforeEach(() => {
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+describe("parseIPv4", () => {
+  it("reads a dotted quad", () => {
+    expect(parseIPv4("192.168.1.1")).toEqual([192, 168, 1, 1]);
+  });
+
+  it("rejects what only looks like one", () => {
+    expect(parseIPv4("256.1.1.1")).toBeNull();
+    expect(parseIPv4("1.2.3")).toBeNull();
+    expect(parseIPv4("1.2.3.4.5")).toBeNull();
+    expect(parseIPv4("0x7f.0.0.1")).toBeNull();
+    expect(parseIPv4("example.com")).toBeNull();
+  });
+});
+
+describe("parseIPv6", () => {
+  it("expands ::", () => {
+    expect(parseIPv6("::1")).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+  });
+
+  it("reads a full address", () => {
+    expect(parseIPv6("2001:0db8:0000:0000:0000:0000:0000:0001")?.slice(0, 4)).toEqual([0x20, 0x01, 0x0d, 0xb8]);
+  });
+
+  it("keeps a trailing dotted quad in the last four bytes", () => {
+    expect(parseIPv6("::ffff:169.254.169.254")?.slice(12)).toEqual([169, 254, 169, 254]);
+  });
+
+  it("drops a zone id", () => {
+    expect(parseIPv6("fe80::1%eth0")?.slice(0, 2)).toEqual([0xfe, 0x80]);
+  });
+
+  it("rejects nonsense", () => {
+    expect(parseIPv6("::1::2")).toBeNull();
+    expect(parseIPv6("gggg::1")).toBeNull();
+    expect(parseIPv6("1.2.3.4")).toBeNull();
+  });
+});
+
+describe("blockedAddressReason", () => {
+  it("blocks the cloud metadata address", () => {
+    expect(blockedAddressReason("169.254.169.254")).toMatch(/metadata/);
+  });
+
+  it("blocks loopback, private and CGNAT ranges", () => {
+    expect(blockedAddressReason("127.0.0.1")).toMatch(/loopback/);
+    expect(blockedAddressReason("10.0.0.19")).toMatch(/private/);
+    expect(blockedAddressReason("172.16.0.1")).toMatch(/private/);
+    expect(blockedAddressReason("172.31.255.255")).toMatch(/private/);
+    expect(blockedAddressReason("192.168.1.1")).toMatch(/private/);
+    expect(blockedAddressReason("100.64.0.1")).toMatch(/Tailscale/);
+  });
+
+  it("lets a public address through", () => {
+    expect(blockedAddressReason("93.184.216.34")).toBeNull();
+    expect(blockedAddressReason("8.8.8.8")).toBeNull();
+    // 172.32 is outside 172.16/12 — the boundary a hand-rolled check gets wrong.
+    expect(blockedAddressReason("172.32.0.1")).toBeNull();
+    expect(blockedAddressReason("100.128.0.1")).toBeNull();
+  });
+
+  it("blocks IPv6 loopback and unique-local", () => {
+    expect(blockedAddressReason("::1")).toMatch(/loopback/);
+    expect(blockedAddressReason("fd00::1")).toMatch(/unique local/);
+    expect(blockedAddressReason("fe80::1")).toMatch(/link-local/);
+  });
+
+  it("unwraps IPv4-mapped IPv6 — the standard way past this filter", () => {
+    expect(blockedAddressReason("::ffff:169.254.169.254")).toMatch(/metadata/);
+    expect(blockedAddressReason("::ffff:127.0.0.1")).toMatch(/loopback/);
+    expect(blockedAddressReason("::ffff:10.0.0.1")).toMatch(/private/);
+  });
+
+  it("unwraps NAT64", () => {
+    expect(blockedAddressReason("64:ff9b::169.254.169.254")).toMatch(/metadata/);
+  });
+
+  it("blocks the EC2 IPv6 metadata address via unique-local", () => {
+    expect(blockedAddressReason("fd00:ec2::254")).toMatch(/unique local/);
+  });
+
+  it("refuses an address it cannot parse rather than allowing it", () => {
+    expect(blockedAddressReason("not-an-address")).toMatch(/unrecognized/);
+  });
+});
+
+describe("assertOutboundUrlAllowed", () => {
+  it("allows a public https URL", async () => {
+    await expect(assertOutboundUrlAllowed("https://example.com/hook")).resolves.toBeInstanceOf(URL);
+  });
+
+  it("refuses a non-HTTP scheme", async () => {
+    await expect(assertOutboundUrlAllowed("file:///etc/passwd")).rejects.toThrow(BlockedUrlError);
+    await expect(assertOutboundUrlAllowed("gopher://x/")).rejects.toThrow(/only http and https/);
+  });
+
+  it("refuses a literal private address without asking DNS", async () => {
+    await expect(assertOutboundUrlAllowed("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(/metadata/);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a bracketed IPv6 literal", async () => {
+    await expect(assertOutboundUrlAllowed("http://[::1]:8080/")).rejects.toThrow(/loopback/);
+  });
+
+  it("blocks a decimal-encoded host once resolved", async () => {
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+    await expect(assertOutboundUrlAllowed("http://2130706433/")).rejects.toThrow(/loopback/);
+  });
+
+  it("blocks a name that resolves into a private range — DNS rebinding", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.19", family: 4 }]);
+    await expect(assertOutboundUrlAllowed("https://evil.example.com/")).rejects.toThrow(/private/);
+  });
+
+  it("checks every record, not just the first", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "169.254.169.254", family: 4 },
+    ]);
+    await expect(assertOutboundUrlAllowed("https://split.example.com/")).rejects.toThrow(/metadata/);
+  });
+
+  it("refuses a host that will not resolve", async () => {
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(assertOutboundUrlAllowed("https://nope.invalid/")).rejects.toThrow(/Could not resolve/);
+  });
+
+  it("honors an allowlist entry, since reaching an internal service on purpose is legitimate", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.19", family: 4 }]);
+    await expect(
+      assertOutboundUrlAllowed("http://ntfy.internal/topic", { allowlist: ["ntfy.internal"] }),
+    ).resolves.toBeInstanceOf(URL);
+  });
+
+  it("matches an allowlist suffix entry only on the suffix", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.19", family: 4 }]);
+    await expect(
+      assertOutboundUrlAllowed("http://a.lab.internal/", { allowlist: [".lab.internal"] }),
+    ).resolves.toBeInstanceOf(URL);
+    await expect(
+      assertOutboundUrlAllowed("http://notlab.internal/", { allowlist: [".lab.internal"] }),
+    ).rejects.toThrow(/private/);
+  });
+
+  it("does not let an allowlist entry match a lookalike domain", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.19", family: 4 }]);
+    await expect(
+      assertOutboundUrlAllowed("http://ntfy.internal.evil.com/", { allowlist: ["ntfy.internal"] }),
+    ).rejects.toThrow(/private/);
+  });
+});


### PR DESCRIPTION
Part of #788.

## SSRF — the one with a deadline

Webhook channels, `url`-type cron jobs and hook callbacks all fetched a URL somebody typed into a form, with no check on where it pointed. On a public VPS that reaches `169.254.169.254` and every service on the internal network. Unlike the shell surfaces in #788, this crosses a real boundary: a low-privilege user reaching infrastructure they have no account on.

`lib/security/ssrf.ts` judges **resolved addresses**, which is what makes the encoding tricks a non-issue — `http://2130706433/` resolves to `127.0.0.1` and is refused as loopback without needing a special case.

What it handles that a first-draft version usually does not:

- **IPv4-mapped and NAT64 unwrapping.** `::ffff:169.254.169.254` is the standard way past this kind of filter. There is a test for it, and it caught a real bug during development — the mapped-prefix arrays were 12 bytes against a 16-byte address, so the length check in `inRange` short-circuited and the address sailed through.
- **Every DNS record, not just the first.** A name answering with one public and one private address cannot be used to slip past.
- **Literals are never sent to the resolver**, so it cannot answer differently the second time.
- **An unparseable address is refused**, not allowed.
- CGNAT (`100.64.0.0/10`) is blocked — that is the Tailscale range, and reaching it unintentionally is exactly the problem.

## Redirects — the less obvious half

`lib/cron/engine.ts` passed `redirect: "follow"`. Vetting the first URL is worthless against a public host that answers 302 to the metadata service.

`safeFetch` sets `redirect: "manual"` and follows hops itself, vetting each one. A hop that changes host drops `Authorization`, `Cookie` and signature headers — the new host is not who the payload was signed for. Method and body follow the usual 301/302/303 vs 307/308 rules.

## Fork PRs no longer build

Webhook signature verification is solid — timing-safe, length-checked first, no fallback to a shared secret. So a fork PR payload is **authentic**; the question was what Vardo did with it.

It read `pr.head.ref` and never checked `pr.head.repo.fork`. It passes the *base* repo name to the preview, so most fork PRs failed at clone rather than building attacker code — accidental, not designed. What it did allow: any GitHub user opening a fork PR against a public repo could trigger deploy attempts, and if their branch name matched one in the base repo, get a preview of that internal branch deployed and its URL posted on their PR.

Teardown is deliberately left above the check, so a PR that becomes a fork after a preview exists still gets cleaned up.

## Authorization surface pinned

The audit found 93 org-scoped routes with a `verify*` call on every one except `/organizations` and `/organizations/switch`, and switch checks membership inline. That was already right — this just stops it drifting. The exemption list requires a written reason, and a second test fails if an exemption outlives the route it describes.

## Escape hatch

Reaching an internal service on purpose is legitimate on a homelab, so `VARDO_OUTBOUND_ALLOWLIST` (or the `outbound_allowlist` setting) permits named hosts. Env is read first so access can be restored without a working console. A `.suffix` entry matches subdomains, and there is a test that `ntfy.internal` does not match `ntfy.internal.evil.com`.

## Verification

4165 tests / 286 files green, 0 lint errors, typecheck clean. 73 new tests. Nothing on the homelab uses any of these paths today — zero notification channels, zero cron jobs — so strict defaults break nothing.

Three existing hooks tests needed updating: that module now vets URLs before fetching, so they mock DNS, and header assertions read through `Headers` since `safeFetch` normalizes them.