### PR TITLE
Select on durability, and recognize Postgres under its other names

### DIFF
--- a/lib/backups/durability.ts
+++ b/lib/backups/durability.ts
@@ -39,6 +39,22 @@ export function isBackupCandidate(durability: Durability | null | undefined): bo
   return durability !== "rebuildable" && durability !== "external";
 }
 
+/**
+ * Whether a backup job covers this volume.
+ *
+ * `persistent` means "survives a deploy", which is not the same question — a
+ * bind-mounted database is `persistent = false` because there is nothing to
+ * externalize, and is still the least replaceable thing on the host. An
+ * explicit `stateful` is therefore sufficient on its own: someone said the word.
+ */
+export function isBackupSelected(vol: {
+  persistent: boolean;
+  durability: Durability | null | undefined;
+}): boolean {
+  if (!isBackupCandidate(vol.durability)) return false;
+  return vol.durability === "stateful" || vol.persistent;
+}
+
 /** Why a volume was left out of a run. Null when it was captured. */
 export function exclusionReason(durability: Durability | null | undefined): string | null {
   if (durability === "rebuildable") return "Rebuildable — reconstructed rather than restored";
@@ -55,7 +71,15 @@ const DATABASE_SIGNATURES: {
   image: RegExp;
   dataDir: string;
 }[] = [
-  { kind: "postgres", image: /(^|\/)(postgres|postgis|timescale|pgvector)/i, dataDir: "/var/lib/postgresql/data" },
+  // Postgres ships under a lot of names that do not contain "postgres" —
+  // immich runs tensorchord/pgvecto-rs. The data directory alone is not enough
+  // to decide: a sidecar mounting it would be proposed as the database and its
+  // dump would target the wrong container.
+  {
+    kind: "postgres",
+    image: /(^|\/)(postgres|postgis|timescale|pgvector|pgvecto|citus|supabase|paradedb|pgautoupgrade|cloudnative-pg)/i,
+    dataDir: "/var/lib/postgresql/data",
+  },
   { kind: "mariadb", image: /(^|\/)(mariadb|percona)/i, dataDir: "/var/lib/mysql" },
   { kind: "mysql", image: /(^|\/)mysql/i, dataDir: "/var/lib/mysql" },
   { kind: "mongo", image: /(^|\/)mongo/i, dataDir: "/data/db" },

--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -18,7 +18,7 @@ import type { BackupStorage } from "./storage-port";
 import { createBackupStorage } from "./storage-factory";
 import { assertSafeName } from "@/lib/docker/validate";
 import { isUncapturedSource, uncapturedReason } from "./coverage";
-import { exclusionReason } from "./durability";
+import { exclusionReason, isBackupSelected } from "./durability";
 import { buildDumpArgv, buildRestoreArgv, describeDumpSpec, type DumpSpec } from "./dump-spec";
 import { resolveDbContainer } from "./resolve-db-container";
 import {
@@ -481,7 +481,7 @@ export async function runBackup(
     const appVolumes = await db.query.volumes.findMany({
       where: eq(volumes.appId, app.id),
     });
-    const persistentVols = appVolumes.filter((v) => v.persistent);
+    const persistentVols = appVolumes.filter(isBackupSelected);
 
     for (const vol of persistentVols) {
       // Classified as reconstructible or held elsewhere. Not a skip — the job

--- a/tests/unit/lib/backups/durability.test.ts
+++ b/tests/unit/lib/backups/durability.test.ts
@@ -4,6 +4,7 @@ import {
   exclusionReason,
   proposeDurability,
   isSafeToApply,
+  isBackupSelected,
 } from "@/lib/backups/durability";
 
 describe("isBackupCandidate", () => {
@@ -134,5 +135,61 @@ describe("isSafeToApply", () => {
     expect(isSafeToApply("rebuildable", "stateful")).toBe(false);
     expect(isSafeToApply("external", "stateful")).toBe(false);
     expect(isSafeToApply("stateful", "stateful")).toBe(false);
+  });
+});
+
+describe("isBackupSelected", () => {
+  const sel = (persistent: boolean, durability: Parameters<typeof isBackupSelected>[0]["durability"]) =>
+    isBackupSelected({ persistent, durability });
+
+  it("covers a persistent, unclassified volume — the behavior that predates durability", () => {
+    expect(sel(true, null)).toBe(true);
+  });
+
+  it("covers a stateful volume even when it is not persistent", () => {
+    // A bind-mounted database: persistent = false because there is nothing to
+    // externalize, and the least replaceable thing on the host.
+    expect(sel(false, "stateful")).toBe(true);
+  });
+
+  it("leaves out rebuildable and external regardless of persistence", () => {
+    expect(sel(true, "rebuildable")).toBe(false);
+    expect(sel(true, "external")).toBe(false);
+    expect(sel(false, "rebuildable")).toBe(false);
+  });
+
+  it("leaves out a non-persistent volume nobody has classified", () => {
+    expect(sel(false, null)).toBe(false);
+  });
+});
+
+describe("proposeDurability — Postgres under other names", () => {
+  it("recognizes a Postgres distribution that does not say postgres", () => {
+    // immich ships tensorchord/pgvecto-rs; matching the image name misses it.
+    expect(
+      proposeDurability({ image: "tensorchord/pgvecto-rs:pg16-v0.2.0", mountPath: "/var/lib/postgresql/data" }),
+    ).toMatchObject({ durability: "stateful", kind: "postgres" });
+  });
+
+  it("recognizes supabase and citus the same way", () => {
+    for (const image of ["supabase/postgres:15.1", "citusdata/citus:12"]) {
+      expect(proposeDurability({ image, mountPath: "/var/lib/postgresql/data" })).toMatchObject({
+        kind: "postgres",
+      });
+    }
+  });
+
+  it("still tells mariadb from mysql, which share a data directory", () => {
+    expect(proposeDurability({ image: "mariadb:11", mountPath: "/var/lib/mysql" })).toMatchObject({ kind: "mariadb" });
+    expect(proposeDurability({ image: "mysql:8", mountPath: "/var/lib/mysql" })).toMatchObject({ kind: "mysql" });
+  });
+
+  it("still refuses a database image mounted somewhere that is not its data", () => {
+    expect(proposeDurability({ image: "postgres:16", mountPath: "/backups" })).toBeNull();
+  });
+
+  it("does not let the data directory alone decide — a sidecar is not the database", () => {
+    // Proposing here would point the dump spec at whatever mounts the volume.
+    expect(proposeDurability({ image: "alpine:3.20", mountPath: "/var/lib/postgresql/data" })).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #790.

## Selection

`engine.ts` filtered on `persistent`, which answers "survives a deploy". A bind-mounted database is `persistent = false` because there is nothing to externalize — and is the least replaceable thing on the host. That is the #784 conflation from the other side.

`isBackupSelected` makes an explicit `stateful` sufficient on its own. Someone said the word; that should be enough.

This is what left five live databases uncovered — authentik, gitea, immich, outline, paperless. Identity provider, git hosting, photos, documents, wiki.

## Detection

immich runs `tensorchord/pgvecto-rs`. Nothing in that image name says "postgres", so the detector missed it.

I first tried letting the **data directory** decide, on the theory that only Postgres uses `/var/lib/postgresql/data`. Two existing tests caught why that is wrong, and I am glad they existed: it made `postgres:16` mounted at `/backups` propose a dump, and it made **`alpine` mounted at the Postgres data directory** propose one too. The second is the dangerous case — post-deploy derives the spec's `service` from whichever container mounts the volume, so a backup sidecar would become the dump target and every dump would run against the wrong container.

Widened the image list instead: `pgvecto`, `citus`, `supabase`, `paradedb`, `pgautoupgrade`, `cloudnative-pg`, alongside the existing ones. Less clever, and it keeps both guards. There is now a test asserting the alpine-sidecar case proposes nothing.

## Verification

4215 tests / 288 files green, 0 lint errors, typecheck clean. 9 new tests.

The five specs are already backfilled on the homelab and the generated `pg_dump` argv is confirmed working against the live paperless database — 193 KB gzipped, 488 `DROP` statements, credentials resolved from the container's own environment. What this PR adds is the engine actually selecting them.

Still outstanding: `volume.name` on those five holds the host path (the #760 shape, never repaired), and #786 restore drills are what would truly prove any of it.