### PR TITLE
fix(security): stop transfer analysis disclosing a destination org's apps

### DIFF
--- a/app/api/v1/organizations/[orgId]/apps/[appId]/transfer/route.ts
+++ b/app/api/v1/organizations/[orgId]/apps/[appId]/transfer/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
-import { apps, appTransfers } from "@/lib/db/schema";
+import { apps, appTransfers, organizations } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
 import { initiateTransfer, analyzeTransfer, rejectTransfer } from "@/lib/transfers/engine";
@@ -53,6 +53,20 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    // Existence only — the destination accepts or rejects, so membership in it
+    // is not required. Its contents must not reach this response.
+    const destinationOrg = await db.query.organizations.findFirst({
+      where: eq(organizations.id, destinationOrgId),
+      columns: { id: true },
+    });
+
+    if (!destinationOrg) {
+      return NextResponse.json(
+        { error: "Destination organization not found" },
+        { status: 404 },
+      );
+    }
+
     // Verify the app exists in this org
     const app = await db.query.apps.findFirst({
       where: and(
@@ -82,7 +96,7 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
     }
 
     // Run analysis and create the transfer
-    const analysis = await analyzeTransfer(appId, orgId, destinationOrgId);
+    const analysis = await analyzeTransfer(appId);
 
     const transferId = await initiateTransfer({
       appId: appId,
@@ -100,7 +114,7 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       metadata: {
         transferId,
         destinationOrgId,
-        frozenRefsCount: analysis.frozenRefs.length,
+        crossProjectRefsCount: analysis.crossProjectRefs.length,
         warningsCount: analysis.warnings.length,
       },
     });
@@ -109,7 +123,7 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       {
         transferId,
         analysis: {
-          frozenRefs: analysis.frozenRefs,
+          crossProjectRefs: analysis.crossProjectRefs,
           warnings: analysis.warnings,
         },
       },

--- a/app/api/v1/organizations/[orgId]/transfers/[transferId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/transfers/[transferId]/route.ts
@@ -36,10 +36,12 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Fetch the transfer
+    // Scoped to the destination org: a transfer addressed to anyone else is
+    // indistinguishable from one that does not exist.
     const transfer = await db.query.appTransfers.findFirst({
       where: and(
         eq(appTransfers.id, transferId),
+        eq(appTransfers.destinationOrgId, orgId),
         eq(appTransfers.status, "pending"),
       ),
       with: {
@@ -51,14 +53,6 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(
         { error: "Transfer not found or not pending" },
         { status: 404 },
-      );
-    }
-
-    // Only owners/admins of the destination org can accept/reject
-    if (transfer.destinationOrgId !== orgId) {
-      return NextResponse.json(
-        { error: "Only the destination organization can respond to this transfer" },
-        { status: 403 },
       );
     }
 

--- a/lib/transfers/engine.ts
+++ b/lib/transfers/engine.ts
@@ -9,16 +9,19 @@ import { eq, and, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { extractExpressions, validateExpression } from "@/lib/env/resolve";
 
+type CrossProjectRef = {
+  key: string;
+  refApp: string;
+  originalRef: string;
+  currentValue: string;
+};
+
 /**
  * Analyze what would happen if an app is transferred.
- * Returns list of cross-project refs that would become unresolvable.
+ * Reads the source app only; which refs actually freeze is decided on accept.
  */
-export async function analyzeTransfer(
-  appId: string,
-  sourceOrgId: string,
-  destinationOrgId: string,
-): Promise<{
-  frozenRefs: { key: string; originalRef: string; currentValue: string }[];
+export async function analyzeTransfer(appId: string): Promise<{
+  crossProjectRefs: CrossProjectRef[];
   warnings: string[];
 }> {
   // Load app's env vars (base-level, no environment override)
@@ -26,20 +29,7 @@ export async function analyzeTransfer(
     where: and(eq(envVars.appId, appId), isNull(envVars.environmentId)),
   });
 
-  // Load all app names in destination org
-  const destApps = await db.query.apps.findMany({
-    where: eq(apps.organizationId, destinationOrgId),
-    columns: { name: true },
-  });
-  const destAppNames = new Set(destApps.map((a) => a.name));
-
-  // Load all app names in source org (for reference resolution)
-  const sourceApps = await db.query.apps.findMany({
-    where: eq(apps.organizationId, sourceOrgId),
-    columns: { name: true },
-  });
-
-  const frozenRefs: { key: string; originalRef: string; currentValue: string }[] = [];
+  const crossProjectRefs: CrossProjectRef[] = [];
   const warnings: string[] = [];
 
   for (const v of vars) {
@@ -47,15 +37,12 @@ export async function analyzeTransfer(
     for (const expr of expressions) {
       const { type, target } = validateExpression(expr);
       if (type === "cross-project") {
-        const refAppName = target.split(".")[0];
-        // If the referenced app won't exist in the destination org
-        if (!destAppNames.has(refAppName)) {
-          frozenRefs.push({
-            key: v.key,
-            originalRef: `\${${expr}}`,
-            currentValue: v.value,
-          });
-        }
+        crossProjectRefs.push({
+          key: v.key,
+          refApp: target.split(".")[0],
+          originalRef: `\${${expr}}`,
+          currentValue: v.value,
+        });
       }
       if (type === "org-var") {
         warnings.push(
@@ -65,7 +52,29 @@ export async function analyzeTransfer(
     }
   }
 
-  return { frozenRefs, warnings };
+  return { crossProjectRefs, warnings };
+}
+
+/** Cross-project refs with no app of that name in the destination org. */
+async function resolveFrozenRefs(
+  appId: string,
+  destinationOrgId: string,
+): Promise<{ key: string; originalRef: string; frozenValue: string }[]> {
+  const { crossProjectRefs } = await analyzeTransfer(appId);
+
+  const destApps = await db.query.apps.findMany({
+    where: eq(apps.organizationId, destinationOrgId),
+    columns: { name: true },
+  });
+  const destAppNames = new Set(destApps.map((a) => a.name));
+
+  return crossProjectRefs
+    .filter((r) => !destAppNames.has(r.refApp))
+    .map((r) => ({
+      key: r.key,
+      originalRef: r.originalRef,
+      frozenValue: r.currentValue,
+    }));
 }
 
 /**
@@ -78,12 +87,6 @@ export async function initiateTransfer(opts: {
   initiatedBy: string;
   note?: string;
 }): Promise<string> {
-  const analysis = await analyzeTransfer(
-    opts.appId,
-    opts.sourceOrgId,
-    opts.destinationOrgId,
-  );
-
   const id = nanoid();
   await db.insert(appTransfers).values({
     id,
@@ -92,11 +95,7 @@ export async function initiateTransfer(opts: {
     destinationOrgId: opts.destinationOrgId,
     initiatedBy: opts.initiatedBy,
     status: "pending",
-    frozenRefs: analysis.frozenRefs.map((r) => ({
-      key: r.key,
-      originalRef: r.originalRef,
-      frozenValue: r.currentValue,
-    })),
+    frozenRefs: [],
     note: opts.note,
   });
 
@@ -120,8 +119,13 @@ export async function acceptTransfer(
   }
 
   // Freeze cross-project refs that won't resolve in the new org
-  if (transfer.frozenRefs && transfer.frozenRefs.length > 0) {
-    for (const ref of transfer.frozenRefs) {
+  const frozenRefs = await resolveFrozenRefs(
+    transfer.appId,
+    transfer.destinationOrgId,
+  );
+
+  if (frozenRefs.length > 0) {
+    for (const ref of frozenRefs) {
       const vars = await db.query.envVars.findMany({
         where: and(
           eq(envVars.appId, transfer.appId),
@@ -176,6 +180,7 @@ export async function acceptTransfer(
     .update(appTransfers)
     .set({
       status: "accepted",
+      frozenRefs,
       respondedBy,
       respondedAt: new Date(),
     })

--- a/tests/unit/api/apps/transfer-destination-oracle.test.ts
+++ b/tests/unit/api/apps/transfer-destination-oracle.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/organizations/[orgId]/apps/[appId]/transfer
+// ---------------------------------------------------------------------------
+// destinationOrgId is caller-supplied and needs no membership — the destination
+// accepts or rejects. Analysis that read the destination's app names turned that
+// into an existence oracle: craft a ref, read which refs came back unresolved.
+
+type Predicate =
+  | { op: "eq"; col: string; val: unknown }
+  | { op: "isNull"; col: string }
+  | { op: "and"; parts: Predicate[] };
+
+function matches(row: Record<string, unknown>, pred: Predicate | undefined): boolean {
+  if (!pred) return true;
+  if (pred.op === "and") return pred.parts.every((p) => matches(row, p));
+  if (pred.op === "isNull") return row[pred.col] == null;
+  return row[pred.col] === pred.val;
+}
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: string, val: unknown) => ({ op: "eq", col, val }),
+  and: (...parts: Predicate[]) => ({ op: "and", parts }),
+  isNull: (col: string) => ({ op: "isNull", col }),
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apps: { id: "id", organizationId: "organizationId", name: "name" },
+  appTransfers: {
+    id: "id",
+    appId: "appId",
+    status: "status",
+    destinationOrgId: "destinationOrgId",
+  },
+  memberships: { userId: "userId", organizationId: "organizationId" },
+  envVars: { id: "id", appId: "appId", key: "key", environmentId: "environmentId" },
+  organizations: { id: "id" },
+  projects: { organizationId: "organizationId", name: "name", id: "id" },
+}));
+
+const {
+  appsFindFirst,
+  appsFindMany,
+  envVarsFindMany,
+  transfersFindFirst,
+  organizationsFindFirst,
+  membershipsFindFirst,
+  insertValues,
+} = vi.hoisted(() => ({
+  appsFindFirst: vi.fn(),
+  appsFindMany: vi.fn(),
+  envVarsFindMany: vi.fn(),
+  transfersFindFirst: vi.fn(),
+  organizationsFindFirst: vi.fn(),
+  membershipsFindFirst: vi.fn(),
+  insertValues: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      apps: { findFirst: appsFindFirst, findMany: appsFindMany },
+      appTransfers: { findFirst: transfersFindFirst },
+      envVars: { findMany: envVarsFindMany },
+      organizations: { findFirst: organizationsFindFirst },
+      memberships: { findFirst: membershipsFindFirst },
+    },
+    insert: () => ({ values: insertValues }),
+  },
+}));
+
+vi.mock("nanoid", () => ({ nanoid: () => "transfer-1" }));
+
+vi.mock("@/lib/api/verify-access", () => ({
+  verifyOrgAccess: vi.fn().mockResolvedValue({
+    organization: { id: "org-source" },
+    membership: { role: "owner" },
+    session: { user: { id: "user-1" } },
+  }),
+}));
+
+vi.mock("@/lib/api/with-rate-limit", () => ({
+  withRateLimit: (handler: (...args: never[]) => unknown) => handler,
+}));
+
+vi.mock("@/lib/api/error-response", () => ({
+  handleRouteError: (error: unknown) => {
+    throw error;
+  },
+}));
+
+vi.mock("@/lib/activity", () => ({ recordActivity: vi.fn() }));
+
+import { POST } from "@/app/api/v1/organizations/[orgId]/apps/[appId]/transfer/route";
+import { POST as respond } from "@/app/api/v1/organizations/[orgId]/transfers/[transferId]/route";
+
+const SOURCE_ORG = "org-source";
+const DEST_ORG = "org-destination";
+const APP_ID = "app-1";
+
+// The app's env var points at "secret-api", the name being probed for.
+const ENV_VARS = [
+  {
+    id: "env-1",
+    appId: APP_ID,
+    key: "DB_URL",
+    environmentId: null,
+    value: "postgres://${secret-api.HOST}/db",
+  },
+];
+
+function transferTo(destinationOrgId: string) {
+  const request = new NextRequest(
+    `http://localhost/api/v1/organizations/${SOURCE_ORG}/apps/${APP_ID}/transfer`,
+    { method: "POST", body: JSON.stringify({ destinationOrgId }) },
+  );
+  return POST(request, {
+    params: Promise.resolve({ orgId: SOURCE_ORG, appId: APP_ID }),
+  });
+}
+
+/** Seed the destination org with the given app names and run the transfer. */
+async function transferWithDestinationApps(names: string[]) {
+  appsFindMany.mockImplementation(({ where }: { where?: Predicate }) =>
+    Promise.resolve(
+      names
+        .map((name) => ({ name, organizationId: DEST_ORG }))
+        .filter((row) => matches(row, where)),
+    ),
+  );
+
+  const response = await transferTo(DEST_ORG);
+  return { status: response.status, body: await response.json() };
+}
+
+describe("POST /apps/[appId]/transfer — destination org disclosure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appsFindFirst.mockResolvedValue({ id: APP_ID, name: "web" });
+    envVarsFindMany.mockResolvedValue(ENV_VARS);
+    transfersFindFirst.mockResolvedValue(undefined);
+    organizationsFindFirst.mockResolvedValue({ id: DEST_ORG });
+    insertValues.mockResolvedValue(undefined);
+  });
+
+  it("answers identically whether the referenced app exists in the destination", async () => {
+    const present = await transferWithDestinationApps(["secret-api"]);
+    const absent = await transferWithDestinationApps(["something-else"]);
+
+    expect(present.status).toBe(201);
+    expect(present).toEqual(absent);
+  });
+
+  it("does not read the destination org's apps", async () => {
+    await transferWithDestinationApps(["secret-api"]);
+
+    expect(appsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("reports the app's own cross-project refs without resolving them", async () => {
+    const { body } = await transferWithDestinationApps(["secret-api"]);
+
+    expect(body.analysis.crossProjectRefs).toEqual([
+      {
+        key: "DB_URL",
+        refApp: "secret-api",
+        originalRef: "${secret-api.HOST}",
+        currentValue: "postgres://${secret-api.HOST}/db",
+      },
+    ]);
+  });
+
+  it("stores no resolved refs on the pending transfer", async () => {
+    await transferWithDestinationApps([]);
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ frozenRefs: [] }),
+    );
+  });
+
+  it("rejects an unknown destination org before touching the app", async () => {
+    organizationsFindFirst.mockResolvedValue(undefined);
+
+    const response = await transferTo("org-missing");
+
+    expect(response.status).toBe(404);
+    expect(appsFindFirst).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+});
+
+// A transfer addressed to another org used to answer 403 where an unknown id
+// answered 404, which told the caller the id was real.
+describe("POST /transfers/[transferId] — transfer id scope", () => {
+  const TRANSFER_ROWS = [
+    {
+      id: "transfer-foreign",
+      appId: APP_ID,
+      status: "pending",
+      destinationOrgId: "org-elsewhere",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    membershipsFindFirst.mockResolvedValue({ role: "owner" });
+    transfersFindFirst.mockImplementation(({ where }: { where?: Predicate }) =>
+      Promise.resolve(TRANSFER_ROWS.find((row) => matches(row, where))),
+    );
+  });
+
+  async function respondTo(transferId: string) {
+    const request = new NextRequest(
+      `http://localhost/api/v1/organizations/${SOURCE_ORG}/transfers/${transferId}`,
+      { method: "POST", body: JSON.stringify({ action: "accept" }) },
+    );
+    const response = await respond(request, {
+      params: Promise.resolve({ orgId: SOURCE_ORG, transferId }),
+    });
+    return { status: response.status, body: await response.json() };
+  }
+
+  it("answers identically for another org's transfer and an unknown id", async () => {
+    const foreign = await respondTo("transfer-foreign");
+    const unknown = await respondTo("transfer-missing");
+
+    expect(foreign.status).toBe(404);
+    expect(foreign).toEqual(unknown);
+  });
+});


### PR DESCRIPTION
Closes #804

## The leak

`POST /organizations/[orgId]/apps/[appId]/transfer` accepts any `destinationOrgId` — by design, since the destination has to accept before anything moves. But `analyzeTransfer` read the destination org's app names to work out which cross-project refs would survive, and the 201 body's `frozenRefs` reported the per-ref verdict. Point a crafted env var at `${probe.HOST}`, initiate a transfer, and the response tells you whether that org has an app called `probe`.

A count instead of a verdict list, as the issue suggested, does not close it: with one crafted ref, 0 vs 1 is the same bit. So the destination is no longer read at initiation at all.

- `analyzeTransfer(appId)` reads the source app's env vars and returns its cross-project refs unresolved, plus the existing org-var warnings. Every field is the caller's own data.
- Resolution moved into `acceptTransfer`, behind the destination org's owner/admin check. The pending row now stores `frozenRefs: []` and is filled in on accept, so the deferred read is not available through `GET /transfers` either.
- Response key renamed `analysis.frozenRefs` → `analysis.crossProjectRefs`, since it no longer means "these will freeze". No UI, docs, MCP tool or test consumed the old key.

## Second oracle in the same handler

`destination_org_id` is a foreign key, so a nonexistent org id threw on insert and came back as a 500 while a real one returned 201 — existence, by status code. The handler now resolves the destination up front and returns a plain 404. Whether an org id exists is still learnable, but that is the precondition of the whole flow — you cannot transfer to an org whose id you were never given — and ids are 21-character nanoids. What is gone is anything that varies with the org's *contents*.

## Authorization order

Already correct: `verifyOrgAccess(orgId)` for the source org runs before anything else in the handler. The bug was not ordering, it was a lookup that had no business happening at that point in the flow.

## Sibling routes

Audited every handler that takes a target org or app identifier from the caller.

Fixed:
- `POST /organizations/[orgId]/transfers/[transferId]` — fetched the transfer by id with no org predicate, then answered 403 "only the destination organization can respond" for a transfer belonging to two other orgs, versus 404 for an id matching nothing. Same shape, smaller blast radius. The lookup is now scoped by `destinationOrgId`, and the 403 branch is gone since it is unreachable.

Already correct, no change:
- `POST /organizations/[orgId]/adopt` — membership first; the instance-wide name check returns `APP_NAME_TAKEN_ERROR` with no `appId` for foreign apps and no org attribution.
- `/organizations/[orgId]/invitations` and `/invitations/[invitationId]` — target is derived from the route, and the lookup is scoped by `targetId`.
- `POST /invitations/accept` — a 32-byte token is the authorization; it only echoes to a holder of the token.
- `/apps/[appId]/environments/[envId]/clone` and the `cloneFrom` path in `/environments` — no caller-supplied target; every lookup is `appId`-scoped.
- `/discover/groups/[composeProject]/import` and `/discover/containers/[containerId]/import` — org verified first, duplicate checks org-scoped, and `resolveProjectForImport` requires a matching `organizationId`.
- `GET /organizations/[orgId]/transfers` — filtered to transfers where the org is source or destination.
- `POST /organizations/switch` — nonexistent org and non-member org both 403.
- `lib/mcp/tools/adopt-app.ts` — one "not found or access denied" for both cases.

`app/api/v1/mesh/*` takes an arbitrary `orgId` on a peer bearer token and will read any org on the instance. That is documented as intentional trust-the-mesh behavior, not the same bug, but it is worth a separate issue if peer isolation is ever wanted. `admin/mesh/*` is instance-admin gated.

## Verification

`pnpm test` — typecheck, lint (0 errors), 4337 vitest tests pass.

New: `tests/unit/api/apps/transfer-destination-oracle.test.ts`. The core case seeds the destination with the probed app name and then without it, and asserts the two responses are equal — status and body — which is the property the issue asks for. Plus: the destination's apps are never queried during initiation, the pending row stores no resolved refs, an unknown destination org 404s before the app is touched, and a foreign transfer id is indistinguishable from an unknown one.

Confirmed the tests fail on the pre-fix code: 5 of the 6 fail when the source changes are stashed.

## Not addressed

`acceptTransfer` freezes a ref by replacing `${app.KEY}` with the whole env var value rather than the value the expression resolves to, which produces a duplicated string. Pre-existing, unrelated to the disclosure, and doing it properly needs the full resolver — left alone deliberately. Worth its own issue.

The frozen value is now snapshotted at accept time rather than initiation, a side effect of moving the computation. That is the more accurate of the two.
