### PR TITLE
fix(migrations): apply each migration file in a transaction

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -13,6 +13,37 @@ if (!DATABASE_URL) {
 
 const sql = postgres(DATABASE_URL);
 
+// The object is already in its target state. Only reachable on a database left
+// half-applied by the older non-transactional runner, or altered out of band.
+const IGNORABLE = new Set([
+  "42710", // duplicate_object (enum value, constraint)
+  "42701", // duplicate_column
+  "42P07", // duplicate_table
+  "42P16", // invalid_table_definition (constraint already exists)
+]);
+
+// Postgres refuses the statement inside a transaction block.
+const NON_TRANSACTIONAL = new Set([
+  "25001", // active_sql_transaction (CREATE INDEX CONCURRENTLY, VACUUM, ...)
+  "55P04", // unsafe_new_enum_value_usage (enum value used in the transaction that added it)
+]);
+
+// A tolerated error still poisons the transaction, so each statement gets a savepoint.
+async function runStatement(db, stmt, transactional) {
+  try {
+    if (transactional) await db.savepoint((sp) => sp.unsafe(stmt));
+    else await db.unsafe(stmt);
+  } catch (err) {
+    if (!IGNORABLE.has(err.code)) throw err;
+    console.log(
+      `[migrate]   ↳ Skipped (already exists): ${err.message.split("\n")[0]}`,
+    );
+  }
+}
+
+const recordSql = (db, tag) =>
+  db`INSERT INTO __drizzle_migrations (hash, created_at) VALUES (${tag}, ${Date.now()})`;
+
 try {
   // Ensure migration tracking table exists
   await sql`
@@ -49,28 +80,24 @@ try {
       `[migrate] Applying ${entry.tag} (${statements.length} statements)...`,
     );
 
-    for (const stmt of statements) {
-      try {
-        await sql.unsafe(stmt);
-      } catch (err) {
-        // Tolerate DDL conflicts from partially-applied or out-of-band schema changes.
-        // These are safe to skip — the object already exists in the target state.
-        const code = err.code;
-        const ignorable =
-          code === "42710" || // duplicate_object (enum value, constraint)
-          code === "42701" || // duplicate_column
-          code === "42P07" || // duplicate_table
-          code === "42P16";   // invalid_table_definition (constraint already exists)
+    try {
+      // Statements and the journal row commit together — applied and recorded, or neither.
+      await sql.begin(async (tx) => {
+        for (const stmt of statements) await runStatement(tx, stmt, true);
+        await recordSql(tx, entry.tag);
+      });
+    } catch (err) {
+      if (!NON_TRANSACTIONAL.has(err.code)) throw err;
 
-        if (ignorable) {
-          console.log(`[migrate]   ↳ Skipped (already exists): ${err.message.split("\n")[0]}`);
-        } else {
-          throw err;
-        }
-      }
+      // The transaction rolled back, so nothing was applied and replaying is safe.
+      // Unwrapped is the only way these statements can run — atomicity is lost.
+      console.warn(
+        `[migrate]   ↳ ${entry.tag} cannot run inside a transaction (${err.code}) — applying it unwrapped, partial failure is possible`,
+      );
+      for (const stmt of statements) await runStatement(sql, stmt, false);
+      await recordSql(sql, entry.tag);
     }
 
-    await sql`INSERT INTO __drizzle_migrations (hash, created_at) VALUES (${entry.tag}, ${Date.now()})`;
     count++;
   }
 


### PR DESCRIPTION
Closes #814 (scope items 1 and 2 — the pre-migration snapshot is left for a separate change).

## What changed

`scripts/migrate.mjs` ran each statement bare and wrote the journal row only after the whole file finished. A failure at statement 3 of 4 committed statements 1-2 and recorded nothing, so the next container start replayed the file: the DDL was swallowed as "already exists" and the DML ran again.

Each file now applies inside a single transaction, with the journal insert in that same transaction. A file is either fully applied and recorded, or rolled back and not recorded — the replay window is gone.

## The swallowed error codes

Kept, but they mean something narrower now and are implemented differently.

Inside a transaction, catching `42710`/`42701`/`42P07`/`42P16` and carrying on does nothing — the transaction is already aborted, so every following statement fails with `25P02` and the file dies anyway. Written as it was, the tolerance would have been silently dead code. It now runs each statement inside its own savepoint, so a tolerated error rolls back that statement only.

The case they were written for — a file left half-applied by this runner — cannot happen any more. What they still cover:

- Databases already sitting in a half-applied state right now, put there by the old runner. Dropping the tolerance would hard-fail those on the next self-deploy.
- Schemas changed out of band, mainly `db:push` in dev.

Both are DDL-only conditions; none of the four codes can be raised by `UPDATE`/`INSERT`/`DELETE` (a duplicate key is `23505`, which is not tolerated). And the failure mode the issue is actually about — tolerated DDL clearing the way for a second DML run — is closed by the transaction, not by the code list.

## Migrations that cannot run in a transaction

None. All 66 files were checked: no `CREATE INDEX CONCURRENTLY`, no `VACUUM`, no `REINDEX`. Five files use `ALTER TYPE ... ADD VALUE` (`0003`, `0008`, `0022`, `0035`, `0044`), which Postgres 12+ permits inside a transaction as long as the new value is not used in the same transaction — none of the five do. All 65 journalled migrations applied wrapped, with no fallback triggered.

Rather than pattern-matching SQL, the escape hatch is driven by what Postgres actually raises. If a file aborts with `25001` (`active_sql_transaction`) or `55P04` (`unsafe_new_enum_value_usage`), the transaction has rolled back cleanly, so the file is replayed unwrapped and a warning is logged. That covers a future `CREATE INDEX CONCURRENTLY` or an enum value added and used in one file without anyone having to remember to annotate it.

## Verification

Postgres 17 in a throwaway container on port 7399. Full commands and output in the PR thread below.

Old runner, migration = `CREATE TABLE` / `UPDATE t SET n = n + 1` / a statement that fails the first time:

```
pass 1  -> [migrate] Failed: relation "gate" does not exist
           n = 1, journal has no row for the file
pass 2  -> Skipped (already exists): relation "keep_me" already exists
           [migrate] Applied 1 migration(s)
           n = 2      <- DML ran twice
```

New runner, same fixture and same database sequence:

```
pass 1  -> [migrate] Failed: relation "gate" does not exist
           n = 0, keep_me does not exist, journal has no row
pass 2  -> [migrate] Applied 1 migration(s)
           n = 1
pass 3  -> [migrate] Database is up to date
           n = 1
```

Also verified:

- The savepoint tolerance: a table pre-created out of band is skipped and the rest of the file still commits.
- The `25001` fallback with `CREATE INDEX CONCURRENTLY` and the `55P04` fallback with an enum value added and used in one file. Both apply and record.
- All 65 journalled migrations against an empty database: applied with no fallback, re-run reports "Database is up to date".
- `pg_dump -s` of a database migrated by the old runner vs the new one is byte-identical apart from pg_dump's own random `\restrict` token.

`pnpm typecheck` clean, `pnpm lint` 0 errors (376 pre-existing warnings), `pnpm vitest run` 4331 passed.

No vitest coverage added — the runner is a standalone `.mjs` with no seam for it, and the behavior under test is Postgres transaction semantics, which a mock would not exercise.

## Two things noticed, not fixed here

- `drizzle/0028_require_project_id.sql` is on disk but absent from `drizzle/meta/_journal.json`, so it has never run in production.
- The issue says 19 of 66 files contain DML. The real count is 10 (9 journalled); the rest of the matches are `ON UPDATE` in foreign keys and `updated_at` columns. Does not change the argument.
