### PR TITLE
fix(backups): keep backing up an app after it is stopped

### DIFF
--- a/lib/attention/rows.ts
+++ b/lib/attention/rows.ts
@@ -1,9 +1,12 @@
 import "server-only";
 
 import { and, desc, eq, gte, inArray, isNotNull, isNull } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 
 import { db } from "@/lib/db";
-import { apps, backups } from "@/lib/db/schema";
+import { apps, backupJobApps, backupJobs, backups, volumes } from "@/lib/db/schema";
+import { isBackupSelected } from "@/lib/backups/durability";
+import { OVERDUE_INTERVALS, overdueBackupJobs } from "@/lib/backups/staleness";
 import { defaultMemoryLimitMb, type QosTier } from "@/lib/docker/compose-inject";
 import { getCooldownUntil } from "@/lib/docker/image-updates/check";
 import { getAggregateUpdateStatus } from "@/lib/docker/image-updates/status";
@@ -24,6 +27,9 @@ import { getFleetAttention } from "./fleet";
 
 /** A failure older than this is history, not something to act on now. */
 const BACKUP_FAILURE_WINDOW_HOURS = 48;
+
+/** A compose child's parent, so a paused database says whose it is. */
+const pausedParents = alias(apps, "paused_parents");
 
 /** An OOM kill older than this is history too, even if the app is still down. */
 const OOM_WINDOW_HOURS = 7 * 24;
@@ -56,6 +62,97 @@ async function loadFailedBackups(appIds: string[]) {
     if (row.appId && !latest.has(row.appId)) latest.set(row.appId, row);
   }
   return [...latest.values()];
