### PR TITLE
fix(security): stop local environments granting the Docker socket

### DIFF
--- a/app/api/v1/organizations/[orgId]/adopt/route.ts
+++ b/app/api/v1/organizations/[orgId]/adopt/route.ts
@@ -154,10 +154,18 @@ async function handler(request: NextRequest, { params }: RouteParams) {
       featureEnabled: isFeatureEnabled("bindMounts"),
     });
 
-    const { compose: sanitized, strippedMounts } = sanitizeCompose(compose, {
-      allowBindMounts: bindMountsEnabled,
-    });
-    compose = sanitized;
+    // A denied mount throws — return what was wrong rather than a bare 500.
+    let strippedMounts: string[];
+    try {
+      const sanitized = sanitizeCompose(compose, { allowBindMounts: bindMountsEnabled });
+      compose = sanitized.compose;
+      strippedMounts = sanitized.strippedMounts;
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : "Compose contains a blocked mount" },
+        { status: 400 }
+      );
+    }
 
     // Determine domain — explicit > vardo.yml env config > default
     const domain =

--- a/lib/docker/compose-validate.ts
+++ b/lib/docker/compose-validate.ts
@@ -165,6 +165,15 @@ function isDockerSocketMount(mountSource: string, rootResolved: string): boolean
   );
 }
 
+/** Names the setting that unblocks the mount and who can turn it on. */
+function dockerSocketBlockedMessage(service: string, volume: string): string {
+  return (
+    `Service "${service}" mounts the Docker socket "${volume}" — turn on ` +
+    `"Allow Docker socket" in the project's settings to allow this ` +
+    `(organization admins and owners only)`
+  );
+}
+
 // ---------------------------------------------------------------------------
 // x-vardo-shared
 // ---------------------------------------------------------------------------
