### PR TITLE
feat(deploy): bound the BuildKit cache after every deploy

### DIFF
--- a/lib/docker/buildkit.ts
+++ b/lib/docker/buildkit.ts
@@ -70,3 +70,46 @@ export async function assertBuildKitReachable(
       `Or point BUILDKIT_HOST at a daemon you run yourself. Nixpacks needs none of this.`,
   );
 }
+
+/**
+ * Prune BuildKit's own store back to a ceiling, returning the bytes reclaimed.
+ * Nothing else touches it — `docker builder prune` bounds the daemon's cache,
+ * not this one.
+ *
+ * Reclaims nothing and stays silent when the daemon is not reachable, or when
+ * the transport is one this cannot exec into.
+ */
+export async function pruneBuildKitCache(
+  host: string,
+  maxBytes: number,
+  signal?: AbortSignal,
+): Promise<{ spaceReclaimed: number }> {
+  const container = buildKitContainerName(host);
+  if (!container) return { spaceReclaimed: 0 };
+  if (!(await isBuildKitReachable(host, signal))) return { spaceReclaimed: 0 };
+
+  // `--keep-storage` is megabytes, not bytes, and is the daemon's
+  // max-used-space: a ceiling, so the call is already a no-op when under it.
+  const keepStorageMb = Math.max(1, Math.floor(maxBytes / 1e6));
+  const { stdout } = await execFileAsync(
+    "docker",
+    [
+      "exec",
+      container,
+      "buildctl",
+      "prune",
+      "--keep-storage",
+      String(keepStorageMb),
+      // One record size per line. The default output only totals in human units.
+      "--format",
+      "{{.Size}}",
+    ],
+    { timeout: DOCKER_CLEANUP_TIMEOUT, signal },
+  );
+
+  const spaceReclaimed = stdout
+    .split("\n")
+    .reduce((total, line) => total + (Number(line.trim()) || 0), 0);
+
+  return { spaceReclaimed };
+}

--- a/lib/docker/constants.ts
+++ b/lib/docker/constants.ts
@@ -22,6 +22,15 @@ const configuredCacheGb = Number(process.env.VARDO_BUILD_CACHE_MAX_GB);
 export const BUILD_CACHE_MAX_BYTES =
   (Number.isFinite(configuredCacheGb) && configuredCacheGb > 0 ? configuredCacheGb : 10) * 1024 ** 3;
 
+/**
+ * Ceiling BuildKit's own store is pruned back to after every deploy. Separate
+ * from the Docker build cache above — the daemon prune never reaches it.
+ */
+const configuredBuildKitGb = Number(process.env.VARDO_BUILDKIT_CACHE_MAX_GB);
+export const BUILDKIT_CACHE_MAX_BYTES =
+  (Number.isFinite(configuredBuildKitGb) && configuredBuildKitGb > 0 ? configuredBuildKitGb : 10) *
+  1024 ** 3;
+
 // ---------------------------------------------------------------------------
 // Timeouts (milliseconds)
 // ---------------------------------------------------------------------------

--- a/lib/docker/deploy-steps/post-deploy.ts
+++ b/lib/docker/deploy-steps/post-deploy.ts
@@ -42,8 +42,10 @@ import { addEvent } from "@/lib/stream/producer";
 import { recordActivity } from "@/lib/activity";
 import { volumeThreshold } from "@/lib/volumes/threshold";
 import { DeployBlockedError } from "../errors";
+import { pruneBuildKitCache, DEFAULT_BUILDKIT_HOST } from "../buildkit";
 import {
   BUILD_CACHE_MAX_BYTES,
+  BUILDKIT_CACHE_MAX_BYTES,
   COMPOSE_DOWN_TIMEOUT,
   POST_DEPLOY_DELAY,
   DOCKER_CLEANUP_TIMEOUT,
@@ -193,6 +195,23 @@ export async function postDeploy(ctx: DeployContext): Promise<DeployContext> {
           }
         } catch {
           // Build cache pruning is optional
+        }
+
+        try {
+          // Railpack's cache lives in the buildkit daemon's own store, on its
+          // own volume, and the prune above never reaches it.
+          const { spaceReclaimed: buildKitReclaimed } = await pruneBuildKitCache(
+            process.env.BUILDKIT_HOST || DEFAULT_BUILDKIT_HOST,
+            BUILDKIT_CACHE_MAX_BYTES,
+          );
+          if (buildKitReclaimed > 0) {
+            log(
+              `[deploy] BuildKit cache over ${formatBytes(BUILDKIT_CACHE_MAX_BYTES)}, ` +
+                `reclaimed ${formatBytes(buildKitReclaimed)}`,
+            );
+          }
+        } catch {
+          // BuildKit cache pruning is optional
         }
       } finally {
         await releaseLock(PRUNE_LOCK_KEY).catch(() => {});

--- a/lib/docker/deploy-steps/post-deploy.ts
+++ b/lib/docker/deploy-steps/post-deploy.ts
@@ -210,8 +210,11 @@ export async function postDeploy(ctx: DeployContext): Promise<DeployContext> {
                 `reclaimed ${formatBytes(buildKitReclaimed)}`,
             );
           }