+}
+
+/**
+ * Jobs that have captured nothing for several of their own schedule intervals,
+ * with a route to the app when the job covers exactly one.
+ *
+ * Read straight from the jobs rather than from the apps they cover: the app
+ * conditions are only evaluated for apps that have a container, which is every
+ * app except the ones whose backups have quietly stopped.
+ */
+async function loadOverdueBackupJobs(orgId: string, now: Date) {
+  const jobRows = await db
+    .select({
+      id: backupJobs.id,
+      name: backupJobs.name,
+      schedule: backupJobs.schedule,
+      enabled: backupJobs.enabled,
+      lastRunAt: backupJobs.lastRunAt,
+      createdAt: backupJobs.createdAt,
+    })
+    .from(backupJobs)
+    .where(eq(backupJobs.organizationId, orgId));
+
+  const overdue = overdueBackupJobs(jobRows, now);
+  if (overdue.length === 0) return [];
+
+  const links = await db
+    .select({ jobId: backupJobApps.backupJobId, appName: apps.name })
+    .from(backupJobApps)
+    .innerJoin(apps, eq(apps.id, backupJobApps.appId))
+    .where(
+      inArray(
+        backupJobApps.backupJobId,
+        overdue.map((o) => o.job.id),
+      ),
+    );
+
+  const appsByJob = new Map<string, string[]>();
+  for (const link of links) {
+    appsByJob.set(link.jobId, [...(appsByJob.get(link.jobId) ?? []), link.appName]);
+  }
+
+  return overdue.map((entry) => {
+    const covered = appsByJob.get(entry.job.id) ?? [];
+    return {
+      ...entry,
+      href: covered.length === 1 ? `/apps/${covered[0]}/backups` : "/backups",
+    };
+  });
+}
+
+/**
+ * Stopped apps whose database cannot be dumped until they run again. Their
+ * other volumes are still archived on schedule — this is the one source a
+ * stopped app cannot produce.
+ */
+async function loadPausedDumps(orgId: string) {
+  const rows = await db
+    .select({
+      id: apps.id,
+      name: apps.name,
+      displayName: apps.displayName,
+      parentName: pausedParents.displayName,
+      statusChangedAt: apps.statusChangedAt,
+      isSystemManaged: apps.isSystemManaged,
+      persistent: volumes.persistent,
+      durability: volumes.durability,
+    })
+    .from(apps)
+    .leftJoin(pausedParents, eq(pausedParents.id, apps.parentAppId))
+    .innerJoin(volumes, eq(volumes.appId, apps.id))
+    .innerJoin(backupJobApps, eq(backupJobApps.appId, apps.id))
+    .innerJoin(
+      backupJobs,
+      and(eq(backupJobs.id, backupJobApps.backupJobId), eq(backupJobs.enabled, true)),
+    )
+    .where(
+      and(
+        eq(apps.organizationId, orgId),
+        eq(apps.status, "stopped"),
+        eq(volumes.backupStrategy, "dump"),
+      ),
+    );
+
+  const byApp = new Map<string, (typeof rows)[number]>();
+  for (const row of rows) {
+    if (isVardoManagedApp(row)) continue;
+    if (!isBackupSelected(row)) continue;
+    if (!byApp.has(row.id)) byApp.set(row.id, row);
+  }
+  return [...byApp.values()];
 }
 
 /**
@@ -138,11 +235,24 @@ export async function buildAttentionRows(
 
   const appIds = appRows.map((a) => a.id);
 
-  const [fleet, updates, version, failedBackups, activity, exited, subjects, elevated] = await Promise.all([
+  const [
+    fleet,
+    updates,
+    version,
+    failedBackups,
+    overdueJobs,
+    pausedDumps,
+    activity,
+    exited,
+    subjects,
+    elevated,
+  ] = await Promise.all([
     getFleetAttention(orgId),
     getCooldownUntil().then((cooldown) => getAggregateUpdateStatus(orgId, appRows, cooldown)),
     isAppAdmin ? getVersionData().catch(() => null) : null,
     loadFailedBackups(appIds),
+    loadOverdueBackupJobs(orgId, new Date()),
+    loadPausedDumps(orgId),
     getFleetActivity(appIds),
     loadExitReasons(orgId),
     loadStatusSubjects(orgId),
@@ -244,6 +354,39 @@ export async function buildAttentionRows(
         };
       }),
       footer: `${failedBackups.length} app${failedBackups.length === 1 ? "" : "s"} failed a backup in the last ${BACKUP_FAILURE_WINDOW_HOURS} hours. Each row is its most recent failure.`,
+    });
+  }
+
+  if (overdueJobs.length > 0) {
+    rows.push({
+      key: "backup-overdue",
+      label: "Backup overdue",
+      tone: "warning",
+      items: overdueJobs.map((o) => ({
+        id: o.job.id,
+        name: o.job.name,
+        href: o.href,
+        detail: o.neverRan ? "Has never captured a backup" : undefined,
+        since: o.since.toISOString(),
+      })),
+      footer: `Each of these jobs has captured nothing for more than ${OVERDUE_INTERVALS} runs of its own schedule. The time shown is since its last archive, or since the job was created.`,
+    });
+  }
+
+  if (pausedDumps.length > 0) {
+    rows.push({
+      key: "backup-paused",
+      label: "Backup paused",
+      tone: "warning",
+      items: pausedDumps.map((a) => ({
+        id: a.id,
+        name: a.parentName ? `${a.parentName} · ${a.displayName}` : a.displayName,
+        href: `/apps/${a.name}/backups`,
+        detail: "Database dump needs a running container",
+        since: a.statusChangedAt?.toISOString(),
+      })),
+      footer:
+        "These apps are stopped. Their volumes are still archived on schedule, but a database dump cannot run until the app is started.",
     });
   }
 

--- a/lib/backups/coverage.ts
+++ b/lib/backups/coverage.ts
@@ -31,3 +31,20 @@ export function uncapturedReason(vol: CoverableVolume): string {
   const path = vol.source ? ` (${vol.source})` : "";
   return `Bind mount${path} is not backed up — mark the volume stateful to archive this host path`;
 }
+
+/**
+ * Why a dump cannot be captured right now, or null when it can.
+ *
+ * A dump runs inside the database, so it needs a container to run in. Tar does
+ * not: a stopped app's volumes are still on disk and still archivable, which is
+ * why only this one strategy pauses when the app comes down.
+ */
+export function pausedDumpReason(vol: {
+  backupStrategy: string;
+  /** apps.status for the owning app. Null for a volume linked without one. */
+  appStatus?: string | null;
+}): string | null {
+  if (vol.backupStrategy !== "dump") return null;
+  if (vol.appStatus !== "stopped") return null;
+  return "App is stopped — a database dump needs a running container. Start the app to capture it.";
+}