@@ -493,9 +502,7 @@ export function validateCompose(compose: ComposeFile, opts?: ValidateOptions): {
         // Docker socket is gated by its own flag, independent of bind mounts.
         if (isDockerSocketMount(mountSource, rootResolved)) {
           if (!opts?.allowDockerSocket) {
-            errors.push(
-              `Service "${name}" mounts the Docker socket "${vol}" — enable the Docker Socket feature flag to allow this`,
-            );
+            errors.push(dockerSocketBlockedMessage(name, vol));
           }
           continue;
         }
@@ -637,9 +644,7 @@ export function sanitizeCompose(
         // socket needs it, and a sharp tool should fail loudly, not degrade.
         if (isDockerSocketMount(mountSource, rootResolved)) {
           if (!opts?.allowDockerSocket) {
-            throw new Error(
-              `Service "${name}" mounts the Docker socket "${v}" — enable the Docker Socket feature flag to allow this`,
-            );
+            throw new Error(dockerSocketBlockedMessage(name, v));
           }
           safe.push(v);
           continue;

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -286,10 +286,10 @@ export async function runDeployment(
     const envBranchOverride = resolvedEnv.gitBranch;
     log(`[deploy] Environment: ${envName} (${envType})`);
 
-    // Local environments always allow bind mounts + the docker socket
+    // Local environments always allow bind mounts. The Docker socket stays on
+    // the project flag — anyone can create a local environment (#803).
     if (envType === "local") {
       projectAllowBindMounts = true;
-      projectAllowDockerSocket = true;
     }
 
     // Execute before.deploy.start hooks — approval gates, pre-flight checks

--- a/lib/docker/resolve-env.ts
+++ b/lib/docker/resolve-env.ts
@@ -53,7 +53,7 @@ const FALLBACK: DeployEnv = { name: "production", type: "production", gitBranch:
  * The id is caller-supplied, so the lookup is scoped to the app being deployed:
  * an environment on another app — in this org or any other — resolves to
  * production rather than lending the deploy its name, branch or type. Type
- * matters most: `local` turns on bind mounts and the Docker socket.
+ * matters most: `local` turns on bind mounts.
  */
 export async function resolveDeployEnv(
   appId: string,

--- a/tests/unit/api/organizations/adopt.test.ts
+++ b/tests/unit/api/organizations/adopt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { APP_NAME_TAKEN_ERROR } from "@/lib/db/app-name";
+import { sanitizeCompose, type ComposeFile } from "@/lib/docker/compose";
 
 // ---------------------------------------------------------------------------
 // POST /api/v1/organizations/[orgId]/adopt — request schema validation
@@ -503,6 +504,56 @@ describe("POST /adopt — transaction rollback", () => {
     };
 
     expect(transactionBehavior.onError).toBe("all changes rolled back");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blocked mounts (400)
+//
+// sanitizeCompose throws on a denied mount. The route catches it so the caller
+// reads what was wrong instead of a bare 500.
+// ---------------------------------------------------------------------------
+
+describe("POST /adopt — blocked mount", () => {
+  function adoptMountResponse(compose: ComposeFile, allowBindMounts: boolean) {
+    try {
+      sanitizeCompose(compose, { allowBindMounts });
+      return { status: 201 as const, error: null };
+    } catch (err) {
+      return {
+        status: 400 as const,
+        error: err instanceof Error ? err.message : "Compose contains a blocked mount",
+      };
+    }
+  }
+
+  const socketCompose: ComposeFile = {
+    services: {
+      web: { name: "web", image: "nginx", volumes: ["/var/run/docker.sock:/var/run/docker.sock"] },
+    },
+  };
+
+  it("returns 400 naming the setting when the compose mounts the Docker socket", () => {
+    const result = adoptMountResponse(socketCompose, true);
+    expect(result.status).toBe(400);
+    expect(result.error).toContain('"Allow Docker socket"');
+    expect(result.error).toContain("organization admins and owners only");
+  });
+
+  it("returns 400 naming the path when the compose mounts a denied host path", () => {
+    const compose: ComposeFile = {
+      services: { web: { name: "web", image: "nginx", volumes: ["/etc:/host/etc"] } },
+    };
+    const result = adoptMountResponse(compose, true);
+    expect(result.status).toBe(400);
+    expect(result.error).toContain("/etc");
+  });
+
+  it("adopts normally when no mount is blocked", () => {
+    const compose: ComposeFile = {
+      services: { web: { name: "web", image: "nginx", volumes: ["data:/var/lib/data"] } },
+    };
+    expect(adoptMountResponse(compose, true).status).toBe(201);
   });
 });
 

--- a/tests/unit/lib/docker/compose.test.ts
+++ b/tests/unit/lib/docker/compose.test.ts
@@ -134,7 +134,7 @@ describe("sanitizeCompose", () => {
     it("throws when mounting /var/run/docker.sock without the docker socket flag", () => {
       const compose = makeCompose(["/var/run/docker.sock:/var/run/docker.sock"]);
       expect(() => sanitizeCompose(compose, { allowBindMounts: true })).toThrow(
-        /Docker socket.*Docker Socket feature flag/,
+        /Docker socket.*Allow Docker socket/,
       );
     });
 
@@ -186,17 +186,26 @@ describe("sanitizeCompose", () => {
     });
 
     it("throws for the socket when the flag is off, regardless of allowBindMounts", () => {
-      expect(() => sanitizeCompose(makeCompose([SOCK]), { allowBindMounts: false })).toThrow(/Docker Socket feature flag/);
-      expect(() => sanitizeCompose(makeCompose([SOCK]), { allowBindMounts: true })).toThrow(/Docker Socket feature flag/);
+      expect(() => sanitizeCompose(makeCompose([SOCK]), { allowBindMounts: false })).toThrow(/Allow Docker socket/);
+      expect(() => sanitizeCompose(makeCompose([SOCK]), { allowBindMounts: true })).toThrow(/Allow Docker socket/);
     });
 
     it("validateCompose errors on the socket without the flag and accepts it with the flag", () => {
       const off = validateCompose(makeCompose([SOCK]), { allowBindMounts: true });
       expect(off.valid).toBe(false);
-      expect(off.errors.join(" ")).toMatch(/Docker Socket feature flag/);
+      expect(off.errors.join(" ")).toMatch(/Allow Docker socket/);
 
       const on = validateCompose(makeCompose([SOCK]), { allowDockerSocket: true });
       expect(on.valid).toBe(true);
+    });
+
+    // An operator who hits this needs to know which setting, and who can flip it.
+    it("names the project setting and the roles that can enable it", () => {
+      const { errors } = validateCompose(makeCompose([SOCK]), {});
+      const message = errors.find((e) => e.includes("Docker socket"))!;
+      expect(message).toContain('"Allow Docker socket"');
+      expect(message).toContain("project's settings");
+      expect(message).toContain("organization admins and owners only");
     });
   });
 

--- a/tests/unit/lib/docker/deploy-env-scope.test.ts
+++ b/tests/unit/lib/docker/deploy-env-scope.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 // The environmentId on a deploy request is caller-supplied. Resolving it by id
 // alone lets an environment on another app — in another organization — decide
-// the deploy's name, branch and type, and `local` grants bind mounts and the
-// Docker socket.
+// the deploy's name, branch and type, and `local` grants bind mounts.
 // ---------------------------------------------------------------------------
 
 type Predicate =

--- a/tests/unit/lib/docker/resolve-allow-docker-socket.test.ts
+++ b/tests/unit/lib/docker/resolve-allow-docker-socket.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Docker socket permission resolution — mirrors runDeployment (lib/docker/deploy.ts).
+// A local environment grants bind mounts but not the socket: creating one takes
+// no admin role, so an implicit grant would bypass the project gate (#803).
+// runDeployment is DB-dependent, so the resolution is extracted here.
+// ---------------------------------------------------------------------------
+
+function resolveAllowDockerSocket(input: {
+  orgTrusted: boolean;
+  projectAllowDockerSocket: boolean | null | undefined;
+  envType: "production" | "staging" | "preview" | "local";
+}): boolean {
+  if (input.orgTrusted) return true;
+  return input.projectAllowDockerSocket ?? false;
+}
+
+describe("resolveAllowDockerSocket", () => {
+  it("grants the socket to a trusted org regardless of the project flag", () => {
+    expect(
+      resolveAllowDockerSocket({ orgTrusted: true, projectAllowDockerSocket: false, envType: "production" }),
+    ).toBe(true);
+  });
+
+  it("refuses the socket in a local environment when the project flag is off", () => {
+    expect(
+      resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: false, envType: "local" }),
+    ).toBe(false);
+  });
+
+  it("refuses the socket in a local environment when there is no project record", () => {
+    expect(
+      resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: null, envType: "local" }),
+    ).toBe(false);
+    expect(
+      resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: undefined, envType: "local" }),
+    ).toBe(false);
+  });
+
+  it("grants the socket in a local environment once the project flag is on", () => {
+    expect(
+      resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: true, envType: "local" }),
+    ).toBe(true);
+  });
+
+  it("resolves the same way for every environment type", () => {
+    const types = ["production", "staging", "preview", "local"] as const;
+    for (const envType of types) {
+      expect(resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: false, envType })).toBe(false);
+      expect(resolveAllowDockerSocket({ orgTrusted: false, projectAllowDockerSocket: true, envType })).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Option 3 from #803. A `local` environment no longer implies the Docker socket; it still implies bind mounts.

Creating a `local` environment needs no role, and `POST /adopt` defaults to one. So the implicit grant made the admin-only `allowDockerSocket` flag on a project decorative — a member could reach host root in two calls. A bind mount reaches a path; the socket reaches the daemon.

## What changed

- `lib/docker/deploy.ts` — `envType === "local"` sets `projectAllowBindMounts` only. The socket resolves from `project.allowDockerSocket` (or a trusted org, or the instance-wide `dockerSocket` feature flag) for every environment type.
- `lib/docker/compose-validate.ts` — one message for both the `validateCompose` error and the `sanitizeCompose` throw, naming the setting and the roles that can set it.
- `app/api/v1/organizations/[orgId]/adopt/route.ts` — `sanitizeCompose` throws on a denied mount and the route swallowed it into a 500 "Internal server error". Now a 400 carrying the message.

## What this breaks

A deploy into a `local` environment whose compose mounts the socket, where the project flag is off and the instance-wide flag is off. It is blocked at prepare-repo — a `DeployBlockedError`, so nothing starts and no mount is silently stripped. The deploy log, the failure notification and the activity record all carry:

> Service "web" mounts the Docker socket "/var/run/docker.sock:/var/run/docker.sock" — turn on "Allow Docker socket" in the project's settings to allow this (organization admins and owners only)

Nothing else moves:

- Adoption of socket-mounting compose already failed before this branch — `/adopt` calls `sanitizeCompose` without `allowDockerSocket` regardless of environment type. It failed as an opaque 500; now it is a 400 that names the fix.
- The `discover/` import routes create `production` environments, so they never had the grant.
- Self-registration (`lib/docker/self-register.ts`) creates no environment, and `resolveDeployEnv` falls back to `production` — Vardo deploying itself already needed the project flag or a trusted org.
- Trusted orgs still bypass mount checks entirely.

The reachable regression is an app that acquired a socket mount after adoption (compose edited on the app, or a socket mount arriving through a git-sourced compose) and deploys into a `local` environment. One admin toggle per project unblocks it, and the instance-wide flag still covers single-operator homelabs.

## Tests

- `tests/unit/lib/docker/resolve-allow-docker-socket.test.ts` — resolution no longer varies by environment type.
- `tests/unit/lib/docker/compose.test.ts` — the message names the setting, the location and the roles.
- `tests/unit/api/organizations/adopt.test.ts` — blocked mount maps to 400 with the reason.

`pnpm typecheck`, `pnpm lint` (0 errors) and `pnpm vitest run` (4299 passing) are clean.

Leaves the escalation surface at one decision point rather than gating `type: "local"` at each creation site (option 1), which would still need `/adopt` gated separately and would leave the grant reachable for anyone who already has a `local` environment.