-        } catch {
-          // BuildKit cache pruning is optional
+        } catch (err) {
+          // Logged rather than swallowed: buildctl is deprecating
+          // --keep-storage, and a silent failure reads exactly like a cache
+          // that never needed pruning.
+          log(`[deploy] BuildKit cache prune failed: ${err instanceof Error ? err.message : err}`);
         }
       } finally {
         await releaseLock(PRUNE_LOCK_KEY).catch(() => {});

--- a/tests/unit/lib/docker/buildkit.test.ts
+++ b/tests/unit/lib/docker/buildkit.test.ts
@@ -11,9 +11,13 @@ const { execFileMock, calls } = vi.hoisted(() => ({
 
 let response: { stdout: string } | Error = { stdout: "true\n" };
 
+/** Consumed one per call, ahead of `response`, for calls that shell out twice. */
+const queued: ({ stdout: string } | Error)[] = [];
+
 (execFileMock as Record<symbol, unknown>)[promisify.custom] = (...args: unknown[]) => {
   calls.push(args);
-  return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  const next = queued.shift() ?? response;
+  return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
 };
 
 vi.mock("child_process", () => ({ execFile: execFileMock }));
@@ -22,11 +26,13 @@ const {
   assertBuildKitReachable,
   isBuildKitReachable,
   buildKitContainerName,
+  pruneBuildKitCache,
   DEFAULT_BUILDKIT_HOST,
 } = await import("@/lib/docker/buildkit");
 
 beforeEach(() => {
   calls.length = 0;
+  queued.length = 0;
   response = { stdout: "true\n" };
 });
 
@@ -108,5 +114,93 @@ describe("isBuildKitReachable", () => {
   it("takes an uninspectable transport at its word", async () => {
     await expect(isBuildKitReachable("tcp://10.0.0.5:1234")).resolves.toBe(true);
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe("pruneBuildKitCache", () => {
+  /** Running container, then the prune's per-record sizes. */
+  const running = (pruneStdout: string) => {
+    queued.push({ stdout: "true\n" }, { stdout: pruneStdout });
+  };
+
+  it("prunes inside the container the host names", async () => {
+    running("");
+
+    await pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3);
+
+    expect(calls[1][1]).toEqual([
+      "exec",
+      "vardo-buildkit",
+      "buildctl",
+      "prune",
+      "--keep-storage",
+      "10737",
+      "--format",
+      "{{.Size}}",
+    ]);
+  });
+
+  it("passes the ceiling in megabytes, which is what buildctl reads", async () => {
+    running("");
+
+    await pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 2 * 1e9);
+
+    expect(calls[1][1]).toContain("2000");
+  });
+
+  it("never asks for a ceiling of zero", async () => {
+    running("");
+
+    await pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 1024);
+
+    expect(calls[1][1]).toContain("1");
+  });
+
+  it("totals the sizes of the records it reclaimed", async () => {
+    running("1048576\n2097152\n524288\n");
+
+    await expect(pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3)).resolves.toEqual({
+      spaceReclaimed: 3_670_016,
+    });
+  });
+
+  it("reclaims nothing when the cache is already under the ceiling", async () => {
+    running("\n");
+
+    await expect(pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3)).resolves.toEqual({
+      spaceReclaimed: 0,
+    });
+  });
+
+  it("is a no-op, not an error, when the daemon is not running", async () => {
+    response = { stdout: "false\n" };
+
+    await expect(pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3)).resolves.toEqual({
+      spaceReclaimed: 0,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("is a no-op when the container does not exist", async () => {
+    response = new Error("No such object: vardo-buildkit");
+
+    await expect(pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3)).resolves.toEqual({
+      spaceReclaimed: 0,
+    });
+  });
+
+  it("leaves a daemon it cannot exec into alone", async () => {
+    await expect(pruneBuildKitCache("tcp://10.0.0.5:1234", 10 * 1024 ** 3)).resolves.toEqual({
+      spaceReclaimed: 0,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces a prune that fails, for the caller to swallow", async () => {
+    queued.push({ stdout: "true\n" }, new Error("buildctl: not found"));
+
+    await expect(pruneBuildKitCache(DEFAULT_BUILDKIT_HOST, 10 * 1024 ** 3)).rejects.toThrow(
+      /buildctl/,
+    );
   });
 });

--- a/tests/unit/lib/docker/deploy-steps/post-deploy-build-cache.test.ts
+++ b/tests/unit/lib/docker/deploy-steps/post-deploy-build-cache.test.ts
@@ -11,23 +11,27 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // prune is asked for must stay a size and must stay unfiltered.
 // ---------------------------------------------------------------------------
 
-const { dbMock, emitMock, pruneBuildCacheMock, queueDrained, lockAcquired } = vi.hoisted(() => {
-  const emitMock = vi.fn();
-  const pruneBuildCacheMock = vi.fn().mockResolvedValue({ spaceReclaimed: 0 });
-  const queueDrained = vi.fn().mockResolvedValue(true);
-  const lockAcquired = vi.fn().mockResolvedValue(true);
+const { dbMock, emitMock, pruneBuildCacheMock, pruneBuildKitMock, queueDrained, lockAcquired } =
+  vi.hoisted(() => {
+    const emitMock = vi.fn();
+    const pruneBuildCacheMock = vi.fn().mockResolvedValue({ spaceReclaimed: 0 });
+    const pruneBuildKitMock = vi.fn().mockResolvedValue({ spaceReclaimed: 0 });
+    const queueDrained = vi.fn().mockResolvedValue(true);
+    const lockAcquired = vi.fn().mockResolvedValue(true);
 
-  const dbMock = {
-    update: vi.fn().mockImplementation(() => ({ set: () => ({ where: async () => undefined }) })),
-    insert: vi.fn().mockReturnValue({ values: () => ({ onConflictDoNothing: async () => undefined }) }),
-    query: {
-      volumes: { findMany: vi.fn().mockResolvedValue([]) },
-      deployments: { findFirst: vi.fn().mockResolvedValue(null) },
-    },
-  };
+    const dbMock = {
+      update: vi.fn().mockImplementation(() => ({ set: () => ({ where: async () => undefined }) })),
+      insert: vi
+        .fn()
+        .mockReturnValue({ values: () => ({ onConflictDoNothing: async () => undefined }) }),
+      query: {
+        volumes: { findMany: vi.fn().mockResolvedValue([]) },
+        deployments: { findFirst: vi.fn().mockResolvedValue(null) },
+      },
+    };
 
-  return { dbMock, emitMock, pruneBuildCacheMock, queueDrained, lockAcquired };
-});
+    return { dbMock, emitMock, pruneBuildCacheMock, pruneBuildKitMock, queueDrained, lockAcquired };
+  });
 
 vi.mock("@/lib/db", () => ({ db: dbMock }));
 vi.mock("@/lib/redis", () => ({
@@ -57,6 +61,10 @@ vi.mock("@/lib/docker/client", () => ({
   pruneImages: vi.fn().mockResolvedValue({ spaceReclaimed: 0, count: 0 }),
   pruneBuildCache: pruneBuildCacheMock,
 }));
+vi.mock("@/lib/docker/buildkit", () => ({
+  pruneBuildKitCache: pruneBuildKitMock,
+  DEFAULT_BUILDKIT_HOST: "docker-container://vardo-buildkit",
+}));
 vi.mock("@/lib/docker/compose", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/docker/compose")>()),
   slotComposeFiles: vi.fn(async () => ["-f", "docker-compose.yml"]),
@@ -79,7 +87,7 @@ vi.mock("child_process", () => ({
 
 import { postDeploy } from "@/lib/docker/deploy-steps/post-deploy";
 import type { DeployContext } from "@/lib/docker/deploy-context";
-import { BUILD_CACHE_MAX_BYTES } from "@/lib/docker/constants";
+import { BUILD_CACHE_MAX_BYTES, BUILDKIT_CACHE_MAX_BYTES } from "@/lib/docker/constants";
 import { formatBytes } from "@/lib/metrics/format";
 
 function makeContext(overrides: Partial<DeployContext> = {}): DeployContext {
@@ -188,5 +196,56 @@ describe("post-deploy build cache prune", () => {
     await postDeploy(makeContext());
 
     expect(pruneBuildCacheMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("post-deploy BuildKit cache prune", () => {
+  beforeEach(() => {
+    pruneBuildKitMock.mockClear();
+    pruneBuildKitMock.mockResolvedValue({ spaceReclaimed: 0 });
+    queueDrained.mockResolvedValue(true);
+    lockAcquired.mockResolvedValue(true);
+  });
+
+  it("bounds the daemon Railpack builds through", async () => {
+    await postDeploy(makeContext());
+
+    expect(pruneBuildKitMock).toHaveBeenCalledWith(
+      "docker-container://vardo-buildkit",
+      BUILDKIT_CACHE_MAX_BYTES,
+    );
+  });
+
+  it("names the ceiling in the deploy log when it reclaims", async () => {
+    pruneBuildKitMock.mockResolvedValue({ spaceReclaimed: 2 * 1024 ** 3 });
+    const ctx = makeContext();
+
+    await postDeploy(ctx);
+
+    const line = ctx.logLines.find((l) => l.includes("BuildKit cache over"));
+    expect(line).toContain(formatBytes(BUILDKIT_CACHE_MAX_BYTES));
+    expect(line).toContain(formatBytes(2 * 1024 ** 3));
+  });
+
+  it("says nothing when there was nothing to reclaim", async () => {
+    const ctx = makeContext();
+
+    await postDeploy(ctx);
+
+    expect(ctx.logLines.some((l) => l.includes("BuildKit cache"))).toBe(false);
+  });
+
+  it("does not fail the deploy when the prune throws", async () => {
+    pruneBuildKitMock.mockRejectedValue(new Error("buildctl: not found"));
+
+    await expect(postDeploy(makeContext())).resolves.toBeDefined();
+  });
+
+  it("defers behind another prune holding the lock", async () => {
+    lockAcquired.mockResolvedValue(false);
+
+    await postDeploy(makeContext());
+
+    expect(pruneBuildKitMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Part of #777 — the ceiling half, not the rebuild benchmark.

`vardo_buildkit_data` had no cap and reached 2.33 GB in a few days of light use, on the same trajectory the Docker build cache took to 18.75 GB/day before it was bounded. Nothing pruned it.

## What this does

`pruneBuildKitCache` in `lib/docker/buildkit.ts` runs `buildctl prune` inside the buildkit container and returns the bytes reclaimed. `postDeploy` calls it right after the Docker build cache prune, inside the same in-flight check and the same `deploy:prune:lock`, and logs in the existing style:

```
[deploy] BuildKit cache over 10 GB, reclaimed 3.4 GB
```

No-op with no error when the container is not running — it reuses `isBuildKitReachable`, so an instance without the `buildkit` profile is unaffected. A `tcp://` or `unix://` `BUILDKIT_HOST` is somebody's own daemon and is left alone.

## The ceiling

`BUILDKIT_CACHE_MAX_BYTES`, 10 GB, overridable with `VARDO_BUILDKIT_CACHE_MAX_GB` — the same shape as `BUILD_CACHE_MAX_BYTES` / `VARDO_BUILD_CACHE_MAX_GB` next to it. 10 GB matches the sibling because the two caches are alternatives, not additive: Railpack apps fill this one, Nixpacks and Dockerfile apps fill the other. At the observed rate (~0.5 GB per build of a small Node app) that holds roughly twenty builds.

## One correction to the issue

The issue says `buildctl prune --keep-storage <bytes>`. It is **megabytes**, not bytes — `cmd/buildctl/prune.go` declares it `cli.Float64Flag` and multiplies by `1e6`. It maps to the daemon's `MaxUsedSpace`, which is the ceiling semantic we want, so the call is already a no-op when the store is under it.

Reclaimed bytes come from `--format '{{.Size}}'`, one record size per line, summed. The default output only totals in human units (`Total: 3.40GB`), which would mean parsing units back out.

## Tests

`buildctl` argv and the megabyte conversion, the size total, both no-op paths, and the post-deploy wiring: lock deferral, the log line, and that a failing prune does not fail the deploy.

`pnpm typecheck` clean, `pnpm lint` 0 errors, 4261 unit tests pass.

## Still open on #777

Surfacing the BuildKit store size in disk reporting, and whether the maintenance sweep should own this rather than post-deploy.