--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -17,7 +17,7 @@ import { resolve, join } from "path";
 import type { BackupStorage } from "./storage-port";
 import { createBackupStorage } from "./storage-factory";
 import { assertSafeName } from "@/lib/docker/validate";
-import { isUncapturedSource, uncapturedReason } from "./coverage";
+import { isUncapturedSource, pausedDumpReason, uncapturedReason } from "./coverage";
 import { exclusionReason, isBackupSelected } from "./durability";
 import { assertSafeBindSource } from "@/lib/docker/mount-paths";
 import { buildDumpArgv, buildRestoreArgv, describeDumpSpec, type DumpSpec } from "./dump-spec";
@@ -78,6 +78,8 @@ export type BackupResult = {
   sizeBytes: number;
   storagePath: string;
   error?: string;
+  /** Skipped because the app is stopped, not because anything went wrong. */
+  paused?: boolean;
   durationMs: number;
 };
 
@@ -92,6 +94,8 @@ type VolumeToBackup = {
   mountPath: string | null;
   appId: string | null;
   appName: string | null;
+  /** apps.status for the owning app. Null for a directly linked volume. */
+  appStatus: string | null;
   /** Owning org, so an instance-level job reports progress to each app's org. */
   orgId: string | null;
   orgSlug: string | null;
@@ -554,11 +558,12 @@ export async function runBackup(
 
   const scope = options.appIds ? new Set(options.appIds) : null;
   const scoped = scope ? owned.filter((bja) => scope.has(bja.app.id)) : owned;
-  // A retired app's volumes are empty or gone, so a scheduled run against it
-  // fails every night with nothing to fix. An explicit request still runs.
+  // A retired app has no volumes left, so a scheduled run against it fails
+  // every night with nothing to fix. A stopped app still holds its data and is
+  // still backed up. An explicit request runs against either.
   const jobApps = options.appIds
     ? scoped
-    : scoped.filter((bja) => bja.app.status !== "missing" && bja.app.status !== "stopped");
+    : scoped.filter((bja) => bja.app.status !== "missing");
   const jobVolumes = scope
     ? job.backupJobVolumes.filter((bjv) => bjv.volume.appId && scope.has(bjv.volume.appId))
     : job.backupJobVolumes;
@@ -609,6 +614,7 @@ export async function runBackup(
         mountPath: vol.mountPath,
         appId: app.id,
         appName: app.name,
+        appStatus: app.status,
         orgId: app.organizationId,
         orgSlug,
         type: vol.type,
@@ -635,6 +641,7 @@ export async function runBackup(
       mountPath: vol.mountPath,
       appId: vol.appId,
       appName: null,
+      appStatus: null,
       orgId: null,
       orgSlug: null,
       type: vol.type,
@@ -856,13 +863,20 @@ export async function runBackup(
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       log(`Backup failed: ${errorMsg}`);
+
+      // Classified after the attempt, not before it: apps.status is a cached
+      // observation, so an app recorded as stopped whose container is in fact
+      // up still gets its dump.
+      const paused = pausedDumpReason(vol);
+      if (paused) log(paused);
+
       const finishedAt = new Date();
       const durationMs = finishedAt.getTime() - startedAt.getTime();
 
       await db
         .update(backups)
         .set({
-          status: "failed",
+          status: paused ? "skipped" : "failed",
           log: logLines.join("\n"),
           finishedAt,
         })
@@ -872,10 +886,11 @@ export async function runBackup(
         backupId,
         appId: vol.appId || "",
         volumeName: vol.name,
-        outcome: "failed",
+        outcome: paused ? "skipped" : "failed",
         sizeBytes: 0,
         storagePath: "",
-        error: errorMsg,
+        error: paused ?? errorMsg,
+        paused: paused !== null,
         durationMs,
       });
     }
@@ -900,9 +915,13 @@ export async function runBackup(
     const succeeded = results.filter((r) => r.outcome === "success");
     const failed = results.filter((r) => r.outcome === "failed");
     const skipped = results.filter((r) => r.outcome === "skipped");
-    // A run that captured nothing is not a success.
+    // A run that captured nothing is not a success, unless everything it could
+    // not capture is a dump waiting on a stopped app. That is a state to show
+    // on the attention surface, not a fault to alert on every night.
     const capturedNothing = succeeded.length === 0;
-    const hasFailures = failed.length > 0 || capturedNothing;
+    const onlyPaused =
+      capturedNothing && failed.length === 0 && skipped.length > 0 && skipped.every((r) => r.paused);
+    const hasFailures = failed.length > 0 || (capturedNothing && !onlyPaused);
     const allSuccess = !hasFailures;
     const notes = [
       skipped.length > 0 ? `${skipped.length} skipped` : null,
@@ -910,7 +929,9 @@ export async function runBackup(
     ].filter(Boolean);
     const skippedNote = notes.length > 0 ? ` (${notes.join(", ")})` : "";
 
-    if (job.organizationId && ((hasFailures && job.notifyOnFailure) || (allSuccess && job.notifyOnSuccess))) {
+    if (onlyPaused) {
+      log.info(`${job.name}: nothing captured — every source is waiting on a stopped app`);
+    } else if (job.organizationId && ((hasFailures && job.notifyOnFailure) || (allSuccess && job.notifyOnSuccess))) {
       const { emit } = await import("@/lib/notifications/dispatch");
       const names = jobApps.map((bja) => bja.app.name).join(", ") || job.name;
       if (hasFailures) {

--- a/lib/backups/staleness.ts
+++ b/lib/backups/staleness.ts
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// Backup job staleness
+//
+// lastRunAt only advances when a run captures something, so a job that has
+// quietly stopped producing archives leaves it behind. This turns that into a
+// verdict the attention surface can read, without asking why the job stopped.
+//
+// Pure — no server imports.
+// ---------------------------------------------------------------------------
+
+import { Cron } from "croner";
+
+/** Missed runs before a job counts as overdue. One late run is a slow night. */
+export const OVERDUE_INTERVALS = 2;
+
+/** Fires sampled to measure an interval. Weekday-only schedules vary by gap. */
+const INTERVAL_SAMPLES = 4;
+
+export type ScheduledBackupJob = {
+  id: string;
+  name: string;
+  schedule: string;
+  enabled: boolean;
+  lastRunAt: Date | null;
+  createdAt: Date;
+};
+
+export type OverdueBackupJob = {
+  job: ScheduledBackupJob;
+  /** Last capture, or when the job was created if it has never captured one. */
+  since: Date;
+  neverRan: boolean;
+};
+
+/**
+ * Longest gap between the schedule's next few fires. Null when the expression
+ * is unparseable or has no repeat left.
+ *
+ * The longest rather than the first: `0 2 * * 1-5` runs 24h apart most nights
+ * and 72h apart over a weekend, and the shorter gap would call every Monday
+ * morning overdue.
+ */
+export function scheduleIntervalMs(schedule: string, from: Date): number | null {
+  if (!schedule.trim()) return null;
+  try {
+    const runs = new Cron(schedule.trim()).nextRuns(INTERVAL_SAMPLES, from);
+    if (runs.length < 2) return null;
+    let longest = 0;
+    for (let i = 1; i < runs.length; i++) {
+      longest = Math.max(longest, runs[i].getTime() - runs[i - 1].getTime());
+    }
+    return longest > 0 ? longest : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enabled jobs that have captured nothing for OVERDUE_INTERVALS of their own
+ * schedule. A job that has never run is measured from when it was created, so
+ * one made a minute ago is not overdue before its first fire.
+ */
+export function overdueBackupJobs(
+  jobs: ScheduledBackupJob[],
+  now: Date,
+): OverdueBackupJob[] {
+  const overdue: OverdueBackupJob[] = [];
+
+  for (const job of jobs) {
+    if (!job.enabled) continue;
+    const interval = scheduleIntervalMs(job.schedule, now);
+    if (interval === null) continue;
+
+    const since = job.lastRunAt ?? job.createdAt;
+    if (now.getTime() - since.getTime() <= interval * OVERDUE_INTERVALS) continue;
+
+    overdue.push({ job, since, neverRan: job.lastRunAt === null });
+  }
+
+  return overdue;
+}

--- a/tests/unit/lib/backups/coverage.test.ts
+++ b/tests/unit/lib/backups/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isUncapturedSource, uncapturedReason } from "@/lib/backups/coverage";
+import { isUncapturedSource, pausedDumpReason, uncapturedReason } from "@/lib/backups/coverage";
 import {
   buildBindPreflightScript,
   buildFileBackupScript,
@@ -42,6 +42,29 @@ describe("bind mounts are opt-in", () => {
   it("tells the operator how to opt in, and which path is affected", () => {
     expect(uncapturedReason(bind())).toMatch(/mark the volume stateful/);
     expect(uncapturedReason(bind())).toContain("/srv/app/data");
+  });
+});
+
+describe("a dump needs a running container", () => {
+  it("pauses a dump while its app is stopped", () => {
+    expect(pausedDumpReason({ backupStrategy: "dump", appStatus: "stopped" })).toMatch(
+      /needs a running container/,
+    );
+  });
+
+  // The data is on disk either way, so tar keeps running. Only the dump waits.
+  it("never pauses a tar — a stopped volume archives fine", () => {
+    expect(pausedDumpReason({ backupStrategy: "tar", appStatus: "stopped" })).toBeNull();
+  });
+
+  it("never pauses a dump for a running app", () => {
+    expect(pausedDumpReason({ backupStrategy: "dump", appStatus: "active" })).toBeNull();
+  });
+
+  // The system database is linked as a volume with no app behind it.
+  it("never pauses a volume with no app", () => {
+    expect(pausedDumpReason({ backupStrategy: "dump", appStatus: null })).toBeNull();
+    expect(pausedDumpReason({ backupStrategy: "dump" })).toBeNull();
   });
 });
 

--- a/tests/unit/lib/backups/run-backup.test.ts
+++ b/tests/unit/lib/backups/run-backup.test.ts
@@ -112,8 +112,8 @@ function volume(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function jobApp(id: string, organizationId = "org-1") {
-  return { app: { id, name: id, organizationId, organization: { slug: "acme" } } };
+function jobApp(id: string, organizationId = "org-1", status = "active") {
+  return { app: { id, name: id, organizationId, status, organization: { slug: "acme" } } };
 }
 
 function job(overrides: Record<string, unknown> = {}) {
@@ -314,6 +314,78 @@ describe("runBackup — app scoping", () => {
     await runBackup("job-1");
 
     expect(updated.some((u) => u.table === backupJobs)).toBe(false);
+  });
+});
+
+// Stopping an app used to end its backups: the scheduled run filtered it out
+// and nothing said so. Its volumes are still on disk, so they are still
+// captured — only a dump, which needs a container to run in, waits.
+describe("runBackup — stopped apps", () => {
+  const dumpVolume = (over: Record<string, unknown> = {}) =>
+    volume({ backupSpec: { kind: "postgres", service: "db" }, backupStrategy: "dump", ...over });
+
+  it("archives a stopped app's volumes on a scheduled run", async () => {
+    backupJobsFindFirst.mockResolvedValue(job({ backupJobApps: [jobApp("app-a", "org-1", "stopped")] }));
+    volumesPerApp([volume({ name: "a-data" })]);
+
+    const results = await runBackup("job-1");
+
+    expect(results.map((r) => [r.volumeName, r.outcome])).toEqual([["a-data", "success"]]);
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still leaves a missing app out — it has no volumes left to capture", async () => {
+    backupJobsFindFirst.mockResolvedValue(job({ backupJobApps: [jobApp("app-a", "org-1", "missing")] }));
+    volumesPerApp([volume({ name: "a-data" })]);
+
+    const results = await runBackup("job-1");
+
+    expect(results).toEqual([]);
+    expect(volumesFindMany).not.toHaveBeenCalled();
+  });
+
+  it("records a dump against a stopped app as skipped, not failed", async () => {
+    backupJobsFindFirst.mockResolvedValue(job({ backupJobApps: [jobApp("app-a", "org-1", "stopped")] }));
+    volumesPerApp([dumpVolume({ name: "pgdata" })]);
+
+    const results = await runBackup("job-1");
+
+    expect(results[0].outcome).toBe("skipped");
+    expect(results[0].error).toMatch(/needs a running container/);
+    expect(updated.some((u) => u.set.status === "skipped")).toBe(true);
+    expect(updated.some((u) => u.set.status === "failed")).toBe(false);
+  });
+
+  it("fails a dump the same way as before when the app is running", async () => {
+    backupJobsFindFirst.mockResolvedValue(job());
+    volumesPerApp([dumpVolume({ name: "pgdata" })]);
+
+    const results = await runBackup("job-1");
+
+    expect(results[0].outcome).toBe("failed");
+    expect(results[0].error).toMatch(/No running container/);
+  });
+
+  it("does not raise a failure for a run that is only waiting on a stopped app", async () => {
+    backupJobsFindFirst.mockResolvedValue(job({ backupJobApps: [jobApp("app-a", "org-1", "stopped")] }));
+    volumesPerApp([dumpVolume({ name: "pgdata" })]);
+
+    await runBackup("job-1");
+
+    expect(emitted("backup.failed")).toHaveLength(0);
+  });
+
+  it("captures what it can beside a paused dump", async () => {
+    backupJobsFindFirst.mockResolvedValue(job({ backupJobApps: [jobApp("app-a", "org-1", "stopped")] }));
+    volumesPerApp([dumpVolume({ name: "pgdata" }), volume({ id: "vol-2", name: "redis" })]);
+
+    const results = await runBackup("job-1");
+
+    expect(results.map((r) => [r.volumeName, r.outcome])).toEqual([
+      ["pgdata", "skipped"],
+      ["redis", "success"],
+    ]);
+    expect(updated.some((u) => u.table === backupJobs && u.set.lastRunAt instanceof Date)).toBe(true);
   });
 });
 

--- a/tests/unit/lib/backups/staleness.test.ts
+++ b/tests/unit/lib/backups/staleness.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  OVERDUE_INTERVALS,
+  overdueBackupJobs,
+  scheduleIntervalMs,
+  type ScheduledBackupJob,
+} from "@/lib/backups/staleness";
+
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+const NOW = new Date("2026-03-10T09:00:00Z");
+
+function job(overrides: Partial<ScheduledBackupJob> = {}): ScheduledBackupJob {
+  return {
+    id: "job-1",
+    name: "Auto: agents",
+    schedule: "17 3 * * *",
+    enabled: true,
+    lastRunAt: new Date(NOW.getTime() - DAY),
+    createdAt: new Date(NOW.getTime() - 30 * DAY),
+    ...overrides,
+  };
+}
+
+describe("scheduleIntervalMs", () => {
+  it("measures a daily schedule as a day", () => {
+    expect(scheduleIntervalMs("17 3 * * *", NOW)).toBe(DAY);
+  });
+
+  it("measures an hourly schedule as an hour", () => {
+    expect(scheduleIntervalMs("0 * * * *", NOW)).toBe(HOUR);
+  });
+
+  it("takes the longest gap, so a weekday job is not overdue every Monday", () => {
+    expect(scheduleIntervalMs("0 2 * * 1-5", NOW)).toBe(3 * DAY);
+  });
+
+  it("returns null for an expression it cannot read", () => {
+    expect(scheduleIntervalMs("not a cron", NOW)).toBeNull();
+    expect(scheduleIntervalMs("   ", NOW)).toBeNull();
+  });
+});
+
+describe("overdueBackupJobs", () => {
+  it("leaves a job alone while it is capturing on schedule", () => {
+    expect(overdueBackupJobs([job()], NOW)).toEqual([]);
+  });
+
+  it("allows one missed run before calling a job overdue", () => {
+    const barely = job({ lastRunAt: new Date(NOW.getTime() - OVERDUE_INTERVALS * DAY) });
+    expect(overdueBackupJobs([barely], NOW)).toEqual([]);
+  });
+
+  it("reports a job that has captured nothing for more than two intervals", () => {
+    const stale = job({ lastRunAt: new Date(NOW.getTime() - 5 * DAY) });
+    const [entry] = overdueBackupJobs([stale], NOW);
+    expect(entry.job.id).toBe("job-1");
+    expect(entry.neverRan).toBe(false);
+    expect(entry.since).toEqual(stale.lastRunAt);
+  });
+
+  // The whole point of measuring against the schedule: an hourly job that has
+  // been quiet since yesterday should not have to wait for a fixed 48h window.
+  it("measures each job against its own schedule", () => {
+    const hourly = job({ schedule: "0 * * * *", lastRunAt: new Date(NOW.getTime() - 3 * HOUR) });
+    expect(overdueBackupJobs([hourly], NOW)).toHaveLength(1);
+  });
+
+  it("dates a job that has never run from when it was created", () => {
+    const fresh = job({ lastRunAt: null, createdAt: new Date(NOW.getTime() - HOUR) });
+    expect(overdueBackupJobs([fresh], NOW)).toEqual([]);
+
+    const forgotten = job({ lastRunAt: null, createdAt: new Date(NOW.getTime() - 5 * DAY) });
+    const [entry] = overdueBackupJobs([forgotten], NOW);
+    expect(entry.neverRan).toBe(true);
+    expect(entry.since).toEqual(forgotten.createdAt);
+  });
+
+  it("says nothing about a job that is turned off", () => {
+    const off = job({ enabled: false, lastRunAt: new Date(NOW.getTime() - 30 * DAY) });
+    expect(overdueBackupJobs([off], NOW)).toEqual([]);
+  });
+
+  it("says nothing about a schedule it cannot read", () => {
+    const broken = job({ schedule: "every other tuesday", lastRunAt: null });
+    expect(overdueBackupJobs([broken], NOW)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #794.

## What was happening

`runBackup` dropped `stopped` apps from every scheduled run alongside `missing` ones. The reasoning holds for `missing` — no container, no volumes, nothing to capture — but a stopped app's volumes are still on disk holding exactly the data they held an hour earlier. Stopping an app for a fortnight meant a fortnight with no archives, and the one signal that could have said so (`lastRunAt` going stale) is only read by the stale-backup deploy condition, which a stopped app never reaches.

Worse than the deploy condition: the app conditions that feed the attention panel are only evaluated for apps the health monitor sees a container for, so a stopped app is precisely the one whose `backup-stale` condition is never written.

## What changed

**Stopped apps are backed up.** The scheduled-run filter now excludes `missing` only. Tar resolution already handles a container-less app — `resolveDockerVolume` falls through to the env-scoped volume name — so nothing else was needed for the archive path.

**A dump on a stopped app is `skipped`, not `failed`.** A dump runs inside the database, so it needs a live container; `resolveDbContainer` correctly returns null and the engine used to turn that into a nightly `failed` row. It is now recorded as skipped with a reason that names the cause.

That classification happens **after** the attempt rather than before it. `apps.status` is a cached observation; an app recorded as stopped whose container is in fact up still gets its dump, and only a dump that genuinely could not run is reclassified. Pre-checking the status column would have traded a real backup for a tidier code path.

**A run that captured nothing only because it was waiting on a stopped app does not raise a failure notification.** That state belongs on the attention surface, not in an email every night at 03:17. Failures beside a paused dump still notify as before.

**Two new attention rows**, both read straight from the backup jobs and neither dependent on a deploy or a running container:

- **Backup overdue** — an enabled job that has captured nothing for more than twice its own schedule interval. Measured per job from its cron expression rather than against a fixed window, so an hourly job is overdue after two hours and a daily one after two days. A job that has never run is dated from its creation, so a job made a minute ago is not flagged before its first fire. This is the part of #794 that matters most: any future reason a job stops running is now visible, not just this one.
- **Backup paused** — a stopped app whose database cannot be dumped until it runs again. Needed as its own row because the common shape (a stack with a Postgres dump volume and a Redis tar volume) still captures something, refreshes `lastRunAt`, and would otherwise never appear as overdue while its database goes uncaptured.

## Considered and not done

Tarring a stopped database's data directory instead of skipping the dump. A cold copy of a shut-down Postgres is a legitimate and arguably more consistent archive — but it silently changes the format written for that volume, mixes tar and dump archives in one retention timeline, and changes what a restore does to a live database. That is a separate decision, not a side effect of a stopped-app fix.

## Verification

- `pnpm test` (typecheck + lint + vitest): 299 files, 4352 tests, green. No new lint warnings.
- New unit tests: `tests/unit/lib/backups/staleness.test.ts` covers interval measurement (including weekday-only schedules, where the longest gap is taken so Mondays are not flagged) and the overdue verdict; `tests/unit/lib/backups/coverage.test.ts` covers the paused-dump reason; `tests/unit/lib/backups/run-backup.test.ts` gains a stopped-app block — volumes archived, `missing` still excluded, dump skipped rather than failed, no failure notification, and a paused dump beside a successful tar.
- Not verified against a live Docker host: the two attention rows are built from database reads inside `buildAttentionRows`, which has no unit-test harness, and the engine paths are exercised through the existing mocked-docker suite rather than a real stopped app.
