### PR TITLE
fix(deploy): pull shared images before the old containers stop

### DIFF
--- a/lib/docker/deploy-steps/classify-services.ts
+++ b/lib/docker/deploy-steps/classify-services.ts
@@ -16,9 +16,9 @@ import { isSharedService } from "../slot-partition";
  * only in the local daemon, referenced via `image:` with no `build:`, so they
  * must be excluded from the pull set — pulling them 404s and aborts the deploy.
  *
- * Services marked `x-vardo-shared` are excluded too. They are brought up with
- * `--no-recreate`, so a freshly pulled image is never used, and a missing one
- * is still pulled by that `up`.
+ * Services marked `x-vardo-shared` are excluded too. They get their own
+ * pre-pull, keyed on the image being absent from the host — see
+ * `sharedPullTargets`.
  */
 export function classifyComposeServices(
   services: ComposeFile["services"],

--- a/lib/docker/deploy-steps/shared-images.ts
+++ b/lib/docker/deploy-steps/shared-images.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// Images the shared project needs, decided before anything is stopped.
+//
+// A shared service is the one thing that cannot be run twice — Traefik holds
+// :80 and :443 for every site on the host. There is no second copy to serve
+// while a pull runs, so a pull issued after the old container is gone is total
+// downtime, and an unreachable registry makes it open-ended.
+// ---------------------------------------------------------------------------
+
+import type { ComposeService } from "../compose-types";
+
+/** Whether this host already holds an image. */
+export type ImageProbe = (image: string) => Promise<boolean>;
+
+/**
+ * Shared services whose image has to come from a registry.
+ *
+ * An image already on the host is skipped. The shared `up` runs
+ * `--no-recreate`, so re-pulling a tag would move it without replacing the
+ * container running the old one; a digest-pinned ref that is local is by
+ * definition the image the compose file names.
+ */
+export async function sharedPullTargets(
+  shared: Record<string, ComposeService>,
+  builtImageRefs: string[],
+  isLocal: ImageProbe,
+): Promise<string[]> {
+  const built = new Set(builtImageRefs);
+  const targets: string[] = [];
+  for (const [name, service] of Object.entries(shared)) {
+    const image = service.image;
+    if (!image || service.build || built.has(image)) continue;
+    if (!(await isLocal(image))) targets.push(name);
+  }
+  return targets;
+}
+
+/** Container each shared service runs as. */
+export function sharedContainerNames(
+  shared: Record<string, ComposeService>,
+  project: string,
+): Map<string, string> {
+  return new Map(
+    Object.entries(shared).map(([name, service]) => [
+      service.container_name ?? `${project}-${name}-1`,
+      name,
+    ]),
+  );
+}
+
+/**
+ * Services a `--dry-run up` says it would replace, meaning the running
+ * container no longer matches the compose file. Compose prints `Recreate` for
+ * those and `Creating` for one that does not exist yet.
+ */
+export function driftedFromDryRun(output: string, containers: Map<string, string>): string[] {
+  const drifted: string[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const container = /^\s*Container\s+(\S+)\s+Recreate\s*$/.exec(line)?.[1];
+    const service = container ? containers.get(container) : undefined;
+    if (service && !drifted.includes(service)) drifted.push(service);
+  }
+  return drifted;
+}

--- a/lib/docker/deploy-steps/swap.ts
+++ b/lib/docker/deploy-steps/swap.ts
@@ -29,6 +29,7 @@ import {
 } from "../constants";
 import type { DeployContext, SlotStopOutcome } from "../deploy-context";
 import { classifyComposeServices } from "./classify-services";
+import { driftedFromDryRun, sharedContainerNames, sharedPullTargets } from "./shared-images";
 import { majorGateAfter, majorGateBefore, type MajorGateState } from "./major-gate";
 import { publishesHostPorts } from "../host-ports";
 import { getServicesWithExternalizedVolumes } from "../compose-inject";
@@ -269,6 +270,25 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
     compose.services,
     ctx.builtImageRefs,
   );
