### PR TITLE
Drill on a rotation instead of only when asked

### DIFF
--- a/lib/backups/drill-schedule.ts
+++ b/lib/backups/drill-schedule.ts
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------
+// Choosing what to drill.
+//
+// A drill costs a container and a download, so they run on a rotation rather
+// than after every backup: pick the archive whose restorability is least
+// known, prove that one, come back tomorrow.
+//
+// Pure — the selection is here, the running is in drill.ts.
+// ---------------------------------------------------------------------------
+
+/** One volume's newest successful backup, and what is known about restoring it. */
+export type DrillCandidate = {
+  backupId: string;
+  /** Groups by what the archive is of, so one drill per volume rather than per run. */
+  volumeKey: string;
+  finishedAt: Date;
+  verifiedAt: Date | null;
+  verifyOutcome: string | null;
+};
+
+/** How long a verification stands before that volume is due again. */
+export const DRILL_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Order candidates by how much a drill would tell us.
+ *
+ * Never drilled comes first — an archive nobody has restored is the one whose
+ * verdict is unknown. Then a previous failure, because a fix should be
+ * confirmed rather than assumed. Then oldest verification.
+ */
+export function drillPriority(c: DrillCandidate, now: Date): number {
+  if (!c.verifiedAt) return 0;
+  if (c.verifyOutcome === "failed") return 1;
+  return now.getTime() - c.verifiedAt.getTime() >= DRILL_INTERVAL_MS ? 2 : 3;
+}
+
+/**
+ * Pick the backups to drill this tick, newest archive per volume.
+ *
+ * Returns at most `limit`, and only candidates that are actually due — a fleet
+ * verified this week schedules nothing rather than re-proving what it knows.
+ */
+export function selectDrillCandidates(
+  candidates: DrillCandidate[],
+  now: Date,
+  limit: number,
+): DrillCandidate[] {
+  const newestPerVolume = new Map<string, DrillCandidate>();
+  for (const c of candidates) {
+    const held = newestPerVolume.get(c.volumeKey);
+    if (!held || c.finishedAt.getTime() > held.finishedAt.getTime()) {
+      newestPerVolume.set(c.volumeKey, c);
+    }
+  }
+
+  return [...newestPerVolume.values()]
+    .map((c) => ({ c, priority: drillPriority(c, now) }))
+    .filter(({ priority }) => priority < 3)
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      // Within a band, the least recently confirmed goes first. An unverified
+      // archive has no verification date, so its own age stands in.
+      const aAge = a.c.verifiedAt ?? a.c.finishedAt;
+      const bAge = b.c.verifiedAt ?? b.c.finishedAt;
+      return aAge.getTime() - bAge.getTime();
+    })
+    .slice(0, limit)
+    .map(({ c }) => c);
+}

--- a/lib/backups/scheduler.ts
+++ b/lib/backups/scheduler.ts
@@ -1,9 +1,14 @@
-import { tickBackupJobs } from "./tick";
+import { tickBackupJobs, tickRestoreDrills } from "./tick";
 import { logger } from "@/lib/logger";
 
 const log = logger.child("backup");
 
 let interval: NodeJS.Timeout | null = null;
+let drillInterval: NodeJS.Timeout | null = null;
+
+// Drills are hourly, not per-minute. Each costs a container and a download,
+// and a verification stands for a week.
+const DRILL_TICK_MS = 60 * 60_000;
 
 export function startBackupScheduler(): void {
   if (interval) return; // Already running
@@ -16,9 +21,22 @@ export function startBackupScheduler(): void {
       log.error("Tick error:", err);
     }
   }, 60_000); // Every minute
