### PR TITLE
Scope second-id lookups to the verified tenant

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/tags/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/tags/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError, isUniqueViolation } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { appTags } from "@/lib/db/schema";
+import { appTags, tags } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
 import { verifyAppAccess } from "@/lib/api/verify-access";
@@ -34,6 +34,16 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
         { error: parsed.error.issues[0].message },
         { status: 400 }
       );
+    }
+
+    // The tag id comes straight from the request body — it must be this org's.
+    const tag = await db.query.tags.findFirst({
+      where: and(eq(tags.id, parsed.data.tagId), eq(tags.organizationId, orgId)),
+      columns: { id: true },
+    });
+
+    if (!tag) {
+      return NextResponse.json({ error: "Tag not found" }, { status: 404 });
     }
 
     await db.insert(appTags).values({

--- a/lib/deploy/sweeper.ts
+++ b/lib/deploy/sweeper.ts
@@ -725,7 +725,7 @@ async function refuse(appId: string, envName: string, reason: string): Promise<v
 async function envNameFor(environmentId: string | null, appId: string): Promise<string> {
   if (environmentId) {
     const env = await db.query.environments.findFirst({
-      where: eq(environments.id, environmentId),
+      where: and(eq(environments.id, environmentId), eq(environments.appId, appId)),
       columns: { name: true },
     });
     if (env) return env.name;

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -31,6 +31,7 @@ import {
   ENDPOINT_CHECK_TIMEOUT,
 } from "./constants";
 import { prepareRepo, resolveCompose, build, swap, postDeploy } from "./deploy-steps";
+import { resolveDeployEnv } from "./resolve-env";
 import {
   loadRollbackTarget,
   applyRollbackTarget,
@@ -279,20 +280,10 @@ export async function runDeployment(
       if (defaultEnv) opts.environmentId = defaultEnv.id;
     }
 
-    let envName = "production";
-    let envType: "production" | "staging" | "preview" | "local" = "production";
-    let envBranchOverride: string | null = null;
-    if (opts.environmentId) {
-      const env = await db.query.environments.findFirst({
-        where: eq(environments.id, opts.environmentId),
-        columns: { name: true, type: true, gitBranch: true },
-      });
-      if (env) {
-        envName = env.name;
-        envType = env.type;
-        envBranchOverride = env.gitBranch;
-      }
-    }
+    const resolvedEnv = await resolveDeployEnv(opts.appId, opts.environmentId);
+    const envName = resolvedEnv.name;
+    const envType = resolvedEnv.type;
+    const envBranchOverride = resolvedEnv.gitBranch;
     log(`[deploy] Environment: ${envName} (${envType})`);
 
     // Local environments always allow bind mounts + the docker socket

--- a/lib/docker/resolve-env.ts
+++ b/lib/docker/resolve-env.ts
@@ -2,9 +2,11 @@ import { db } from "@/lib/db";
 import { environments } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 
+export type EnvType = "production" | "staging" | "preview" | "local";
+
 export type ResolvedEnv = {
   name: string;
-  type: "production" | "staging" | "preview" | "local";
+  type: EnvType;
   id: string | null;
 };
 
@@ -19,4 +21,47 @@ export async function resolveDefaultEnv(appId: string): Promise<ResolvedEnv> {
     type: env?.type ?? "production",
     id: env?.id ?? null,
   };
+}
+
+export type DeployEnv = {
+  name: string;
+  type: EnvType;
+  gitBranch: string | null;
+};
+
+type DeployEnvRow = { name: string; type: EnvType; gitBranch: string | null };
+
+/** Injectable loader — the real implementation reads the environments table. */
+export type DeployEnvLoader = (
+  appId: string,
+  environmentId: string,
+) => Promise<DeployEnvRow | null>;
+
+const defaultLoader: DeployEnvLoader = async (appId, environmentId) => {
+  const row = await db.query.environments.findFirst({
+    where: and(eq(environments.id, environmentId), eq(environments.appId, appId)),
+    columns: { name: true, type: true, gitBranch: true },
+  });
+  return row ?? null;
+};
+
+const FALLBACK: DeployEnv = { name: "production", type: "production", gitBranch: null };
+
+/**
+ * Resolve the environment a deploy runs under.
+ *
+ * The id is caller-supplied, so the lookup is scoped to the app being deployed:
+ * an environment on another app — in this org or any other — resolves to
+ * production rather than lending the deploy its name, branch or type. Type
+ * matters most: `local` turns on bind mounts and the Docker socket.
+ */
+export async function resolveDeployEnv(
+  appId: string,
+  environmentId: string | undefined | null,
+  load: DeployEnvLoader = defaultLoader,
+): Promise<DeployEnv> {
+  if (!environmentId) return FALLBACK;
+  const env = await load(appId, environmentId);
+  if (!env) return FALLBACK;
+  return { name: env.name, type: env.type, gitBranch: env.gitBranch };
 }

--- a/tests/unit/api/apps/tags-scope.test.ts
+++ b/tests/unit/api/apps/tags-scope.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/organizations/[orgId]/apps/[appId]/tags
+// ---------------------------------------------------------------------------
+// tagId is caller-supplied. Verifying the app alone is not enough: without an
+// org check on the tag, a member can link another organization's tag to their
+// own app, which then reads that tag's name and color back out of the app list.
+
+type Predicate =
+  | { op: "eq"; col: string; val: unknown }
+  | { op: "and"; parts: Predicate[] };
+
+function matches(row: Record<string, unknown>, pred: Predicate | undefined): boolean {
+  if (!pred) return true;
+  if (pred.op === "and") return pred.parts.every((p) => matches(row, p));
+  return row[pred.col] === pred.val;
+}
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: string, val: unknown) => ({ op: "eq", col, val }),
+  and: (...parts: Predicate[]) => ({ op: "and", parts }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  appTags: { appId: "appId", tagId: "tagId" },
+  tags: { id: "id", organizationId: "organizationId" },
+}));
+
+const { mockTagFindFirst, mockInsertValues } = vi.hoisted(() => ({
+  mockTagFindFirst: vi.fn(),
+  mockInsertValues: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: { tags: { findFirst: mockTagFindFirst } },
+    insert: () => ({ values: mockInsertValues }),
+  },
+}));
+
+vi.mock("@/lib/api/verify-access", () => ({
+  verifyAppAccess: vi.fn().mockResolvedValue({ id: "app-1" }),
+}));
+
+vi.mock("@/lib/api/with-rate-limit", () => ({
+  withRateLimit: (handler: (...args: never[]) => unknown) => handler,
+}));
+
+vi.mock("@/lib/api/error-response", () => ({
+  handleRouteError: (error: unknown) => {
+    throw error;
+  },
+  isUniqueViolation: () => false,
+}));
+
+import { POST } from "@/app/api/v1/organizations/[orgId]/apps/[appId]/tags/route";
+
+// Two tags with the same shape, owned by different organizations.
+const TAG_ROWS = [
+  { id: "tag-mine", organizationId: "org-1" },
+  { id: "tag-foreign", organizationId: "org-2" },
+];
+
+function postTag(tagId: string) {
+  const request = new NextRequest("http://localhost/api/v1/organizations/org-1/apps/app-1/tags", {
+    method: "POST",
+    body: JSON.stringify({ tagId }),
+  });
+  return POST(request, { params: Promise.resolve({ orgId: "org-1", appId: "app-1" }) });
+}
+
+describe("POST /apps/[appId]/tags — tagId scope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInsertValues.mockResolvedValue(undefined);
+    mockTagFindFirst.mockImplementation(({ where }: { where?: Predicate }) =>
+      Promise.resolve(TAG_ROWS.find((row) => matches(row, where)))
+    );
+  });
+
+  it("scopes the tag lookup to the org in the path", async () => {
+    await postTag("tag-mine");
+
+    const { where } = mockTagFindFirst.mock.calls[0][0];
+    expect(where).toEqual({
+      op: "and",
+      parts: [
+        { op: "eq", col: "id", val: "tag-mine" },
+        { op: "eq", col: "organizationId", val: "org-1" },
+      ],
+    });
+  });
+
+  it("links a tag owned by the caller's org", async () => {
+    const response = await postTag("tag-mine");
+
+    expect(response.status).toBe(201);
+    expect(mockInsertValues).toHaveBeenCalledWith({ appId: "app-1", tagId: "tag-mine" });
+  });
+
+  it("refuses a tag owned by another org", async () => {
+    const response = await postTag("tag-foreign");
+
+    expect(response.status).toBe(404);
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tag id that matches nothing", async () => {
+    const response = await postTag("tag-missing");
+
+    expect(response.status).toBe(404);
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/docker/deploy-env-scope.test.ts
+++ b/tests/unit/lib/docker/deploy-env-scope.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// The environmentId on a deploy request is caller-supplied. Resolving it by id
+// alone lets an environment on another app — in another organization — decide
+// the deploy's name, branch and type, and `local` grants bind mounts and the
+// Docker socket.
+// ---------------------------------------------------------------------------
+
+type Predicate =
+  | { op: "eq"; col: string; val: unknown }
+  | { op: "and"; parts: Predicate[] };
+
+function matches(row: Record<string, unknown>, pred: Predicate | undefined): boolean {
+  if (!pred) return true;
+  if (pred.op === "and") return pred.parts.every((p) => matches(row, p));
+  return row[pred.col] === pred.val;
+}
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: string, val: unknown) => ({ op: "eq", col, val }),
+  and: (...parts: Predicate[]) => ({ op: "and", parts }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  environments: { id: "id", appId: "appId", isDefault: "isDefault" },
+}));
+
+const { mockEnvFindFirst } = vi.hoisted(() => ({ mockEnvFindFirst: vi.fn() }));
+
+vi.mock("@/lib/db", () => ({
+  db: { query: { environments: { findFirst: mockEnvFindFirst } } },
+}));
+
+import { resolveDeployEnv, type DeployEnvLoader } from "@/lib/docker/resolve-env";
+
+// Same shape, different owner: one environment on the app being deployed, one
+// on an app the caller has no access to.
+const ENV_ROWS = [
+  { id: "env-own", appId: "app-1", name: "staging", type: "staging", gitBranch: "develop" },
+  { id: "env-foreign", appId: "app-2", name: "sandbox", type: "local", gitBranch: "main" },
+];
+
+const PRODUCTION = { name: "production", type: "production", gitBranch: null };
+
+describe("resolveDeployEnv", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnvFindFirst.mockImplementation(({ where }: { where?: Predicate }) =>
+      Promise.resolve(ENV_ROWS.find((row) => matches(row, where)))
+    );
+  });
+
+  it("scopes the lookup to the app being deployed", async () => {
+    await resolveDeployEnv("app-1", "env-own");
+
+    const { where } = mockEnvFindFirst.mock.calls[0][0];
+    expect(where).toEqual({
+      op: "and",
+      parts: [
+        { op: "eq", col: "id", val: "env-own" },
+        { op: "eq", col: "appId", val: "app-1" },
+      ],
+    });
+  });
+
+  it("resolves an environment belonging to the app being deployed", async () => {
+    await expect(resolveDeployEnv("app-1", "env-own")).resolves.toEqual({
+      name: "staging",
+      type: "staging",
+      gitBranch: "develop",
+    });
+  });
+
+  it("falls back to production for an environment on another app", async () => {
+    await expect(resolveDeployEnv("app-1", "env-foreign")).resolves.toEqual(PRODUCTION);
+  });
+
+  it("does not take the local type from another app's environment", async () => {
+    const env = await resolveDeployEnv("app-1", "env-foreign");
+    expect(env.type).not.toBe("local");
+  });
+
+  it("falls back to production for an id that matches nothing", async () => {
+    await expect(resolveDeployEnv("app-1", "env-missing")).resolves.toEqual(PRODUCTION);
+  });
+
+  it("does not query at all when no environment was named", async () => {
+    const load = vi.fn<DeployEnvLoader>();
+    await expect(resolveDeployEnv("app-1", undefined, load)).resolves.toEqual(PRODUCTION);
+    expect(load).not.toHaveBeenCalled();
+    expect(mockEnvFindFirst).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Part of #788 — the tenant A → tenant B boundary.

`tests/unit/api/route-authorization.test.ts` proves every org-scoped route calls a `verify*` helper. It does not prove the check guards the right thing. This is an audit of the routes that take a **second** id from the path or body, looking for ones that verify the org and then fetch a row by that id without re-scoping it.

## Fixed

**`lib/docker/deploy.ts:285` — environment take-over on deploy.** `POST /apps/[appId]/deploy` passes `body.environmentId` straight through, and the deploy resolved it by id alone:

```ts
const env = await db.query.environments.findFirst({
  where: eq(environments.id, opts.environmentId),
  columns: { name: true, type: true, gitBranch: true },
});
```

Any environment row, on any app, in any organization, could then set the deploy's name (which appears in the deploy log and the on-disk env directory), its git branch, and its type. Type is the one that bites — thirteen lines later:

```ts
if (envType === "local") {
  projectAllowBindMounts = true;
  projectAllowDockerSocket = true;
}
```

Extracted to `resolveDeployEnv` in `lib/docker/resolve-env.ts`, which scopes the lookup to the app being deployed and falls back to production when the id resolves to nothing — the same fallback the old code had for a missing row, so behavior is unchanged for every legitimate caller. The loader is injectable, matching `loadRollbackTarget`.

`lib/deploy/sweeper.ts:728` read the same table the same way, from a deployment row rather than a request. Scoped for consistency; with the deploy fix in place the stored value is always the app's own.

**`app/api/v1/organizations/[orgId]/apps/[appId]/tags/route.ts:39` — foreign tag link.** POST verified the app, then inserted `body.tagId` with no check on the tag:

```ts
await db.insert(appTags).values({ appId, tagId: parsed.data.tagId });
```

`GET /apps` returns `appTags` with the joined tag row, so linking another org's tag reads its name and color back out. Now 404s unless the tag belongs to the org in the path.

## Reported, not changed

**Any member can grant themselves bind mounts and the Docker socket.** `allowBindMounts` and `allowDockerSocket` are admin-only on a project (`projects/[projectId]/route.ts:112`), but `POST /apps/[appId]/environments` accepts `type: "local"` with no role gate, and the deploy branch above turns both on for a local environment. This is member → admin, not tenant → tenant. Left alone because `adopt` defaults every adopted app to a local environment, so the behavior is load-bearing and the fix is a product decision.

**`apps/[appId]/transfer` accepts any `destinationOrgId`.** No membership check on the destination — by design, since the destination has to accept. But `analyzeTransfer` reads the destination org's app names and the response's `frozenRefs` reflects which references failed to resolve, making it an existence oracle for app names in an arbitrary org. It also lets anyone drop a transfer offer into any org's inbox. Both need a known org id.

## Assessment

The isolation model is sound. Ninety-odd routes follow one convention — `and(eq(table.id, id), eq(table.organizationId, orgId))`, or the app-scoped equivalent — and it holds nearly everywhere, including the places most likely to be got wrong: backup job `appIds` and `targetId` from the body, `apps/sort`, batch image updates, group deploys, container import, the MCP tool surface. Where an id is verified and then reused unscoped, it is usually deliberate and safe (`deploy-keys`, `tokens`, `members` all check ownership first and delete by primary key after).

Both findings are the same slip in the same place: a lookup that reached past the tenant boundary because the surrounding route had already established access and the second query looked like a detail. Neither is trivially exploitable — every id is a 21-character nanoid, so both need an id to leak first. Worth fixing on a public server, not worth a callout.

Typecheck, lint (0 errors) and 4257 unit tests pass.