+
+  /** Whether the host already holds an image, so no registry is involved. */
+  const imageIsLocal = async (image: string): Promise<boolean> => {
+    try {
+      await execFileAsync("docker", ["image", "inspect", "--format", "{{.Id}}", image], {
+        timeout: COMPOSE_QUERY_TIMEOUT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  // Shared images are fetched here rather than by the `up` further down, which
+  // runs after the old slot may already be stopped. Only the ones missing from
+  // this host: a re-pull on every deploy would slow all of them down and move
+  // tags under containers `--no-recreate` will not replace.
+  const sharedPulls = await sharedPullTargets(shared, ctx.builtImageRefs, imageIsLocal);
+
   let majorGate: MajorGateState = { candidates: [], before: new Map() };
   try {
     // Both phases reach registries — a `build:` service pulls the bases its
@@ -305,12 +325,23 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
           logs.push(`[deploy][pull] ${line.trim()}`);
         }
       }
+      if (sharedPulls.length > 0) {
+        log(`[deploy] Pre-pulling shared images: ${sharedPulls.join(", ")} (old slot still serving)...`);
+        const { stdout, stderr } = await execFileAsync(
+          "docker",
+          ["compose", ...composeFileArgs, "-p", sharedProject, "pull", ...sharedPulls],
+          { cwd: slotDir, env, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER, signal: ctx.signal }
+        );
+        for (const line of `${stdout}\n${stderr}`.split(/\r?\n|\r/).filter(Boolean)) {
+          logs.push(`[deploy][pull] ${line.trim()}`);
+        }
+      }
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const hint = await registryAuthHint(
       message,
-      pullServices.map((name) => compose.services[name]?.image),
+      [...pullServices, ...sharedPulls].map((name) => compose.services[name]?.image),
     );
     throw new Error(
       `Pre-build/pre-pull for ${newSlot} failed (old slot unaffected): ${message}` +
@@ -556,43 +587,72 @@ export async function swap(ctx: DeployContext): Promise<DeployContext> {
     }
   };
 
+  // `--no-recreate` leaves a running shared service exactly as it is, so an
+  // edited healthcheck, command, environment or image tag never reaches it.
+  // Compose is asked what it would replace and the answer is logged, because a
+  // change that is silently dropped reads as a change that was applied.
+  const reportSharedDrift = async () => {
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        "docker",
+        [
+          "compose",
+          "--dry-run",
+          ...composeFileArgs,
+          "-p", sharedProject,
+          "up", "-d",
+          "--no-deps",
+          ...sharedNames,
+        ],
+        { cwd: slotDir, timeout: COMPOSE_QUERY_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER }
+      );
+      const drifted = driftedFromDryRun(
+        `${stdout}\n${stderr}`,
+        sharedContainerNames(shared, sharedProject),
+      );
+      if (drifted.length > 0) {
+        log(
+          `[deploy] ${drifted.join(", ")} still ${drifted.length === 1 ? "runs" : "run"} an older definition — a deploy never recreates a shared service, so recreate ${drifted.length === 1 ? "it" : "them"} to apply the change`,
+        );
+      }
+    } catch {
+      // Nothing to report on a compose without --dry-run.
+    }
+  };
+
   // Step 6b2: Bring up the shared services. --no-recreate means an already
   // running database is left exactly as it is; only a missing one is created.
   // Runs before the new slot so anything depending on it can connect.
   if (sharedNames.length > 0) {
     log(`[deploy] Shared services (not rotated): ${sharedNames.join(", ")}`);
     try {
-      // Shared services are left out of the pre-pull, so this `up` is where a
-      // missing one is fetched.
-      const { stdout, stderr } = await withRegistryAuth((env) =>
-        execFileAsync(
-          "docker",
-          [
-            "compose",
-            ...composeFileArgs,
-            "-p", sharedProject,
-            "up", "-d",
-            "--no-recreate",
-            "--no-deps",
-            ...sharedNames,
-          ],
-          { cwd: slotDir, env, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER }
-        )
+      // `--pull never`: every image was fetched above, while the old slot was
+      // still serving. Reaching a registry here is what turns a slow pull into
+      // an outage, so it is taken away rather than relied on not to happen.
+      const { stdout, stderr } = await execFileAsync(
+        "docker",
+        [
+          "compose",
+          ...composeFileArgs,
+          "-p", sharedProject,
+          "up", "-d",
+          "--no-recreate",
+          "--pull", "never",
+          "--no-deps",
+          ...sharedNames,
+        ],
+        { cwd: slotDir, timeout: COMPOSE_UP_TIMEOUT, maxBuffer: EXEC_MAX_BUFFER }
       );
       for (const line of `${stdout}\n${stderr}`.split(/\r?\n|\r/).filter(Boolean)) {
         logs.push(`[deploy][shared] ${line.trim()}`);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const hint = await registryAuthHint(
-        message,
-        sharedNames.map((name) => compose.services[name]?.image),
-      );
-      throw new Error(
-        `Shared services failed to start (old slot unaffected): ${message}` +
-          (hint ? `\n${hint}` : "")
-      );
+      await restoreOldSlot("shared services failing to start");
+      throw new Error(`Shared services failed to start: ${message}`);
     }
+
+    await reportSharedDrift();
   }
 
   // Step 6c: Pre-create and chown bind-mount targets to each service's non-root

--- a/tests/unit/lib/docker/deploy-steps/shared-images.test.ts
+++ b/tests/unit/lib/docker/deploy-steps/shared-images.test.ts
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------------
+// Which shared images a deploy has to fetch, and which running shared services
+// no longer match the compose file.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  driftedFromDryRun,
+  sharedContainerNames,
+  sharedPullTargets,
+} from "@/lib/docker/deploy-steps/shared-images";
+import type { ComposeService } from "@/lib/docker/compose-types";
+
+const shared = (services: Record<string, Partial<ComposeService>>) =>
+  services as Record<string, ComposeService>;
+
+describe("sharedPullTargets", () => {
+  it("names a service whose image is missing from the host", async () => {
+    const isLocal = vi.fn(async () => false);
+
+    expect(
+      await sharedPullTargets(shared({ traefik: { image: "traefik:v3.2" } }), [], isLocal),
+    ).toEqual(["traefik"]);
+    expect(isLocal).toHaveBeenCalledWith("traefik:v3.2");
+  });
+
+  it("skips a tag already on the host — the up will not replace the container anyway", async () => {
+    expect(
+      await sharedPullTargets(
+        shared({ traefik: { image: "traefik:v3.2" } }),
+        [],
+        async () => true,
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips a digest pin already on the host, which cannot be stale", async () => {
+    expect(
+      await sharedPullTargets(
+        shared({ postgres: { image: "postgres@sha256:abc" } }),
+        [],
+        async () => true,
+      ),
+    ).toEqual([]);
+  });
+
+  it("pulls a digest pin the host does not hold", async () => {
+    expect(
+      await sharedPullTargets(
+        shared({ postgres: { image: "postgres@sha256:abc" } }),
+        [],
+        async () => false,
+      ),
+    ).toEqual(["postgres"]);
+  });
+
+  it("leaves a service this deploy built locally alone", async () => {
+    expect(
+      await sharedPullTargets(
+        shared({ app: { image: "host/app:sha" } }),
+        ["host/app:sha"],
+        async () => false,
+      ),
+    ).toEqual([]);
+  });
+
+  it("leaves a service compose builds alone", async () => {
+    expect(
+      await sharedPullTargets(
+        shared({ app: { image: "host/app:1", build: "." as unknown as ComposeService["build"] } }),
+        [],
+        async () => false,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("sharedContainerNames", () => {
+  it("uses container_name when the service pins one", () => {
+    const names = sharedContainerNames(
+      shared({ traefik: { image: "traefik:v3.2", container_name: "vardo-traefik" } }),
+      "vardo",
+    );
+    expect(names.get("vardo-traefik")).toBe("traefik");
+  });
+
+  it("falls back to the name compose generates", () => {
+    const names = sharedContainerNames(shared({ postgres: { image: "postgres:17" } }), "app-production-shared");
+    expect(names.get("app-production-shared-postgres-1")).toBe("postgres");
+  });
+});
+
+describe("driftedFromDryRun", () => {
+  const containers = new Map([["vardo-traefik", "traefik"], ["vardo-redis", "redis"]]);
+
+  it("reads the service compose would replace", () => {
+    const output = " Container vardo-traefik  Recreate \n Container vardo-redis  Running ";
+    expect(driftedFromDryRun(output, containers)).toEqual(["traefik"]);
+  });
+
+  it("says nothing when every container matches its definition", () => {
+    expect(driftedFromDryRun(" Container vardo-traefik  Running ", containers)).toEqual([]);
+  });
+
+  it("ignores a container that does not exist yet", () => {
+    expect(driftedFromDryRun(" Container vardo-traefik  Creating ", containers)).toEqual([]);
+  });
+
+  it("ignores containers outside the shared set", () => {
+    expect(driftedFromDryRun(" Container other-thing  Recreate ", containers)).toEqual([]);
+  });
+
+  it("reports each service once", () => {
+    const output = " Container vardo-traefik  Recreate \n Container vardo-traefik  Recreate ";
+    expect(driftedFromDryRun(output, containers)).toEqual(["traefik"]);
+  });
+});

--- a/tests/unit/lib/docker/deploy-steps/swap-shared-pull.test.ts
+++ b/tests/unit/lib/docker/deploy-steps/swap-shared-pull.test.ts
@@ -1,0 +1,232 @@
+// ---------------------------------------------------------------------------
+// A shared service holds the ports every site on the host answers on, so it has
+// no second copy to serve during a pull. Its image is fetched while the old
+// containers are still up, and a pull that fails must leave them running.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { dbMock, execFileAsyncMock, execFileMock } = vi.hoisted(() => {
+  const dbMock = {
+    update: vi.fn().mockImplementation(() => ({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    })),
+  };
+
+  const execFileAsyncMock = vi.fn();
+  const execFileMock = vi.fn();
+  Object.defineProperty(execFileMock, Symbol.for("nodejs.util.promisify.custom"), {
+    value: execFileAsyncMock,
+    configurable: true,
+    writable: true,
+  });
+
+  return { dbMock, execFileAsyncMock, execFileMock };
+});
+
+vi.mock("child_process", () => ({ execFile: execFileMock }));
+vi.mock("@/lib/db", () => ({ db: dbMock }));
+vi.mock("@/lib/docker/memory-headroom", () => ({ overlapFitsNow: vi.fn(async () => true) }));
+vi.mock("@/lib/docker/deploy-oom", () => ({ reportOomDuringDeploy: vi.fn(async () => {}) }));
+vi.mock("@/lib/docker/restart-policy", () => ({
+  demoteStandbyRestart: vi.fn(async () => {}),
+  restoreSlotRestart: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/docker/traefik-cutover", () => ({
+  clearCutoverPin: vi.fn(async () => {}),
+  guardCutover: vi.fn(async () => ({ pinned: true, release: async () => {} })),
+}));
+vi.mock("@/lib/docker/image-updates/registry", () => ({ getRegistryCredentials: vi.fn(async () => ({})) }));
+vi.mock("@/lib/docker/client", () => ({ ensureNetwork: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/docker/compose", () => ({
+  slotComposeFiles: vi.fn().mockResolvedValue(["-f", "docker-compose.yml"]),
+  getTraefikRoutedServices: vi.fn().mockReturnValue(new Set(["web"])),
+}));
+vi.mock("@/lib/docker/deploy-steps/bind-mount-ownership", () => ({
+  prepareBindMountOwnership: vi.fn().mockResolvedValue(undefined),
+  bindMountHostSource: vi.fn(),
+  numericUid: vi.fn(),
+}));
+
+import { swap } from "@/lib/docker/deploy-steps/swap";
+import type { DeployContext } from "@/lib/docker/deploy-context";
+import type { ComposeFile } from "@/lib/docker/compose-types";
+
+function calls(): string[][] {
+  return execFileAsyncMock.mock.calls.map((c) => c[1] as string[]);
+}
+
+function indexOf(match: (a: string[]) => boolean): number {
+  return calls().findIndex(match);
+}
+
+const isSharedPull = (a: string[]) => a.includes("pull") && a.includes("app-production-shared");
+const isSharedUp = (a: string[]) =>
+  a.includes("up") && a.includes("app-production-shared") && !a.includes("--dry-run");
+const isOldSlotStop = (a: string[]) => a.includes("stop") && a.includes("app-production-blue");
+const isOldSlotRestore = (a: string[]) =>
+  a.includes("up") && a.includes("app-production-blue") && a.includes("--no-recreate");
+const isImageInspect = (a: string[]) => a[0] === "image" && a[1] === "inspect";
+
+/** A rotating web service in front of a postgres both slots would share. */
+function composeFile(): ComposeFile {
+  return {
+    services: {
+      web: { name: "web", image: "nginx", labels: { "traefik.enable": "true" } },
+      postgres: {
+        name: "postgres",
+        image: "postgres:17",
+        volumes: ["postgres-data:/var/lib/postgresql/data"],
+      },
+    },
+    volumes: { "postgres-data": {} },
+  } as unknown as ComposeFile;
+}
+
+function context(): DeployContext {
+  const logLines: string[] = [];
+  return {
+    deploymentId: "deploy-1",
+    appId: "app-1",
+    organizationId: "org-1",
+    app: { id: "app-1", name: "app", displayName: "app", healthCheckTimeout: null, domains: [] },
+    envName: "production",
+    compose: composeFile(),
+    builtImageRefs: [],
+    appDir: "/opt/vardo/apps/app/production",
+    slotDir: "/opt/vardo/apps/app/production/green",
+    newProjectName: "app-production-green",
+    activeSlot: "blue",
+    newSlot: "green",
+    isLocalEnv: false,
+    containerPort: 3000,
+    composeFileArgs: ["-f", "docker-compose.yml"],
+    logLines,
+    logs: { push: (line: string) => logLines.push(line) },
+    log: (line: string) => { logLines.push(line); return line; },
+    stage: () => {},
+    checkAbort: () => {},
+    startTime: Date.now(),
+  } as unknown as DeployContext;
+}
+
+type DockerOpts = {
+  /** Whether the host already holds postgres:17. */
+  imageLocal?: boolean;
+  /** Whether the shared pull fails, as a rate-limited registry would. */
+  pullFails?: boolean;
+  /** Whether the shared `up` fails. */
+  sharedUpFails?: boolean;
+  /** What a `--dry-run up` reports for the shared containers. */
+  dryRun?: string;
+  /** Whether the old slot still runs the shared service. */
+  oldSlotHoldsShared?: boolean;
+};
+
+function dockerWith(opts: DockerOpts = {}) {
+  execFileAsyncMock.mockImplementation(async (_cmd: string, args: string[]) => {
+    if (isImageInspect(args)) {
+      if (opts.imageLocal === false) throw new Error("No such image: postgres:17");
+      return { stdout: "sha256:abc\n", stderr: "" };
+    }
+    if (args.includes("--dry-run")) return { stdout: opts.dryRun ?? "", stderr: "" };
+    if (isSharedPull(args) && opts.pullFails) {
+      throw new Error("toomanyrequests: You have reached your pull rate limit");
+    }
+    if (isSharedUp(args) && opts.sharedUpFails) {
+      throw new Error("Error response from daemon: no such image");
+    }
+    if (args.includes("ps") && args.includes("-q")) {
+      return { stdout: opts.oldSlotHoldsShared ? "abc123\n" : "", stderr: "" };
+    }
+    if (args.includes("ps")) {
+      return {
+        stdout: JSON.stringify({
+          Service: "web",
+          Name: "app-production-green-web-1",
+          State: "running",
+          Health: "healthy",
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "", stderr: "" };
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("swap — fetching shared images", () => {
+  it("pulls a missing shared image before the old slot is stopped", async () => {
+    dockerWith({ imageLocal: false, oldSlotHoldsShared: true });
+    await swap(context());
+
+    expect(indexOf(isSharedPull)).toBeGreaterThan(-1);
+    expect(indexOf(isOldSlotStop)).toBeGreaterThan(-1);
+    expect(indexOf(isSharedPull)).toBeLessThan(indexOf(isOldSlotStop));
+  });
+
+  it("pulls it before the shared project starts", async () => {
+    dockerWith({ imageLocal: false });
+    await swap(context());
+
+    expect(indexOf(isSharedPull)).toBeLessThan(indexOf(isSharedUp));
+  });
+
+  it("leaves the old containers running when the pull fails", async () => {
+    dockerWith({ imageLocal: false, pullFails: true, oldSlotHoldsShared: true });
+
+    await expect(swap(context())).rejects.toThrow(/pull rate limit/);
+    expect(indexOf(isOldSlotStop)).toBe(-1);
+    expect(indexOf(isSharedUp)).toBe(-1);
+  });
+
+  it("says the old slot is untouched when the pull fails", async () => {
+    dockerWith({ imageLocal: false, pullFails: true });
+
+    await expect(swap(context())).rejects.toThrow(/old slot unaffected/);
+  });
+
+  it("does not pull an image the host already holds", async () => {
+    dockerWith({ imageLocal: true });
+    await swap(context());
+
+    expect(indexOf(isSharedPull)).toBe(-1);
+  });
+
+  it("starts the shared project without reaching a registry", async () => {
+    dockerWith({ imageLocal: true });
+    await swap(context());
+
+    const up = calls().find(isSharedUp)!;
+    expect(up.join(" ")).toContain("--pull never");
+  });
+
+  it("brings the old slot back when the shared project fails to start", async () => {
+    dockerWith({ imageLocal: true, sharedUpFails: true, oldSlotHoldsShared: true });
+
+    await expect(swap(context())).rejects.toThrow(/Shared services failed to start/);
+    expect(indexOf(isOldSlotRestore)).toBeGreaterThan(indexOf(isOldSlotStop));
+  });
+
+  it("reports a shared service still running an older definition", async () => {
+    dockerWith({
+      imageLocal: true,
+      dryRun: " Container app-production-shared-postgres-1  Recreate ",
+    });
+    const ctx = context();
+    await swap(ctx);
+
+    expect(ctx.logLines).toContainEqual(
+      "[deploy] postgres still runs an older definition — a deploy never recreates a shared service, so recreate it to apply the change",
+    );
+  });
+
+  it("stays quiet when the running definition matches", async () => {
+    dockerWith({ imageLocal: true, dryRun: " Container app-production-shared-postgres-1  Running " });
+    const ctx = context();
+    await swap(ctx);
+
+    expect(ctx.logLines.some((l) => l.includes("older definition"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #817.

## The order today

`swap` pre-pulls and pre-builds the **rotating** services before it touches the old slot, so a registry failure there is free. Shared services were deliberately left out of that phase — `lib/docker/deploy-steps/classify-services.ts` excluded anything marked `x-vardo-shared`, and the shared `docker compose up -d --no-recreate` further down was where a missing image got fetched.

That `up` runs *after* the old slot has been stopped on four separate paths: a published host port (which Traefik always has), the old slot still holding a service that just left the rotation, an externalized volume both slots would mount, and insufficient memory headroom for an overlap. On every one of them, a shared image that is not on the host is fetched with the old containers already down. If the registry is rate-limiting or unreachable, the host stays down for as long as that takes rather than for the length of a restart. The error message even claimed `(old slot unaffected)`, which was false on exactly the paths that matter.

## The change

- Shared images are fetched in the pre-pull phase, inside the same `withRegistryAuth` block as the rotating ones, so a private registry works and the credential never reaches argv. Nothing has been stopped at that point, so a failure aborts the deploy with everything still serving.
- The shared `up` gained `--pull never`. The invariant is enforced rather than assumed: after the stop, no command can reach a registry.
- A shared `up` that fails now restores the old slot instead of leaving it down.
- The auth hint on a failed pre-pull now covers shared images too.

## Tag versus digest

Only images **absent from the host** are pulled, decided per service with `docker image inspect`.

- **Digest-pinned** (`postgres@sha256:…`) — if it is local it is byte-for-byte the image the compose file names, so a re-pull can never change anything. Never re-pulled.
- **Tag-based** (`traefik:v3.2`) — a local tag might have moved in the registry, but the shared `up` is `--no-recreate` and will not replace the running container regardless, so a re-pull would only move the tag out from under a container still running the old image. That is the same hazard `major-gate` exists to catch for rotating services. Pulled only when absent.

The upgrade case still works: bumping `traefik:v3.1` to `v3.2` makes the image absent, so it is pulled — before anything stops. Steady-state deploys, where every shared image is already local, issue no pull at all and are not slowed down.

## `--no-recreate` drops changes silently

Observed on the homelab while this was being written: a healthcheck was added to the shared `traefik` service, the deploy logged `Container vardo-traefik Running`, and `docker inspect` afterwards still showed `Healthcheck: null` on a container up three days. `--no-recreate` means **no** change to a shared service's definition — image, healthcheck, command, environment — ever reaches a running container. `compose-validate` already warns about this for `build:` only.

Recreating shared services is a separate and much larger change (it is a deliberate outage of the front door or the control-plane database, and it needs this PR's ordering to be safe at all). What is here instead is the honest minimum: after the shared `up`, compose is asked `up -d --dry-run` and any container it reports as `Recreate` is logged.

```
[deploy] traefik still runs an older definition — a deploy never recreates a shared service, so recreate it to apply the change
```

Verified against Docker Compose directly: a drifted service reports `Recreate`, an unchanged one `Running`, an absent one `Creating`, and the dry run mutates nothing. If a compose build predates `--dry-run` the check is skipped silently.

## Tests

`tests/unit/lib/docker/deploy-steps/swap-shared-pull.test.ts` covers the ordering end to end, including a rate-limited pull where the assertion is that no `stop` was ever issued against the old slot, and a failed shared `up` that brings the old slot back. `shared-images.test.ts` covers the pull-target selection (tag, digest, locally built, `build:`) and the drift parsing.

`pnpm test` passes: typecheck clean, lint 0 errors, 4361 unit tests.

## Out of scope

Blue/green overlap is still gated on memory only, never on disk. Untouched here, worth its own issue.