+
+  // On its own timer, so a slow drill cannot delay a backup.
+  drillInterval = setInterval(async () => {
+    try {
+      await tickRestoreDrills();
+    } catch (err) {
+      log.error("Drill tick error:", err);
+    }
+  }, DRILL_TICK_MS);
 }
 
 export function stopBackupScheduler(): void {
+  if (drillInterval) {
+    clearInterval(drillInterval);
+    drillInterval = null;
+  }
   if (interval) {
     clearInterval(interval);
     interval = null;

--- a/lib/backups/tick.ts
+++ b/lib/backups/tick.ts
@@ -5,6 +5,7 @@ import { runBackup, STALE_RUN_MS } from "./engine";
 import { shouldRunNow } from "@/lib/cron/parse";
 import { acquireLock } from "@/lib/redis-lock";
 import { logger } from "@/lib/logger";
+import { selectDrillCandidates, type DrillCandidate } from "./drill-schedule";
 
 const log = logger.child("backup");
 
@@ -66,6 +67,59 @@ export async function tickBackupJobs(): Promise<void> {
     } catch (err) {
       log.error(`Job "${job.name}" (${job.id}) error:`, err);
       // Continue to next job — don't let one failure crash the whole tick
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Drill tick
+// ---------------------------------------------------------------------------
+
+/** How many drills one tick may start. Each costs a container and a download. */
+const DRILLS_PER_TICK = 1;
+
+/**
+ * Drill whichever archive's restorability is least known.
+ *
+ * Separate from the backup tick so a slow drill can never delay a backup, and
+ * so turning drills off leaves backups untouched.
+ */
+export async function tickRestoreDrills(now = new Date()): Promise<void> {
+  const locked = await acquireLock(`lock:drill:${Math.floor(now.getTime() / 60_000)}`, 61_000);
+  if (!locked) return;
+
+  const rows = await db.query.backups.findMany({
+    where: eq(backups.status, "success"),
+    columns: {
+      id: true,
+      appId: true,
+      volumeName: true,
+      finishedAt: true,
+      verifiedAt: true,
+      verifyOutcome: true,
+    },
+  });
+
+  const candidates: DrillCandidate[] = rows
+    .filter((r): r is typeof r & { finishedAt: Date } => r.finishedAt !== null)
+    .map((r) => ({
+      backupId: r.id,
+      volumeKey: `${r.appId ?? "system"}:${r.volumeName ?? ""}`,
+      finishedAt: r.finishedAt,
+      verifiedAt: r.verifiedAt,
+      verifyOutcome: r.verifyOutcome,
+    }));
+
+  const due = selectDrillCandidates(candidates, now, DRILLS_PER_TICK);
+  if (due.length === 0) return;
+
+  const { runRestoreDrill } = await import("./drill");
+  for (const candidate of due) {
+    try {
+      const result = await runRestoreDrill(candidate.backupId);
+      log.info(`Drill ${candidate.volumeKey}: ${result.outcome} — ${result.detail}`);
+    } catch (err) {
+      log.error(`Drill ${candidate.volumeKey} error:`, err);
     }
   }
 }

--- a/tests/unit/lib/backups/drill-schedule.test.ts
+++ b/tests/unit/lib/backups/drill-schedule.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectDrillCandidates,
+  drillPriority,
+  DRILL_INTERVAL_MS,
+  type DrillCandidate,
+} from "@/lib/backups/drill-schedule";
+
+const NOW = new Date("2026-08-04T12:00:00Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+const DAY = 24 * 60 * 60 * 1000;
+
+function candidate(over: Partial<DrillCandidate> & { backupId: string; volumeKey: string }): DrillCandidate {
+  return {
+    finishedAt: ago(DAY),
+    verifiedAt: null,
+    verifyOutcome: null,
+    ...over,
+  };
+}
+
+describe("drillPriority", () => {
+  it("puts a never-drilled archive first — its verdict is unknown", () => {
+    expect(drillPriority(candidate({ backupId: "a", volumeKey: "v" }), NOW)).toBe(0);
+  });
+
+  it("puts a previous failure next, so a fix is confirmed rather than assumed", () => {
+    const c = candidate({ backupId: "a", volumeKey: "v", verifiedAt: ago(DAY), verifyOutcome: "failed" });
+    expect(drillPriority(c, NOW)).toBe(1);
+  });
+
+  it("re-drills a verified archive once its verification has aged out", () => {
+    const stale = candidate({
+      backupId: "a", volumeKey: "v",
+      verifiedAt: ago(DRILL_INTERVAL_MS + DAY), verifyOutcome: "verified",
+    });
+    expect(drillPriority(stale, NOW)).toBe(2);
+  });
+
+  it("leaves a recently verified archive alone", () => {
+    const fresh = candidate({
+      backupId: "a", volumeKey: "v", verifiedAt: ago(DAY), verifyOutcome: "verified",
+    });
+    expect(drillPriority(fresh, NOW)).toBe(3);
+  });
+});
+
+describe("selectDrillCandidates", () => {
+  it("schedules nothing when everything was verified this week", () => {
+    const fresh = [
+      candidate({ backupId: "a", volumeKey: "v1", verifiedAt: ago(DAY), verifyOutcome: "verified" }),
+      candidate({ backupId: "b", volumeKey: "v2", verifiedAt: ago(2 * DAY), verifyOutcome: "verified" }),
+    ];
+    expect(selectDrillCandidates(fresh, NOW, 5)).toEqual([]);
+  });
+
+  it("drills one archive per volume, not one per run", () => {
+    const many = [
+      candidate({ backupId: "old", volumeKey: "v1", finishedAt: ago(3 * DAY) }),
+      candidate({ backupId: "new", volumeKey: "v1", finishedAt: ago(DAY) }),
+    ];
+    const picked = selectDrillCandidates(many, NOW, 5);
+    expect(picked).toHaveLength(1);
+    expect(picked[0].backupId).toBe("new");
+  });
+
+  it("takes the newest archive for a volume — an old one proves less", () => {
+    const picked = selectDrillCandidates(
+      [
+        candidate({ backupId: "yesterday", volumeKey: "v", finishedAt: ago(DAY) }),
+        candidate({ backupId: "lastweek", volumeKey: "v", finishedAt: ago(7 * DAY) }),
+      ],
+      NOW,
+      5,
+    );
+    expect(picked[0].backupId).toBe("yesterday");
+  });
+
+  it("prefers never-drilled over stale-verified", () => {
+    const picked = selectDrillCandidates(
+      [
+        candidate({ backupId: "stale", volumeKey: "v1", verifiedAt: ago(DRILL_INTERVAL_MS + DAY), verifyOutcome: "verified" }),
+        candidate({ backupId: "never", volumeKey: "v2" }),
+      ],
+      NOW,
+      1,
+    );
+    expect(picked[0].backupId).toBe("never");
+  });
+
+  it("prefers a past failure over a stale success", () => {
+    const picked = selectDrillCandidates(
+      [
+        candidate({ backupId: "stale", volumeKey: "v1", verifiedAt: ago(DRILL_INTERVAL_MS + DAY), verifyOutcome: "verified" }),
+        candidate({ backupId: "broken", volumeKey: "v2", verifiedAt: ago(2 * DAY), verifyOutcome: "failed" }),
+      ],
+      NOW,
+      1,
+    );
+    expect(picked[0].backupId).toBe("broken");
+  });
+
+  it("within a band, takes the least recently confirmed", () => {
+    const picked = selectDrillCandidates(
+      [
+        candidate({ backupId: "recent", volumeKey: "v1", verifiedAt: ago(DRILL_INTERVAL_MS + DAY), verifyOutcome: "verified" }),
+        candidate({ backupId: "ancient", volumeKey: "v2", verifiedAt: ago(90 * DAY), verifyOutcome: "verified" }),
+      ],
+      NOW,
+      1,
+    );
+    expect(picked[0].backupId).toBe("ancient");
+  });
+
+  it("honors the limit, so one tick cannot start a fleet of drills", () => {
+    const many = Array.from({ length: 20 }, (_, i) =>
+      candidate({ backupId: `b${i}`, volumeKey: `v${i}` }),
+    );
+    expect(selectDrillCandidates(many, NOW, 3)).toHaveLength(3);
+  });
+
+  it("handles an empty fleet", () => {
+    expect(selectDrillCandidates([], NOW, 5)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #799, which added the drill mechanism and a manual trigger. A drill that only runs when someone asks is not much better than never for a system meant to run unattended.

## Selection

`selectDrillCandidates` orders by how much a drill would actually tell us:

1. **Never drilled** — an archive nobody has restored is the one whose verdict is unknown.
2. **Previously failed** — a fix should be confirmed, not assumed.
3. **Verified, but longer ago than the interval.**
4. Verified recently — skipped entirely.

Within a band, least recently confirmed goes first. A fleet verified this week schedules nothing rather than re-proving what it already knows.

Newest archive **per volume**, not per run: drilling last week's copy of a volume that has been backed up nightly proves the wrong thing.

## Pacing

One drill per tick, hourly, on its own timer. Each costs a container and a download, so this is deliberately slow — with a handful of volumes everything gets confirmed within a day, and the load is one scratch container at a time.

The separate timer matters: a slow drill cannot delay a backup, and the two failure modes stay independent.

## Verification

4302 tests / 293 files green, 0 lint errors, typecheck clean. 12 new tests covering each priority band, the per-volume collapse, the limit, and the case where nothing is due.

Not included: surfacing "last verified" in the UI. The data is on the row (`verifiedAt` / `verifyOutcome` / `verifyDetail`) and rendering it is a separate change.