### PR TITLE
fix(traefik): add a healthcheck so a wedged front door is visible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,9 +256,18 @@ services:
       - "--providers.file.directory=/etc/traefik/dynamic"
       - "--providers.file.watch=true"
       - "--log.level=${TRAEFIK_LOG_LEVEL:-WARN}"
+      # Serves /ping on the traefik entrypoint for the healthcheck below.
+      - "--ping=true"
     environment:
       # Required for DNS-01 challenge with Cloudflare. Set in .env when using DNS challenge.
       CF_DNS_API_TOKEN: ${CF_DNS_API_TOKEN:-}
+    healthcheck:
+      # Distroless image — no shell and no curl, so the probe is Traefik's own subcommand.
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
Traefik holds `:80` and `:443` alone for every site on the host and had no healthcheck at all. `restart: unless-stopped` acts on exit, never on health, so a Traefik that hangs rather than dies takes every site down while Docker reports it running and the health monitor reports the app containers healthy — because they are.

This does not restart anything. It makes the state legible: `docker ps` shows it, the monitor can read it, and a watchdog can act on it. That is the prerequisite for the rest of #807.

## Why the binary's own subcommand

The `traefik:v3` image is distroless — no shell, no `curl`, no `wget` — so a `CMD-SHELL` probe or a `curl` probe silently fails as a missing binary rather than as a real signal. `traefik healthcheck --ping` is the only probe the image can actually run.

## Verified, not assumed

Against `traefik:v3` (resolves to 3.7.10), in throwaway containers on `--network none`:

| Case | Result |
|---|---|
| `--ping=true`, `api.insecure=true` | `OK: http://:8080/ping`, exit 0 |
| No `--ping` at all | `Bad healthcheck status: 404`, exit 1 |
| `--ping=true`, no `api.insecure` | exit 0 — ping does not depend on the insecure API |
| `--ping=true`, entrypoint not declared | exit 0 — the `traefik` entrypoint defaults to `:8080` |

The second row is the one that matters: the probe is not vacuously passing.

Then the case this exists for — wedged but running, which is what the restart policy misses. With the healthcheck configured and the container frozen mid-flight:

```
healthy baseline: healthy
after freeze:     unhealthy  running=true
after unfreeze:   healthy
```

It recovers rather than latching, so a slow moment does not strand it unhealthy.

## Timings

15s interval, 5s timeout, 3 retries, 20s start period — about 45s to declare a wedge. Tighter than the console's 30s because everything on the host is behind this one container.

Closes part of #807. The watchdog sidecar, the escalation to slot rollback, and the systemd unit are still open there.
