### PR TITLE
Refuse to deploy when env vars cannot be decrypted

### DIFF
--- a/lib/docker/deploy-steps/build.ts
+++ b/lib/docker/deploy-steps/build.ts
@@ -11,6 +11,7 @@ import { promisify } from "util";
 import { mkdir, writeFile, readFile, rm, symlink, copyFile, stat, readdir } from "fs/promises";
 import { join } from "path";
 import { decryptOrFallback } from "@/lib/crypto/encrypt";
+import { DeployBlockedError } from "../errors";
 import { parseEnvToMap } from "@/lib/env/parse-env";
 import { resolveAllEnvVars, type ResolveContext } from "@/lib/env/resolve";
 import {
@@ -238,7 +239,12 @@ export async function build(ctx: DeployContext): Promise<DeployContext> {
         }
       }
       if (child.envContent) {
-        const { content } = decryptOrFallback(child.envContent, ctx.organizationId);
+        const { content, decryptFailed } = decryptOrFallback(child.envContent, ctx.organizationId);
+        if (decryptFailed) {
+          throw new DeployBlockedError(
+            `Could not decrypt environment variables for service "${child.composeService}" — check ENCRYPTION_MASTER_KEY.`,
+          );
+        }
         if (content) {
           const map = parseEnvToMap(content);
           if (Object.keys(map).length > 0) serviceEnvRaw[child.composeService] = map;

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -339,7 +339,19 @@ export async function runDeployment(
     // Load env vars from encrypted blob
     const envMap: Record<string, string> = {};
     if (app.envContent) {
-      const { content: envText, wasEncrypted } = decryptOrFallback(app.envContent, app.organizationId);
+      const { content: envText, wasEncrypted, decryptFailed } = decryptOrFallback(
+        app.envContent,
+        app.organizationId,
+      );
+      // Deploying with no env is worse than not deploying: most apps boot on
+      // defaults, pass their healthcheck, and take the cutover while pointed
+      // at nothing.
+      if (decryptFailed) {
+        throw new DeployBlockedError(
+          `Could not decrypt this app's environment variables — check ENCRYPTION_MASTER_KEY. ` +
+            `Refusing to deploy without them.`,
+        );
+      }
       if (envText) {
         Object.assign(envMap, parseEnvToMap(envText));
         if (!wasEncrypted) {
@@ -351,8 +363,6 @@ export async function runDeployment(
               .where(eq(apps.id, app.id));
           } catch { /* best-effort */ }
         }
-      } else if (!wasEncrypted) {
-        log("[deploy] Warning: failed to decrypt env vars — check ENCRYPTION_MASTER_KEY");
       }
     }
 

--- a/tests/unit/lib/crypto/decrypt-fails-closed.test.ts
+++ b/tests/unit/lib/crypto/decrypt-fails-closed.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+
+// Set before the module loads — the key is read at import time.
+process.env.ENCRYPTION_MASTER_KEY ??= "0".repeat(64);
+
+const { decryptOrFallback, encrypt } = await import("@/lib/crypto/encrypt");
+
+// ---------------------------------------------------------------------------
+// The three states decryptOrFallback reports, and why the third has to abort
+// whatever was about to use the result.
+//
+// A failed decrypt returns empty content with wasEncrypted = true. Code shaped
+// as `if (content) {...} else if (!wasEncrypted) {warn}` takes neither branch,
+// so the caller proceeds with nothing and says nothing.
+// ---------------------------------------------------------------------------
+
+const ORG = "org-test";
+
+describe("decryptOrFallback", () => {
+  it("passes plaintext through as unencrypted", () => {
+    const result = decryptOrFallback("PLAIN=1", ORG);
+    expect(result).toMatchObject({ content: "PLAIN=1", wasEncrypted: false });
+    expect(result.decryptFailed).toBeFalsy();
+  });
+
+  it("round-trips a value encrypted for the same org", () => {
+    const result = decryptOrFallback(encrypt("SECRET=1", ORG), ORG);
+    expect(result).toMatchObject({ content: "SECRET=1", wasEncrypted: true });
+    expect(result.decryptFailed).toBeFalsy();
+  });
+
+  it("reports a failure distinctly, rather than as empty plaintext", () => {
+    const result = decryptOrFallback(encrypt("SECRET=1", ORG), "a-different-org");
+    expect(result.decryptFailed).toBe(true);
+    expect(result.content).toBe("");
+    expect(result.wasEncrypted).toBe(true);
+  });
+
+  it("the failure state is invisible to a content-or-wasEncrypted check", () => {
+    // This is the shape that shipped: neither branch fires, so a deploy
+    // proceeded with an empty environment and logged nothing.
+    const { content, wasEncrypted } = decryptOrFallback(encrypt("SECRET=1", ORG), "wrong-org");
+    const tookContentBranch = Boolean(content);
+    const tookWarningBranch = !wasEncrypted;
+    expect(tookContentBranch).toBe(false);
+    expect(tookWarningBranch).toBe(false);
+  });
+
+  it("an empty plaintext value is not a failure", () => {
+    const result = decryptOrFallback("", ORG);
+    expect(result.decryptFailed).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Found by a survey of comparable products' issue trackers, then confirmed against our own code.

`decryptOrFallback` reports three states (`lib/crypto/encrypt.ts:140-161`), and the third is a failure:

```
wasEncrypted=false, decryptFailed=false → plaintext (unmigrated row)
wasEncrypted=true,  decryptFailed=false → decrypted
wasEncrypted=true,  decryptFailed=true  → recognized as encrypted, decryption failed, content is empty
```

The deploy path read it as:

```ts
if (envText) { ...use it... }
else if (!wasEncrypted) { log("Warning: failed to decrypt env vars") }
```

On a genuine failure `envText` is `""` and `wasEncrypted` is `true`, so **neither branch fires**. The app deployed with an empty environment and logged nothing at all — the warning was unreachable, since it could only trigger for an empty *plaintext* value, which is not an error.

## Why it matters more than it looks

Most apps boot on defaults. So the deploy goes green, the healthcheck passes, Traefik cuts over, and the first symptom is a live app running against the wrong database or with auth disabled. Nothing in the log says why.

`decryptFailed` was already checked in exactly one of seven call sites — `deploy-steps/build.ts:287`, which correctly aborts for **org-level** secrets. App and child envs now match it. That asymmetry was the bug: org secrets failed closed, app secrets failed open.

## Peer evidence

The same shape has shipped elsewhere. Dokploy [#4817](https://github.com/Dokploy/dokploy/issues/4817) — a fail-open catch returned raw ciphertext, dotenv produced an empty env, and the service deployed with `Env: []`.

## Verification

4331 tests / 298 files green, 0 lint errors, typecheck clean. Five new tests, including one that asserts the failure state is invisible to the exact `content`/`wasEncrypted` check that shipped — so the shape cannot come back unnoticed.
