### PR TITLE
Authenticate image pulls with the configured registry credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,18 @@ VARDO_DOMAIN=localhost
 # VARDO_MOUNT_2=          # Extra mount slot 2
 
 # ---------------------
+# Registry Credentials
+# ---------------------
+# Logins for private image registries, used for update checks and image pulls.
+# Keyed by registry host; use "docker.io" for Docker Hub. Overrides anything
+# stored in system settings.
+# VARDO_REGISTRY_CREDENTIALS={"ghcr.io":{"username":"user","password":"token"}}
+#
+# Docker Hub shorthand, equivalent to a "docker.io" entry above.
+# DOCKERHUB_USERNAME=
+# DOCKERHUB_TOKEN=
+
+# ---------------------
 # TLS (production only)
 # ---------------------
 # ACME_EMAIL=you@example.com

--- a/lib/docker/deploy-steps/prepare-repo.ts
+++ b/lib/docker/deploy-steps/prepare-repo.ts
@@ -51,6 +51,7 @@ import {
 } from "@/lib/crypto/deploy-key";
 import { detectPreventiveFixes, detectCompatIssues, applyCompatFixes } from "../compat";
 import { checkoutRollbackSha } from "./checkout-sha";
+import { withRegistryAuth } from "../registry-auth";
 import {
   APP_UID,
   GIT_CLONE_TIMEOUT,
@@ -254,53 +255,57 @@ async function buildFromRepo(
   dockerfilePath?: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  const buildEnv = { ...process.env, ...envVars };
+  // A Dockerfile can name a private base image, so every builder runs against
+  // the configured registry credentials.
+  await withRegistryAuth(async (authEnv) => {
+    const buildEnv = { ...authEnv, ...envVars };
 
-  if (deployType === "nixpacks") {
-    logs.push(`[build] Building with Nixpacks...`);
-    const args = ["build", repoPath, "--name", imageName];
-    if (envVars) {
-      for (const [k, v] of Object.entries(envVars)) {
-        args.push("--env", `${k}=${v}`);
+    if (deployType === "nixpacks") {
+      logs.push(`[build] Building with Nixpacks...`);
+      const args = ["build", repoPath, "--name", imageName];
+      if (envVars) {
+        for (const [k, v] of Object.entries(envVars)) {
+          args.push("--env", `${k}=${v}`);
+        }
       }
+      await spawnStream("nixpacks", args, { cwd: repoPath, env: buildEnv, signal }, logs, "[build][nixpacks]");
+      logs.push(`[build] Nixpacks build complete: ${imageName}`);
+      return;
     }
-    await spawnStream("nixpacks", args, { cwd: repoPath, env: buildEnv, signal }, logs, "[build][nixpacks]");
-    logs.push(`[build] Nixpacks build complete: ${imageName}`);
-    return;
-  }
 
-  if (deployType === "railpack") {
-    // Railpack builds through BuildKit rather than the Docker daemon, and exits
-    // non-zero with only a hint if it cannot find one. Default to the daemon
-    // Vardo documents, and check it is actually there before spending a deploy
-    // on discovering it is not.
-    if (!buildEnv.BUILDKIT_HOST) buildEnv.BUILDKIT_HOST = DEFAULT_BUILDKIT_HOST;
-    await assertBuildKitReachable(buildEnv.BUILDKIT_HOST, signal);
+    if (deployType === "railpack") {
+      // Railpack builds through BuildKit rather than the Docker daemon, and exits
+      // non-zero with only a hint if it cannot find one. Default to the daemon
+      // Vardo documents, and check it is actually there before spending a deploy
+      // on discovering it is not.
+      if (!buildEnv.BUILDKIT_HOST) buildEnv.BUILDKIT_HOST = DEFAULT_BUILDKIT_HOST;
+      await assertBuildKitReachable(buildEnv.BUILDKIT_HOST, signal);
 
-    logs.push(`[build] Building with Railpack...`);
-    const args = ["build", "--name", imageName];
+      logs.push(`[build] Building with Railpack...`);
+      const args = ["build", "--name", imageName];
+      if (envVars) {
+        for (const [k, v] of Object.entries(envVars)) {
+          args.push("--env", `${k}=${v}`);
+        }
+      }
+      args.push(repoPath);
+      await spawnStream("railpack", args, { cwd: repoPath, env: buildEnv, signal }, logs, "[build][railpack]");
+      logs.push(`[build] Railpack build complete: ${imageName}`);
+      return;
+    }
+
+    const dfPath = dockerfilePath || "Dockerfile";
+    logs.push(`[build] Building with Dockerfile (${dfPath})...`);
+    const args = ["build", "-t", imageName, "-f", join(repoPath, dfPath)];
     if (envVars) {
       for (const [k, v] of Object.entries(envVars)) {
-        args.push("--env", `${k}=${v}`);
+        args.push("--build-arg", `${k}=${v}`);
       }
     }
     args.push(repoPath);
-    await spawnStream("railpack", args, { cwd: repoPath, env: buildEnv, signal }, logs, "[build][railpack]");
-    logs.push(`[build] Railpack build complete: ${imageName}`);
-    return;
-  }
-
-  const dfPath = dockerfilePath || "Dockerfile";
-  logs.push(`[build] Building with Dockerfile (${dfPath})...`);
-  const args = ["build", "-t", imageName, "-f", join(repoPath, dfPath)];
-  if (envVars) {
-    for (const [k, v] of Object.entries(envVars)) {
-      args.push("--build-arg", `${k}=${v}`);
-    }
-  }
-  args.push(repoPath);
-  await spawnStream("docker", args, { cwd: repoPath, signal }, logs, "[build][docker]");
-  logs.push(`[build] Docker build complete: ${imageName}`);
+    await spawnStream("docker", args, { cwd: repoPath, env: authEnv, signal }, logs, "[build][docker]");
+    logs.push(`[build] Docker build complete: ${imageName}`);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/docker/deploy-steps/swap.ts
+++ b/lib/docker/deploy-steps/swap.ts
@@ -31,6 +31,7 @@ import type { DeployContext, SlotStopOutcome } from "../deploy-context";
 import { classifyComposeServices } from "./classify-services";
 import { majorGateAfter, majorGateBefore, type MajorGateState } from "./major-gate";
 import { publishesHostPorts } from "../host-ports";
+import { registryAuthHint, withRegistryAuth } from "../registry-auth";
 import { partitionBySlot, sharedProjectName, slotScopeArgs } from "../slot-partition";
 import { isSelfApp } from "../self-env";
 import { clearCutoverPin, guardCutover, type CutoverGuard } from "../traefik-cutover";
@@ -269,41 +270,50 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
   );
   let majorGate: MajorGateState = { candidates: [], before: new Map() };
   try {
-    if (buildServices.length > 0) {
-      log(`[deploy] Pre-building ${newSlot} slot images (old slot still serving)...`);
-      const { stdout, stderr } = await execFileAsync(
-        "docker",
-        ["compose", "--progress=plain", ...composeFileArgs, "-p", newProjectName, "build"],
-        { cwd: slotDir, timeout: COMPOSE_BUILD_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER, signal: ctx.signal }
-      );
-      for (const line of stdout.split(/\r?\n|\r/).filter(Boolean)) {
-        logs.push(`[deploy][build] ${line.trim()}`);
+    // Both phases reach registries — a `build:` service pulls the bases its
+    // Dockerfile names — so both run against the configured credentials.
+    await withRegistryAuth(async (env) => {
+      if (buildServices.length > 0) {
+        log(`[deploy] Pre-building ${newSlot} slot images (old slot still serving)...`);
+        const { stdout, stderr } = await execFileAsync(
+          "docker",
+          ["compose", "--progress=plain", ...composeFileArgs, "-p", newProjectName, "build"],
+          { cwd: slotDir, env, timeout: COMPOSE_BUILD_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER, signal: ctx.signal }
+        );
+        for (const line of stdout.split(/\r?\n|\r/).filter(Boolean)) {
+          logs.push(`[deploy][build] ${line.trim()}`);
+        }
+        for (const line of stderr.split(/\r?\n|\r/).filter(Boolean)) {
+          logs.push(`[deploy][build] ${line.trim()}`);
+        }
       }
-      for (const line of stderr.split(/\r?\n|\r/).filter(Boolean)) {
-        logs.push(`[deploy][build] ${line.trim()}`);
+      if (pullServices.length > 0) {
+        // Read the engine majors off the local images first. After the pull the
+        // tag points somewhere else and the old major is unreadable.
+        majorGate = await majorGateBefore(ctx, pullServices);
+        log(`[deploy] Pre-pulling ${newSlot} slot images (old slot still serving)...`);
+        const { stdout, stderr } = await execFileAsync(
+          "docker",
+          ["compose", ...composeFileArgs, "-p", newProjectName, "pull", ...pullServices],
+          { cwd: slotDir, env, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER, signal: ctx.signal }
+        );
+        for (const line of stdout.split(/\r?\n|\r/).filter(Boolean)) {
+          logs.push(`[deploy][pull] ${line.trim()}`);
+        }
+        for (const line of stderr.split(/\r?\n|\r/).filter(Boolean)) {
+          logs.push(`[deploy][pull] ${line.trim()}`);
+        }
       }
-    }
-    if (pullServices.length > 0) {
-      // Read the engine majors off the local images first. After the pull the
-      // tag points somewhere else and the old major is unreadable.
-      majorGate = await majorGateBefore(ctx, pullServices);
-      log(`[deploy] Pre-pulling ${newSlot} slot images (old slot still serving)...`);
-      const { stdout, stderr } = await execFileAsync(
-        "docker",
-        ["compose", ...composeFileArgs, "-p", newProjectName, "pull", ...pullServices],
-        { cwd: slotDir, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER, signal: ctx.signal }
-      );
-      for (const line of stdout.split(/\r?\n|\r/).filter(Boolean)) {
-        logs.push(`[deploy][pull] ${line.trim()}`);
-      }
-      for (const line of stderr.split(/\r?\n|\r/).filter(Boolean)) {
-        logs.push(`[deploy][pull] ${line.trim()}`);
-      }
-    }
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    const hint = await registryAuthHint(
+      message,
+      pullServices.map((name) => compose.services[name]?.image),
+    );
     throw new Error(
-      `Pre-build/pre-pull for ${newSlot} failed (old slot unaffected): ${message}`
+      `Pre-build/pre-pull for ${newSlot} failed (old slot unaffected): ${message}` +
+        (hint ? `\n${hint}` : "")
     );
   }
 
@@ -531,25 +541,36 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
   if (sharedNames.length > 0) {
     log(`[deploy] Shared services (not rotated): ${sharedNames.join(", ")}`);
     try {
-      const { stdout, stderr } = await execFileAsync(
-        "docker",
-        [
-          "compose",
-          ...composeFileArgs,
-          "-p", sharedProject,
-          "up", "-d",
-          "--no-recreate",
-          "--no-deps",
-          ...sharedNames,
-        ],
-        { cwd: slotDir, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER }
+      // Shared services are left out of the pre-pull, so this `up` is where a
+      // missing one is fetched.
+      const { stdout, stderr } = await withRegistryAuth((env) =>
+        execFileAsync(
+          "docker",
+          [
+            "compose",
+            ...composeFileArgs,
+            "-p", sharedProject,
+            "up", "-d",
+            "--no-recreate",
+            "--no-deps",
+            ...sharedNames,
+          ],
+          { cwd: slotDir, env, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER }
+        )
       );
       for (const line of `${stdout}\n${stderr}`.split(/\r?\n|\r/).filter(Boolean)) {
         logs.push(`[deploy][shared] ${line.trim()}`);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Shared services failed to start (old slot unaffected): ${message}`);
+      const hint = await registryAuthHint(
+        message,
+        sharedNames.map((name) => compose.services[name]?.image),
+      );
+      throw new Error(
+        `Shared services failed to start (old slot unaffected): ${message}` +
+          (hint ? `\n${hint}` : "")
+      );
     }
   }
 

--- a/lib/docker/registry-auth.ts
+++ b/lib/docker/registry-auth.ts
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------------
+// Registry authentication for image pulls.
+//
+// Vardo's own container holds no Docker credentials, so `docker compose pull`
+// authenticates as nobody. The configured credentials are handed to the pull
+// through a throwaway DOCKER_CONFIG directory: never on argv, which `ps` shows
+// to every user on the host, and never in the shared ~/.docker/config.json,
+// which concurrent deploys would race over.
+// ---------------------------------------------------------------------------
+
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+
+import { parseImageRef } from "./image-updates/image-ref";
+import { getRegistryCredentials, type RegistryCredential } from "./image-updates/registry";
+
+/** Docker Hub's auth entry is keyed by the v1 endpoint, not by the registry host. */
+const DOCKER_HUB_KEY = "https://index.docker.io/v1/";
+
+/** What Docker prints when it pulled without usable credentials. */
+const AUTH_FAILURE =
+  /unauthorized|authentication required|no basic auth credentials|pull access denied|requested access to the resource is denied/i;
+
+type AuthEntry = { auth?: string; [key: string]: unknown };
+
+function authKey(host: string): string {
+  return host === "docker.io" || host === "index.docker.io" ? DOCKER_HUB_KEY : host;
+}
+
+/** Where the Docker CLI reads its config when nothing overrides it. */
+function baseConfigDir(): string {
+  return process.env.DOCKER_CONFIG ?? join(homedir(), ".docker");
+}
+
+/** Auth entries already on disk, so a config an operator mounted keeps working. */
+async function mountedAuths(): Promise<Record<string, AuthEntry>> {
+  try {
+    const parsed = JSON.parse(await readFile(join(baseConfigDir(), "config.json"), "utf-8")) as {
+      auths?: Record<string, AuthEntry>;
+    };
+    return parsed.auths ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** Renders credentials as a Docker CLI config. Configured ones win over mounted ones. */
+export function buildDockerConfig(
+  credentials: Record<string, RegistryCredential>,
+  mounted: Record<string, AuthEntry> = {},
+): string {
+  const auths: Record<string, AuthEntry> = { ...mounted };
+  for (const [host, cred] of Object.entries(credentials)) {
+    auths[authKey(host)] = {
+      auth: Buffer.from(`${cred.username}:${cred.password}`).toString("base64"),
+    };
+  }
+  return JSON.stringify({ auths });
+}
+
+/**
+ * Runs `run` against a Docker config carrying the configured registry logins,
+ * removed once it returns. Hands the ambient environment straight through when
+ * no credentials are configured.
+ */
+export async function withRegistryAuth<T>(
+  run: (env: NodeJS.ProcessEnv) => Promise<T>,
+): Promise<T> {
+  const credentials = await getRegistryCredentials();
+  if (Object.keys(credentials).length === 0) return run(process.env);
+
+  const dir = await mkdtemp(join(tmpdir(), "vardo-docker-config-"));
+  try {
+    const config = buildDockerConfig(credentials, await mountedAuths());
+    await writeFile(join(dir, "config.json"), config, { mode: 0o600 });
+    return await run({ ...process.env, DOCKER_CONFIG: dir });
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Names the registries a failed pull had no credentials for. Null when the
+ * failure was not an authentication one, or every registry involved is covered.
+ */
+export async function registryAuthHint(
+  message: string,
+  images: (string | undefined)[],
+): Promise<string | null> {
+  if (!AUTH_FAILURE.test(message)) return null;
+
+  const configured = new Set(Object.keys(await getRegistryCredentials()));
+  const missing = new Set<string>();
+  for (const image of images) {
+    const ref = image ? parseImageRef(image) : null;
+    if (ref && !configured.has(ref.registry)) missing.add(ref.registry);
+  }
+  if (missing.size === 0) return null;
+
+  return `No registry credentials are configured for ${[...missing].sort().join(", ")} — set VARDO_REGISTRY_CREDENTIALS so the pull can authenticate.`;
+}

--- a/tests/unit/lib/docker/deploy-steps/swap-registry-auth.test.ts
+++ b/tests/unit/lib/docker/deploy-steps/swap-registry-auth.test.ts
@@ -1,0 +1,211 @@
+// ---------------------------------------------------------------------------
+// The pre-pull runs against the configured registry credentials.
+//
+// Vardo's container has none of its own, so a private image only resolves if
+// the pull subprocess is handed a Docker config that carries them.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  dbMock,
+  execFileAsyncMock,
+  execFileMock,
+  restartPolicyMock,
+  cutoverMock,
+  inspectImageMeta,
+  getRegistryCredentials,
+} = vi.hoisted(() => {
+  const execFileAsyncMock = vi.fn();
+  const execFileMock = vi.fn();
+  Object.defineProperty(execFileMock, Symbol.for("nodejs.util.promisify.custom"), {
+    value: execFileAsyncMock,
+    configurable: true,
+    writable: true,
+  });
+
+  return {
+    execFileAsyncMock,
+    execFileMock,
+    inspectImageMeta: vi.fn(async () => null),
+    getRegistryCredentials: vi.fn(
+      async () => ({}) as Record<string, { username: string; password: string }>,
+    ),
+    dbMock: {
+      update: vi.fn().mockImplementation(() => ({
+        set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+      })),
+      query: { deployments: { findFirst: vi.fn(async () => undefined) } },
+    },
+    restartPolicyMock: {
+      demoteStandbyRestart: vi.fn(async () => {}),
+      restoreSlotRestart: vi.fn(async () => {}),
+    },
+    cutoverMock: {
+      clearCutoverPin: vi.fn(async () => {}),
+      guardCutover: vi.fn(async () => ({ pinned: true, release: async () => {} })),
+    },
+  };
+});
+
+vi.mock("child_process", () => ({ execFile: execFileMock }));
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/lib/docker/restart-policy", () => restartPolicyMock);
+vi.mock("@/lib/docker/traefik-cutover", () => cutoverMock);
+vi.mock("@/lib/docker/image-updates/registry", () => ({ getRegistryCredentials }));
+vi.mock("@/lib/docker/client", () => ({
+  ensureNetwork: vi.fn().mockResolvedValue(undefined),
+  inspectImageMeta,
+}));
+vi.mock("@/lib/docker/compose", () => ({
+  slotComposeFiles: vi.fn().mockResolvedValue(["-f", "docker-compose.yml"]),
+  getTraefikRoutedServices: vi.fn().mockReturnValue(new Set(["web"])),
+}));
+vi.mock("@/lib/docker/deploy-steps/bind-mount-ownership", () => ({
+  prepareBindMountOwnership: vi.fn().mockResolvedValue(undefined),
+  bindMountHostSource: vi.fn(),
+  numericUid: vi.fn(),
+}));
+
+import { readFile } from "fs/promises";
+
+import { swap } from "@/lib/docker/deploy-steps/swap";
+import type { DeployContext } from "@/lib/docker/deploy-context";
+import type { ComposeFile } from "@/lib/docker/compose-types";
+
+function composeFile(): ComposeFile {
+  return {
+    services: {
+      web: {
+        name: "web",
+        image: "registry.example.test/acme/web:1.2.3",
+        labels: { "traefik.enable": "true" },
+      },
+    },
+  } as unknown as ComposeFile;
+}
+
+function context(): DeployContext {
+  const logLines: string[] = [];
+  return {
+    deploymentId: "deploy-1",
+    appId: "app-1",
+    organizationId: "org-1",
+    app: {
+      id: "app-1",
+      name: "acme",
+      displayName: "Acme",
+      deployType: "compose",
+      healthCheckTimeout: null,
+      domains: [],
+    },
+    envName: "production",
+    compose: composeFile(),
+    builtImageRefs: [],
+    appDir: "/opt/vardo/apps/acme/production",
+    slotDir: "/opt/vardo/apps/acme/production/green",
+    newProjectName: "acme-production-green",
+    activeSlot: "blue",
+    newSlot: "green",
+    isLocalEnv: false,
+    containerPort: 3000,
+    composeFileArgs: ["-f", "docker-compose.yml"],
+    logLines,
+    logs: { push: (line: string) => logLines.push(line) },
+    log: (line: string) => {
+      logLines.push(line);
+      return line;
+    },
+    stage: () => {},
+    checkAbort: () => {},
+    startTime: Date.now(),
+  } as unknown as DeployContext;
+}
+
+/** The options object each docker invocation was given. */
+function optionsFor(command: string): Record<string, unknown> | undefined {
+  const call = execFileAsyncMock.mock.calls.find((c) => (c[1] as string[]).includes(command));
+  return call?.[2] as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRegistryCredentials.mockResolvedValue({});
+  execFileAsyncMock.mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args.includes("ps")) {
+      return {
+        stdout: JSON.stringify({
+          Service: "web",
+          Name: "acme-production-green-web-1",
+          State: "running",
+          Health: "healthy",
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "", stderr: "" };
+  });
+});
+
+describe("swap — registry auth", () => {
+  it("hands the pull a Docker config carrying the credential", async () => {
+    getRegistryCredentials.mockResolvedValue({
+      "registry.example.test": { username: "svc", password: "s3cret" },
+    });
+
+    let config = "";
+    execFileAsyncMock.mockImplementation(async (_cmd: string, args: string[], opts: Record<string, string | undefined>) => {
+      if (args.includes("pull")) {
+        const env = opts.env as unknown as NodeJS.ProcessEnv;
+        config = await readFile(`${env.DOCKER_CONFIG}/config.json`, "utf-8");
+      }
+      if (args.includes("ps")) {
+        return {
+          stdout: JSON.stringify({
+            Service: "web",
+            Name: "acme-production-green-web-1",
+            State: "running",
+            Health: "healthy",
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await swap(context());
+
+    expect(JSON.parse(config).auths["registry.example.test"].auth).toBe(
+      Buffer.from("svc:s3cret").toString("base64"),
+    );
+  });
+
+  it("keeps the credential off the argument list", async () => {
+    getRegistryCredentials.mockResolvedValue({
+      "registry.example.test": { username: "svc", password: "s3cret" },
+    });
+
+    await swap(context());
+
+    const argv = execFileAsyncMock.mock.calls.flatMap((c) => c[1] as string[]).join(" ");
+    expect(argv).not.toContain("s3cret");
+    expect(argv).not.toContain("svc");
+  });
+
+  it("says which registry has no credentials when the pull is rejected", async () => {
+    execFileAsyncMock.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("pull")) throw new Error("Error response from daemon: unauthorized");
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(swap(context())).rejects.toThrow(
+      /No registry credentials are configured for registry\.example\.test/,
+    );
+  });
+
+  it("leaves the environment alone when no credentials are configured", async () => {
+    await swap(context());
+
+    expect(optionsFor("pull")?.env).toBe(process.env);
+  });
+});

--- a/tests/unit/lib/docker/registry-auth.test.ts
+++ b/tests/unit/lib/docker/registry-auth.test.ts
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------
+// Registry credentials reaching a pull.
+//
+// The credential must arrive through a file the subprocess reads, not through
+// argv, which `ps` shows to every user on the host.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFile, readdir, rm, stat } from "fs/promises";
+
+const { getRegistryCredentials } = vi.hoisted(() => ({
+  getRegistryCredentials: vi.fn(async () => ({}) as Record<string, { username: string; password: string }>),
+}));
+
+vi.mock("@/lib/docker/image-updates/registry", () => ({ getRegistryCredentials }));
+
+const { buildDockerConfig, registryAuthHint, withRegistryAuth } = await import(
+  "@/lib/docker/registry-auth"
+);
+
+/** An empty config dir, so a config.json on the machine running the tests is not read. */
+let emptyConfigDir: string;
+const originalDockerConfig = process.env.DOCKER_CONFIG;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  getRegistryCredentials.mockResolvedValue({});
+  const { mkdtemp } = await import("fs/promises");
+  const { tmpdir } = await import("os");
+  const { join } = await import("path");
+  emptyConfigDir = await mkdtemp(join(tmpdir(), "vardo-test-config-"));
+  process.env.DOCKER_CONFIG = emptyConfigDir;
+});
+
+afterEach(async () => {
+  if (originalDockerConfig === undefined) delete process.env.DOCKER_CONFIG;
+  else process.env.DOCKER_CONFIG = originalDockerConfig;
+  await rm(emptyConfigDir, { recursive: true, force: true });
+});
+
+describe("buildDockerConfig", () => {
+  it("writes basic auth Docker understands", () => {
+    const config = JSON.parse(
+      buildDockerConfig({ "registry.example.test": { username: "svc", password: "s3cret" } }),
+    );
+    expect(config.auths["registry.example.test"].auth).toBe(
+      Buffer.from("svc:s3cret").toString("base64"),
+    );
+  });
+
+  it("keys Docker Hub by its v1 endpoint", () => {
+    const config = JSON.parse(buildDockerConfig({ "docker.io": { username: "u", password: "p" } }));
+    expect(Object.keys(config.auths)).toEqual(["https://index.docker.io/v1/"]);
+  });
+
+  it("keeps entries from a config an operator mounted", () => {
+    const config = JSON.parse(
+      buildDockerConfig(
+        { "ghcr.io": { username: "u", password: "p" } },
+        { "other.example.test": { auth: "bW91bnRlZA==" } },
+      ),
+    );
+    expect(config.auths["other.example.test"].auth).toBe("bW91bnRlZA==");
+    expect(config.auths["ghcr.io"].auth).toBe(Buffer.from("u:p").toString("base64"));
+  });
+});
+
+describe("withRegistryAuth", () => {
+  it("passes the environment through untouched when nothing is configured", async () => {
+    const env = await withRegistryAuth(async (e) => e);
+    expect(env.DOCKER_CONFIG).toBe(emptyConfigDir);
+  });
+
+  it("points DOCKER_CONFIG at a config holding the credential", async () => {
+    getRegistryCredentials.mockResolvedValue({
+      "ghcr.io": { username: "svc", password: "s3cret" },
+    });
+
+    const seen = await withRegistryAuth(async (env) => {
+      const dir = env.DOCKER_CONFIG!;
+      return {
+        dir,
+        config: JSON.parse(await readFile(`${dir}/config.json`, "utf-8")),
+        mode: (await stat(`${dir}/config.json`)).mode & 0o777,
+      };
+    });
+
+    expect(seen.dir).not.toBe(emptyConfigDir);
+    expect(seen.config.auths["ghcr.io"].auth).toBe(Buffer.from("svc:s3cret").toString("base64"));
+    expect(seen.mode).toBe(0o600);
+  });
+
+  it("removes the config once the command returns", async () => {
+    getRegistryCredentials.mockResolvedValue({ "ghcr.io": { username: "u", password: "p" } });
+
+    const dir = await withRegistryAuth(async (env) => env.DOCKER_CONFIG!);
+
+    await expect(readdir(dir)).rejects.toThrow();
+  });
+
+  it("removes the config when the command fails", async () => {
+    getRegistryCredentials.mockResolvedValue({ "ghcr.io": { username: "u", password: "p" } });
+    let dir = "";
+
+    await expect(
+      withRegistryAuth(async (env) => {
+        dir = env.DOCKER_CONFIG!;
+        throw new Error("pull failed");
+      }),
+    ).rejects.toThrow("pull failed");
+
+    await expect(readdir(dir)).rejects.toThrow();
+  });
+});
+
+describe("registryAuthHint", () => {
+  it("names the registry nothing is configured for", async () => {
+    const hint = await registryAuthHint("Error response from daemon: unauthorized", [
+      "ghcr.io/acme/api:1.2.3",
+    ]);
+    expect(hint).toContain("ghcr.io");
+    expect(hint).toContain("VARDO_REGISTRY_CREDENTIALS");
+  });
+
+  it("stays quiet when the failure was not an auth failure", async () => {
+    const hint = await registryAuthHint("manifest for ghcr.io/acme/api:9 not found", [
+      "ghcr.io/acme/api:9",
+    ]);
+    expect(hint).toBeNull();
+  });
+
+  it("stays quiet when the registry already has credentials", async () => {
+    getRegistryCredentials.mockResolvedValue({ "ghcr.io": { username: "u", password: "p" } });
+
+    const hint = await registryAuthHint("pull access denied", ["ghcr.io/acme/api:1"]);
+
+    expect(hint).toBeNull();
+  });
+
+  it("names only the registries that are missing", async () => {
+    getRegistryCredentials.mockResolvedValue({ "ghcr.io": { username: "u", password: "p" } });
+
+    const hint = await registryAuthHint("no basic auth credentials", [
+      "ghcr.io/acme/api:1",
+      "registry.example.test/acme/worker:1",
+      undefined,
+    ]);
+
+    expect(hint).toContain("registry.example.test");
+    expect(hint).not.toContain("ghcr.io");
+  });
+});


### PR DESCRIPTION
Closes #782

`VARDO_REGISTRY_CREDENTIALS` and the `registry_credentials` system setting were read in one place — the update checker. Every pull ran with whatever sat in Vardo's own container config, which is nothing, so a private image only worked if an operator mounted a config file from the host.

## What changed

`lib/docker/registry-auth.ts` renders the existing credentials into a throwaway `DOCKER_CONFIG` directory and hands it to the pull subprocess through its environment, removing it when the command returns. No second credential store.

Why a config file rather than `docker login`:

- `docker login` writes to the shared `~/.docker/config.json`, so two concurrent deploys race, and one's `docker logout` cancels the other's in-flight pull.
- `--password-stdin` keeps the secret off argv for the login itself but still leaves it on disk afterwards, with no owner responsible for removing it.
- A per-command config has no shared state, is scoped to the one subprocess, and is gone when it exits.

Credentials never touch argv, which `ps` shows to every user on the host — only a directory path travels, and it travels in the environment. The file is written `0600` inside a `0700` `mkdtemp` directory. Auth entries in an existing config are merged in, so an operator's mounted config keeps working.

## Pull sites covered

- `deploy-steps/swap.ts` — the `compose pull`, the `compose build` (a `build:` service pulls the bases its Dockerfile names), and the shared-services `up`, which is excluded from the pre-pull and so is where a missing shared image is fetched.
- `deploy-steps/prepare-repo.ts` — the Dockerfile, Nixpacks, and Railpack builds.

Not covered, deliberately:

- Every `up` carrying `--pull never` — `start-app.ts`, `instant-rollback.ts`, `rollback-monitor.ts`, and the new-slot start in `swap.ts`. They cannot reach a registry.
- `client.ts` has no pull; it inspects and prunes over the Docker API and never calls `/images/create`.
- `deploy.ts:916` (`up -d --force-recreate`) — another stream is working in that file.
- `self-preview.ts` and the maintenance restart route act on Vardo's own stack; the maintenance update route hands off to `install.sh` on the host, which uses the host's Docker config.

## Failure message

A rejected pull used to surface whatever Docker printed. It now appends the registries the images belong to that have no credentials configured:

```
Pre-build/pre-pull for green failed (old slot unaffected): ... unauthorized
No registry credentials are configured for registry.example.test — set VARDO_REGISTRY_CREDENTIALS so the pull can authenticate.
```

## Secrets in logs

Nothing new can reach a log. The credential exists as a `0600` file and as a directory path in a subprocess environment; neither the path nor the file contents are logged, and Docker prints neither on failure. The redaction patterns in `deploy-logger.ts` needed no extension.

## Storage

`registry_credentials` in `system_settings` is encrypted at rest — AES-256-GCM under `ENCRYPTION_MASTER_KEY`, same as env vars. The `VARDO_REGISTRY_CREDENTIALS` override is plaintext in `.env` and in the container's environment, which is the normal trade for an env-var override and is now documented in `.env.example`. Note there is still no admin UI that writes the setting, so today the env var is the only practical way to configure it.

## Tests

`tests/unit/lib/docker/registry-auth.test.ts` covers the config rendering, the Docker Hub key, merging a mounted config, and that the temp directory is removed on both success and failure. `tests/unit/lib/docker/deploy-steps/swap-registry-auth.test.ts` drives a full swap and asserts the pull subprocess reads a config carrying the credential, that no credential appears in any argument list, and that a rejected pull names the registry.

`pnpm typecheck`, `pnpm lint` (0 errors), and `pnpm vitest run` (4305 tests) pass.