### PR TITLE
fix(security): latch the first-run setup gate and redact credentials from exec failures

### DIFF
--- a/app/api/v1/admin/maintenance/route.ts
+++ b/app/api/v1/admin/maintenance/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from "next/server";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { requireAppAdmin } from "@/lib/auth/admin";
 import { handleRouteError } from "@/lib/api/error-response";
 import { logger } from "@/lib/logger";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("admin:maintenance");
 

--- a/lib/backups/drill.ts
+++ b/lib/backups/drill.ts
@@ -10,8 +10,7 @@ import { db } from "@/lib/db";
 import { backups, volumes } from "@/lib/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { execFile, spawn } from "child_process";
-import { promisify } from "util";
+import { spawn } from "child_process";
 import { pipeline } from "stream/promises";
 import { createGunzip } from "zlib";
 import { createReadStream } from "fs";
@@ -29,9 +28,9 @@ import {
   type DrillOutcome,
 } from "./drill-plan";
 import { resolveDefaultEnv } from "@/lib/docker/resolve-env";
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("drill");
-const execFileAsync = promisify(execFile);
 
 const READY_ATTEMPTS = 30;
 const READY_INTERVAL_MS = 2000;

--- a/lib/backups/engine.ts
+++ b/lib/backups/engine.ts
@@ -8,8 +8,7 @@ import { eq, and, isNull, desc, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { createHash } from "crypto";
 import { createReadStream, createWriteStream } from "fs";
-import { execFile, spawn } from "child_process";
-import { promisify } from "util";
+import { spawn } from "child_process";
 import { pipeline } from "stream/promises";
 import { createGzip, createGunzip } from "zlib";
 import { mkdir, rm, stat } from "fs/promises";
@@ -38,10 +37,10 @@ import { listContainers, inspectContainer } from "@/lib/docker/client";
 import { resolveDefaultEnv } from "@/lib/docker/resolve-env";
 import { logger } from "@/lib/logger";
 import type { BusEvent } from "@/lib/bus/events";
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("backup");
 
-const execFileAsync = promisify(execFile);
 
 // Local staging dir for backup archives before upload. Must be writable by the
 // app user AND host-visible: the engine bind-mounts it into a one-shot `alpine`

--- a/lib/backups/storage-ssh.ts
+++ b/lib/backups/storage-ssh.ts
@@ -6,13 +6,10 @@
 // Implements the BackupStorage port interface.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { stat, writeFile as fsWriteFile, unlink } from "fs/promises";
 import { nanoid } from "nanoid";
 import type { BackupStorage } from "./storage-port";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/lib/cron/engine.ts
+++ b/lib/cron/engine.ts
@@ -2,8 +2,6 @@ import { db } from "@/lib/db";
 import { cronJobs, cronJobRuns } from "@/lib/db/schema";
 import { and, eq, lt } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { listContainers, type ContainerInfo, type ContainerScope } from "@/lib/docker/client";
 import { matchContainers, type ReconcilableApp } from "@/lib/docker/container-match";
 import { shouldRunNow } from "./parse";
@@ -11,10 +9,10 @@ import { acquireLock } from "@/lib/redis-lock";
 import { logger } from "@/lib/logger";
 import { safeFetch } from "@/lib/security/safe-fetch";
 import { getOutboundPolicy } from "@/lib/security/outbound-policy";
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("cron");
 
-const execFileAsync = promisify(execFile);
 
 /** An app a cron job can target, plus the stack it belongs to. */
 export type CronTargetApp = ReconcilableApp & {

--- a/lib/docker/buildkit.ts
+++ b/lib/docker/buildkit.ts
@@ -6,13 +6,10 @@
 // cloned and staged — so the check belongs before the build starts.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 
 import { DOCKER_CLEANUP_TIMEOUT } from "./constants";
 import { DeployBlockedError } from "./errors";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 const DOCKER_CONTAINER_PREFIX = "docker-container://";
 

--- a/lib/docker/constants.ts
+++ b/lib/docker/constants.ts
@@ -92,11 +92,8 @@ export const INSTANT_ROLLBACK_POLL_INTERVAL = 1_000;
 
 import { mkdir, writeFile, rm } from "fs/promises";
 import { join } from "path";
-import { execFile } from "child_process";
-import { promisify } from "util";
+import { execFileAsync as execFileAsyncInternal } from "@/lib/utils/exec";
 import { PROJECTS_DIR } from "@/lib/paths";
-
-const execFileAsyncInternal = promisify(execFile);
 
 /**
  * Create a directory and ensure the app user can write to it.

--- a/lib/docker/deploy-logger.ts
+++ b/lib/docker/deploy-logger.ts
@@ -8,6 +8,7 @@
 
 import { addDeployLog } from "@/lib/stream/producer";
 import { logger } from "@/lib/logger";
+import { redactSecrets } from "@/lib/redact";
 
 const log = logger.child("deploy-logger");
 
@@ -59,16 +60,15 @@ export function isTerminalStageEvent(stage?: string, status?: string): boolean {
   return stage === "done" && status === "success";
 }
 
-/** Secret patterns to strip from log output. */
-const SECRET_PATTERNS = [
-  { pattern: /x-access-token:[^\s@]+/g, replacement: "x-access-token:***" },
-  { pattern: /ghs_[A-Za-z0-9]+/g, replacement: "***" },
+/** Key file names, which point at a secret without being one. */
+const KEY_FILE_PATTERNS = [
   { pattern: /\.host-deploy-key-[A-Za-z0-9_-]+/g, replacement: ".host-deploy-key-***" },
+  { pattern: /\.host-ssh-key-[A-Za-z0-9_-]+/g, replacement: ".host-ssh-key-***" },
 ];
 
 function sanitize(line: string): string {
-  let result = line;
-  for (const { pattern, replacement } of SECRET_PATTERNS) {
+  let result = redactSecrets(line);
+  for (const { pattern, replacement } of KEY_FILE_PATTERNS) {
     result = result.replace(pattern, replacement);
   }
   return result;

--- a/lib/docker/deploy-steps/bind-mount-ownership.ts
+++ b/lib/docker/deploy-steps/bind-mount-ownership.ts
@@ -15,15 +15,12 @@
 // user bind-mount targets.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { resolve } from "path";
+import { execFileAsync } from "@/lib/utils/exec";
 
 import { DOCKER_CHOWN_TIMEOUT, COMPOSE_QUERY_TIMEOUT } from "../constants";
 import type { ComposeService } from "../compose-types";
 import type { DeployContext } from "../deploy-context";
-
-const execFileAsync = promisify(execFile);
 
 /**
  * Resolve a compose volume entry to its absolute host bind-mount source, or

--- a/lib/docker/deploy-steps/build.ts
+++ b/lib/docker/deploy-steps/build.ts
@@ -6,8 +6,6 @@
 import { db } from "@/lib/db";
 import { orgEnvVars, apps, environments } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { mkdir, writeFile, readFile, rm, symlink, copyFile, stat, readdir } from "fs/promises";
 import { join } from "path";
 import { decryptOrFallback } from "@/lib/crypto/encrypt";
@@ -35,8 +33,8 @@ import {
   sharedNetworkName,
   sharedNetworks,
 } from "../shared-networks";
+import { execFileAsync } from "@/lib/utils/exec";
 
-const execFileAsync = promisify(execFile);
 const NETWORK_NAME = VARDO_NETWORK;
 
 export async function build(ctx: DeployContext): Promise<DeployContext> {

--- a/lib/docker/deploy-steps/post-deploy.ts
+++ b/lib/docker/deploy-steps/post-deploy.ts
@@ -11,8 +11,6 @@ import { setParked } from "@/lib/db/app-parked";
 import { deployments, apps, volumes } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { rm, symlink, rename } from "fs/promises";
 import { join } from "path";
 import { encrypt, decryptOrFallback } from "@/lib/crypto/encrypt";
@@ -58,12 +56,12 @@ import type { DeployContext, SlotStopOutcome } from "../deploy-context";
 import { demoteStandbyRestart } from "../restart-policy";
 import { isSelfApp } from "../self-env";
 import { proposeDurability, isSafeToApply } from "@/lib/backups/durability";
+import { execFileAsync } from "@/lib/utils/exec";
 
 /** Serializes the host-global prune across deploys. */
 const PRUNE_LOCK_KEY = "deploy:prune:lock";
 const PRUNE_LOCK_TTL_MS = 5 * 60_000;
 
-const execFileAsync = promisify(execFile);
 
 export async function postDeploy(ctx: DeployContext): Promise<DeployContext> {
   const { app, log, logs, compose, activeSlot, newSlot, isLocalEnv, hostConfig } = ctx;

--- a/lib/docker/deploy-steps/prepare-repo.ts
+++ b/lib/docker/deploy-steps/prepare-repo.ts
@@ -18,8 +18,6 @@ import {
 } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { mkdir, writeFile, readFile, rm } from "fs/promises";
 import { join } from "path";
 import { appBaseDir, appEnvDir, PROJECTS_DIR } from "@/lib/paths";
@@ -61,8 +59,7 @@ import {
 } from "../constants";
 import type { DeployContext } from "../deploy-context";
 import { deployments } from "@/lib/db/schema";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/lib/docker/deploy-steps/swap.ts
+++ b/lib/docker/deploy-steps/swap.ts
@@ -6,8 +6,6 @@
 import { db } from "@/lib/db";
 import { apps } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { join } from "path";
 import { ensureNetwork } from "../client";
 import {
@@ -39,8 +37,8 @@ import { clearCutoverPin, guardCutover, type CutoverGuard } from "../traefik-cut
 import { projectScopedNetworkNames } from "../shared-networks";
 import { overlapFitsNow } from "../memory-headroom";
 import { reportOomDuringDeploy } from "../deploy-oom";
+import { execFileAsync } from "@/lib/utils/exec";
 
-const execFileAsync = promisify(execFile);
 const NETWORK_NAME = VARDO_NETWORK;
 const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = DEFAULT_HEALTH_CHECK_TIMEOUT;
 const HEALTH_CHECK_INTERVAL_MS = 2000;

--- a/lib/docker/deploy.ts
+++ b/lib/docker/deploy.ts
@@ -5,10 +5,9 @@ import { decryptOrFallback } from "@/lib/crypto/encrypt";
 import { parseEnvToMap } from "@/lib/env/parse-env";
 import { eq, and, inArray } from "drizzle-orm";
 import { logger } from "@/lib/logger";
+import { redactSecrets } from "@/lib/redact";
 import { nanoid } from "nanoid";
 import { addEvent } from "@/lib/stream/producer";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { readlink } from "fs/promises";
 import { join } from "path";
 import { appBaseDir, appEnvDir } from "@/lib/paths";
@@ -38,8 +37,7 @@ import {
   applyRollbackEnv,
   type RollbackTarget,
 } from "./rollback-target";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 export type { DeployStage } from "./deploy-logger";
 
@@ -439,7 +437,9 @@ export async function runDeployment(
     await streamLogger.flush();
     return { deploymentId, success: true, log: logLines.join("\n"), durationMs, status: "success" };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    // Redacted here rather than at each sink below — this message reaches the
+    // event feed, the activity row, notification channels and the API response.
+    const message = redactSecrets(error instanceof Error ? error.message : "Unknown error");
     const durationMs = Date.now() - startTime;
 
     // The release cut over and is serving; only the tail behind it failed. The

--- a/lib/docker/import.ts
+++ b/lib/docker/import.ts
@@ -17,6 +17,7 @@ import { requestDeploy } from "@/lib/docker/deploy-cancel";
 import { addEvent } from "@/lib/stream/producer";
 import { recordActivity } from "@/lib/activity";
 import type { ComposeFile } from "@/lib/docker/compose";
+import { execFileAsync } from "@/lib/utils/exec";
 
 // Infer the Drizzle transaction type from the db.transaction callback signature.
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -421,11 +422,7 @@ export function mergeComposeFile(
 
 import { readFile, access, constants } from "fs/promises";
 import { join } from "path";
-import { promisify } from "util";
-import { execFile } from "child_process";
 import { parseCompose } from "@/lib/docker/compose";
-
-const execFileAsync = promisify(execFile);
 
 export type GitBuildContext = {
   gitUrl: string;

--- a/lib/docker/instant-rollback.ts
+++ b/lib/docker/instant-rollback.ts
@@ -4,8 +4,6 @@ import { apps, deployments } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { rm, symlink, rename } from "fs/promises";
 import { join } from "path";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { nanoid } from "nanoid";
 import { appEnvDir } from "@/lib/paths";
 import { slotComposeFiles } from "./compose";
@@ -25,8 +23,7 @@ import {
 import type { ResolvedEnv } from "./resolve-env";
 import { demoteStandbyRestart, restoreSlotRestart } from "./restart-policy";
 import { clearCutoverPin } from "./traefik-cutover";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/lib/docker/restart-policy.ts
+++ b/lib/docker/restart-policy.ts
@@ -8,13 +8,11 @@
 // containers created before that, or created outside Vardo, still carry it.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 
 import { COMPOSE_QUERY_TIMEOUT } from "./constants";
 import { logger } from "@/lib/logger";
+import { execFileAsync } from "@/lib/utils/exec";
 
-const execFileAsync = promisify(execFile);
 const log = logger.child("restart-policy");
 
 /** Restart policy a slot's compose declares per service. */

--- a/lib/docker/rollback-monitor.ts
+++ b/lib/docker/rollback-monitor.ts
@@ -13,8 +13,6 @@ import { db } from "@/lib/db";
 import { statusChange } from "@/lib/db/app-status";
 import { deployments, apps } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { join } from "path";
 import { nanoid } from "nanoid";
 import { appEnvDir } from "@/lib/paths";
@@ -30,10 +28,10 @@ import { createDeployLogger } from "./deploy-logger";
 import type { RollbackStage, DeployStatus } from "./deploy-logger";
 import { recordActivity } from "@/lib/activity";
 import { logger } from "@/lib/logger";
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("rollback-monitor");
 
-const execFileAsync = promisify(execFile);
 
 /**
  * Container ids belonging to a compose project. `all` includes stopped ones.

--- a/lib/docker/self-env.ts
+++ b/lib/docker/self-env.ts
@@ -1,11 +1,8 @@
 import { copyFile } from "fs/promises";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { dirname, join } from "path";
 import { VARDO_SELF_APP_NAME } from "@/lib/api/system-managed";
 import { APP_UID, DOCKER_CLEANUP_TIMEOUT } from "./constants";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 /** The self-app is the only app whose env lives on the host, not in the database. */
 export function isSelfApp(appName: string): boolean {

--- a/lib/docker/self-preview.ts
+++ b/lib/docker/self-preview.ts
@@ -14,8 +14,6 @@
 // running vardo-postgres and vardo-redis services.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { mkdir, writeFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -24,10 +22,10 @@ import { apps, organizations } from "@/lib/db/schema";
 import { eq, and, asc } from "drizzle-orm";
 import { getInstanceConfig } from "@/lib/system-settings";
 import { logger } from "@/lib/logger";
+import { execFileAsync } from "@/lib/utils/exec";
 
 const log = logger.child("self-preview");
 
-const execFileAsync = promisify(execFile);
 
 const PREVIEW_PROJECT_PREFIX = "vardo-preview-pr";
 const VARDO_NETWORK = process.env.VARDO_NETWORK ?? "vardo-network";

--- a/lib/docker/self-register.ts
+++ b/lib/docker/self-register.ts
@@ -10,10 +10,9 @@
 
 import { readFile, access } from "fs/promises";
 import { join } from "path";
-import { promisify } from "util";
-import { execFile } from "child_process";
 import { and, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import { execFileAsync } from "@/lib/utils/exec";
 
 import { db } from "@/lib/db";
 import { apps, deployments, projects } from "@/lib/db/schema";
@@ -27,8 +26,6 @@ import { ensureVardoOrg } from "@/lib/infra/vardo-org";
 import { logger } from "@/lib/logger";
 import { VARDO_HOME_DIR, VARDO_CURRENT_DIR } from "@/lib/paths";
 import type { ComposeService } from "@/lib/docker/compose-types";
-
-const execFileAsync = promisify(execFile);
 
 const log = logger.child("self-register");
 

--- a/lib/docker/slots.ts
+++ b/lib/docker/slots.ts
@@ -10,12 +10,9 @@
 // ---------------------------------------------------------------------------
 
 import { readlink, readFile } from "fs/promises";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { join } from "path";
 import { COMPOSE_QUERY_TIMEOUT } from "./constants";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 export type Slot = "blue" | "green";
 

--- a/lib/docker/standby-slot.ts
+++ b/lib/docker/standby-slot.ts
@@ -8,10 +8,9 @@
 // This finds a standby that came back and stops it again.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { readlink } from "fs/promises";
 import { join } from "path";
+import { execFileAsync } from "@/lib/utils/exec";
 
 import { COMPOSE_QUERY_TIMEOUT, COMPOSE_DOWN_TIMEOUT } from "./constants";
 import { slotComposeFiles } from "./compose-inject";
@@ -19,7 +18,6 @@ import { demoteStandbyRestart } from "./restart-policy";
 import { logger } from "@/lib/logger";
 import type { Slot } from "./slots";
 
-const execFileAsync = promisify(execFile);
 const log = logger.child("standby-slot");
 
 export const SLOTS: readonly Slot[] = ["blue", "green"];

--- a/lib/docker/start-app.ts
+++ b/lib/docker/start-app.ts
@@ -6,10 +6,9 @@
 // through here so the two cannot drift apart again.
 // ---------------------------------------------------------------------------
 
-import { execFile } from "child_process";
 import { access } from "fs/promises";
-import { promisify } from "util";
 import { and, eq } from "drizzle-orm";
+import { execFileAsync } from "@/lib/utils/exec";
 
 import { db } from "@/lib/db";
 import { apps } from "@/lib/db/schema";
@@ -26,8 +25,6 @@ import { resolveDefaultEnv } from "./resolve-env";
 import { readSlotPartition, sharedScopeArgs } from "./shared-project";
 import { sharedProjectName, slotScopeArgs } from "./slot-partition";
 import { reconcileAppNow, type ObservedStatus } from "./status-reconcile";
-
-const execFileAsync = promisify(execFile);
 
 export type StartAction = "restarted" | "started" | "none";
 

--- a/lib/hooks/execute.ts
+++ b/lib/hooks/execute.ts
@@ -11,8 +11,6 @@
 // ---------------------------------------------------------------------------
 
 import { createHmac } from "crypto";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { safeFetch } from "@/lib/security/safe-fetch";
 import { getOutboundPolicy } from "@/lib/security/outbound-policy";
 import { getHooksForEvent, getInternalHandler } from "./registry";
@@ -27,8 +25,8 @@ import type {
   ScriptHookConfig,
 } from "./types";
 import { logger } from "@/lib/logger";
+import { execFileAsync } from "@/lib/utils/exec";
 
-const execFileAsync = promisify(execFile);
 const log = logger.child("hooks");
 
 const DEFAULT_TIMEOUT_MS = 30_000;

--- a/lib/infra/provision.ts
+++ b/lib/infra/provision.ts
@@ -398,9 +398,7 @@ async function resolveComposeContent(template: Template): Promise<string | null>
 /** Check if an NVIDIA GPU runtime is available on the Docker host. */
 async function detectNvidiaGpu(): Promise<boolean> {
   try {
-    const { execFile } = await import("child_process");
-    const { promisify } = await import("util");
-    const execFileAsync = promisify(execFile);
+    const { execFileAsync } = await import("@/lib/utils/exec");
     const { stdout } = await execFileAsync("docker", ["info", "--format", "{{json .Runtimes}}"], { timeout: 5000 });
     return stdout.includes("nvidia");
   } catch {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,3 +1,5 @@
+import { redactSecrets } from "@/lib/redact";
+
 type LogLevel = "debug" | "info" | "warn" | "error";
 
 const LEVELS: Record<LogLevel, number> = {
@@ -13,7 +15,8 @@ const currentLevel: number =
 function fmt(level: LogLevel, prefix: string, args: unknown[]): unknown[] {
   const tag = prefix ? `[${prefix}]` : "";
   const ts = new Date().toISOString();
-  return [`${ts} ${level.toUpperCase()}${tag}`, ...args];
+  const safe = args.map((arg) => (typeof arg === "string" ? redactSecrets(arg) : arg));
+  return [`${ts} ${level.toUpperCase()}${tag}`, ...safe];
 }
 
 function createLogger(prefix = "") {

--- a/lib/mesh/wireguard.ts
+++ b/lib/mesh/wireguard.ts
@@ -1,9 +1,8 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { HUB_IP } from "./ip-allocator";
 import { WG_CONTAINER, FRONTEND_MESH_IP, CONSOLE_PORT } from "./constants";
-
-const execFileAsync = promisify(execFile);
+import { execFile } from "node:child_process";
+import { execFileAsync } from "@/lib/utils/exec";
+import { redactError } from "@/lib/redact";
 
 // WireGuard base64 key: 44 chars, A-Z a-z 0-9 + / ending with =
 const WG_KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
@@ -91,7 +90,7 @@ export async function writeWgConfig(config: string): Promise<void> {
     const child = execFile(
       "docker",
       ["exec", "-i", WG_CONTAINER, "sh", "-c", "mkdir -p /config/wg_confs && cat > /config/wg_confs/wg0.conf"],
-      (err) => (err ? reject(err) : resolve())
+      (err) => (err ? reject(redactError(err)) : resolve())
     );
     child.stdin?.write(config);
     child.stdin?.end();

--- a/lib/redact.ts
+++ b/lib/redact.ts
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------
+// Secret redaction for text that leaves the process — error messages, command
+// lines, captured stderr, deployment logs.
+//
+// A match is replaced whole: no length, no prefix, no suffix survives.
+// ---------------------------------------------------------------------------
+
+export const REDACTED = "[redacted]";
+
+/** Shortest value worth redacting by exact match — below this it is noise. */
+const MIN_VALUE_LENGTH = 6;
+
+const PATTERNS: { pattern: RegExp; replacement: string }[] = [
+  // PEM blocks — the whole body, not just the header.
+  {
+    pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+    replacement: REDACTED,
+  },
+  // URL credentials: scheme://user:pass@host and scheme://token@host.
+  {
+    pattern: /([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^\s@]*@/gi,
+    replacement: `$1${REDACTED}:${REDACTED}@`,
+  },
+  {
+    pattern: /([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+@/gi,
+    replacement: `$1${REDACTED}@`,
+  },
+  // Provider token shapes, which travel outside any recognisable key/value form.
+  { pattern: /\bgh[pousr]_[A-Za-z0-9]{16,}/g, replacement: REDACTED },
+  { pattern: /\bgithub_pat_[A-Za-z0-9_]{20,}/g, replacement: REDACTED },
+  { pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, replacement: REDACTED },
+  { pattern: /\bxox[abposr]-[A-Za-z0-9-]{10,}/g, replacement: REDACTED },
+  // Authorization headers.
+  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: `$1 ${REDACTED}` },
+  // Docker config auth blobs.
+  { pattern: /("auth"\s*:\s*)"[^"]*"/g, replacement: `$1"${REDACTED}"` },
+  // Environment assignments whose name says secret.
+  {
+    pattern:
+      /\b([A-Za-z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIALS?|PWD)[A-Za-z0-9_]*)=\S+/gi,
+    replacement: `$1=${REDACTED}`,
+  },
+  // CLI flags that carry a credential, joined or separated.
+  {
+    pattern:
+      /(--(?:password|passwd|pass|token|secret|secret-key|secret-access-key|access-key|access-key-id|api-key|auth|credential)[a-z-]*)(=|\s+)(?!-)\S+/gi,
+    replacement: `$1$2${REDACTED}`,
+  },
+  { pattern: /(\s-p)(?!\s)\S+/g, replacement: `$1${REDACTED}` },
+];
+
+/** Replaces every occurrence of the given literal values. */
+export function redactValues(text: string, values: Iterable<string>): string {
+  let out = text;
+  for (const value of values) {
+    if (typeof value !== "string" || value.length < MIN_VALUE_LENGTH) continue;
+    out = out.replaceAll(value, REDACTED);
+  }
+  return out;
+}
+
+/** Replaces anything shaped like a credential. */
+export function redactSecrets(text: string, values: Iterable<string> = []): string {
+  let out = redactValues(text, values);
+  for (const { pattern, replacement } of PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+/** Fields a failed child process carries the command line and its output in. */
+const ERROR_TEXT_FIELDS = ["message", "cmd", "stdout", "stderr", "stack"] as const;
+
+/**
+ * Rewrites an error's text in place so a credential on argv cannot survive
+ * into whatever logs it. Non-errors are returned untouched.
+ */
+export function redactError<T>(error: T, values: Iterable<string> = []): T {
+  if (!error || typeof error !== "object") return error;
+
+  const target = error as Record<string, unknown>;
+  for (const field of ERROR_TEXT_FIELDS) {
+    const value = target[field];
+    if (typeof value !== "string") continue;
+    try {
+      target[field] = redactSecrets(value, values);
+    } catch {
+      // Frozen or getter-only field — the remaining fields still get cleaned.
+    }
+  }
+  return error;
+}

--- a/lib/setup.ts
+++ b/lib/setup.ts
@@ -1,10 +1,40 @@
 import { db } from "@/lib/db";
-import { user } from "@/lib/db/schema";
-import { sql } from "drizzle-orm";
+import { systemSettings, user } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { setSystemSetting } from "@/lib/system-settings";
 
+/** Presence of this row is the record that first-run setup already happened. */
+const SETUP_COMPLETED_KEY = "setup_completed";
+
+/** Writes the latch. Idempotent. */
+async function markSetupCompleted(): Promise<void> {
+  await setSystemSetting(SETUP_COMPLETED_KEY, new Date().toISOString());
+}
+
+async function setupLatched(): Promise<boolean> {
+  const row = await db.query.systemSettings.findFirst({
+    where: eq(systemSettings.key, SETUP_COMPLETED_KEY),
+    columns: { key: true },
+  });
+  return row !== undefined;
+}
+
+/**
+ * Whether first-run setup is still open. Latches shut the first time an account
+ * is seen and never reopens, so an empty user table cannot hand out a new admin.
+ * Throws rather than guessing when the count is unreadable.
+ */
 export async function needsSetup(): Promise<boolean> {
-  const [{ count }] = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(user);
-  return Number(count) === 0;
+  if (await setupLatched()) return false;
+
+  const [row] = await db.select({ count: sql<number>`count(*)` }).from(user);
+  const count = Number(row?.count);
+
+  if (count > 0) {
+    await markSetupCompleted();
+    return false;
+  }
+  if (count === 0) return true;
+
+  throw new Error("Could not determine whether any accounts exist");
 }

--- a/lib/utils/exec.ts
+++ b/lib/utils/exec.ts
@@ -8,8 +8,23 @@
 
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { redactError } from "@/lib/redact";
 
-export const execFileAsync = promisify(execFile);
+const execFileRaw = promisify(execFile);
+
+/**
+ * `execFile`, with credentials stripped from a failure before it propagates.
+ * Node builds the error message out of the whole argv, so any secret passed as
+ * an argument would otherwise reach every logger that prints the error.
+ * Use this rather than promisifying `execFile` again.
+ */
+export const execFileAsync = (async (...args: Parameters<typeof execFileRaw>) => {
+  try {
+    return await execFileRaw(...args);
+  } catch (err) {
+    throw redactError(err);
+  }
+}) as typeof execFileRaw;
 
 export type ExecOptions = Parameters<typeof execFileAsync>[2];
 

--- a/lib/volumes/diff.ts
+++ b/lib/volumes/diff.ts
@@ -1,9 +1,6 @@
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { assertSafeName, assertSafeMountPath } from "@/lib/docker/validate";
 import { assertSafeSyncPath } from "@/lib/utils/exec";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "@/lib/utils/exec";
 
 /**
  * Validate that an image reference contains only safe characters.

--- a/tests/unit/lib/redact.test.ts
+++ b/tests/unit/lib/redact.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "child_process";
+import { redactSecrets, redactValues, redactError, REDACTED } from "@/lib/redact";
+import { execFileAsync } from "@/lib/utils/exec";
+
+// ---------------------------------------------------------------------------
+// Redaction of credentials on their way out of the process.
+// ---------------------------------------------------------------------------
+
+const GITHUB_TOKEN = "ghs_16CharsAndThenSomeMoreABCDEF123456";
+const AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+describe("redactSecrets", () => {
+  it("removes the password from a URL", () => {
+    const out = redactSecrets(`git clone https://x-access-token:${GITHUB_TOKEN}@github.com/acme/app`);
+
+    expect(out).not.toContain(GITHUB_TOKEN);
+    expect(out).toContain("github.com/acme/app");
+  });
+
+  it("removes a bare token used as URL userinfo", () => {
+    expect(redactSecrets(`https://${GITHUB_TOKEN}@github.com/acme/app`)).not.toContain(GITHUB_TOKEN);
+  });
+
+  it("removes provider token shapes anywhere in the text", () => {
+    expect(redactSecrets(`token is ${GITHUB_TOKEN}`)).not.toContain(GITHUB_TOKEN);
+    expect(redactSecrets("key AKIAIOSFODNN7EXAMPLE here")).not.toContain("AKIAIOSFODNN7EXAMPLE");
+  });
+
+  it("removes a private key body, not just its header", () => {
+    const pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAA\n-----END OPENSSH PRIVATE KEY-----";
+
+    const out = redactSecrets(`failed to read key: ${pem}`);
+    expect(out).not.toContain("b3BlbnNzaC1rZXktdjEAAAA");
+    expect(out).toContain(REDACTED);
+  });
+
+  it("removes secret-named environment assignments", () => {
+    const out = redactSecrets("env PGPASSWORD=hunter2000 AWS_SECRET_ACCESS_KEY=abcdef123456");
+
+    expect(out).not.toContain("hunter2000");
+    expect(out).not.toContain("abcdef123456");
+    expect(out).toContain("PGPASSWORD=");
+  });
+
+  it("removes credential-carrying CLI flags in both forms", () => {
+    expect(redactSecrets("restic --password=hunter2000")).not.toContain("hunter2000");
+    expect(redactSecrets("mc --secret-key hunter2000 alias")).not.toContain("hunter2000");
+  });
+
+  it("removes Authorization header values", () => {
+    expect(redactSecrets("Authorization: Bearer abcdef123456789")).not.toContain("abcdef123456789");
+  });
+
+  it("removes the base64 auth blob from a docker config", () => {
+    const out = redactSecrets('{"auths":{"ghcr.io":{"auth":"dXNlcjpwYXNzd29yZA=="}}}');
+
+    expect(out).not.toContain("dXNlcjpwYXNzd29yZA==");
+    expect(out).toContain("ghcr.io");
+  });
+
+  it("leaves ordinary log lines alone", () => {
+    const line = "[deploy] Pulled latest from main";
+    expect(redactSecrets(line)).toBe(line);
+  });
+
+  it("keeps neither the length nor a prefix of what it removed", () => {
+    const out = redactSecrets(`https://user:${AWS_SECRET}@s3.example.com/bucket`);
+
+    expect(out).not.toContain(AWS_SECRET);
+    expect(out).not.toContain(AWS_SECRET.slice(0, 4));
+    expect(out).not.toMatch(new RegExp(`.{${AWS_SECRET.length}}@s3`));
+    expect(out).toContain(REDACTED);
+  });
+});
+
+describe("redactValues", () => {
+  it("removes a known value whatever shape it has", () => {
+    expect(redactValues("prefix-s3cr3tvalue-suffix", ["s3cr3tvalue"])).toBe(`prefix-${REDACTED}-suffix`);
+  });
+
+  it("ignores values too short to be worth matching", () => {
+    expect(redactValues("a b c", ["a"])).toBe("a b c");
+  });
+});
+
+describe("redactError", () => {
+  it("cleans message, cmd, stderr and stack together", () => {
+    const err = Object.assign(new Error(`Command failed: git clone https://x:${GITHUB_TOKEN}@github.com/a/b`), {
+      cmd: `git clone https://x:${GITHUB_TOKEN}@github.com/a/b`,
+      stderr: `fatal: could not read from https://x:${GITHUB_TOKEN}@github.com/a/b`,
+      stdout: "",
+    });
+
+    redactError(err);
+
+    expect(err.message).not.toContain(GITHUB_TOKEN);
+    expect(err.cmd).not.toContain(GITHUB_TOKEN);
+    expect(err.stderr).not.toContain(GITHUB_TOKEN);
+    expect(err.stack).not.toContain(GITHUB_TOKEN);
+  });
+
+  it("passes non-errors through", () => {
+    expect(redactError("plain")).toBe("plain");
+    expect(redactError(null)).toBe(null);
+  });
+});
+
+describe("execFileAsync", () => {
+  it("does not let a credential on argv survive into the error", async () => {
+    const url = `https://x-access-token:${GITHUB_TOKEN}@github.com/acme/app`;
+
+    const err = await execFileAsync("/bin/sh", ["-c", "exit 3", url]).then(
+      () => null,
+      (e: Error & { cmd?: string }) => e,
+    );
+
+    expect(err).toBeTruthy();
+    expect(err!.message).toContain("Command failed");
+    expect(err!.message).not.toContain(GITHUB_TOKEN);
+    expect(err!.cmd).not.toContain(GITHUB_TOKEN);
+    expect(err!.stack).not.toContain(GITHUB_TOKEN);
+  });
+
+  it("keeps a credential echoed on stderr out of the error", async () => {
+    const err = await execFileAsync("/bin/sh", [
+      "-c",
+      `echo "fatal: repository 'https://x-access-token:${GITHUB_TOKEN}@github.com/a/b' not found" >&2; exit 128`,
+    ]).then(
+      () => null,
+      (e: Error & { stderr?: string }) => e,
+    );
+
+    expect(err!.stderr).not.toContain(GITHUB_TOKEN);
+    expect(err!.message).not.toContain(GITHUB_TOKEN);
+  });
+
+  it("returns output unchanged when the command succeeds", async () => {
+    const { stdout } = await execFileAsync("/bin/sh", ["-c", "echo ok"]);
+    expect(stdout.trim()).toBe("ok");
+  });
+});
+
+describe("exec call sites", () => {
+  it("all go through the redacting wrapper", async () => {
+    const { readdirSync, readFileSync } = await import("fs");
+    const { join } = await import("path");
+
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "node_modules") walk(path);
+        } else if (entry.name.endsWith(".ts") && path !== join("lib", "utils", "exec.ts")) {
+          if (/promisify\(\s*execFile\s*\)/.test(readFileSync(path, "utf-8"))) offenders.push(path);
+        }
+      }
+    };
+    walk("lib");
+    walk("app");
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("proves the raw promisified execFile is what leaks", async () => {
+    const url = `https://x-access-token:${GITHUB_TOKEN}@github.com/acme/app`;
+
+    const err = await new Promise<Error & { cmd?: string }>((resolve) => {
+      execFile("/bin/sh", ["-c", "exit 3", url], (e) => resolve(e as Error & { cmd?: string }));
+    });
+
+    expect(err.message).toContain(GITHUB_TOKEN);
+  });
+});

--- a/tests/unit/lib/setup-gate.test.ts
+++ b/tests/unit/lib/setup-gate.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// needsSetup — the first-run gate. Once an account has been seen the gate is
+// latched in system_settings, so a later empty user table must not reopen it.
+// ---------------------------------------------------------------------------
+
+const { mockFindFirst, mockSelect, mockSetSystemSetting } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockSelect: vi.fn(),
+  mockSetSystemSetting: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    query: { systemSettings: { findFirst: mockFindFirst } },
+    select: mockSelect,
+  },
+}));
+
+vi.mock("@/lib/system-settings", () => ({
+  setSystemSetting: mockSetSystemSetting,
+}));
+
+import { needsSetup } from "@/lib/setup";
+
+function userRows(rows: { count: number | string }[]) {
+  mockSelect.mockReturnValue({ from: () => Promise.resolve(rows) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindFirst.mockResolvedValue(undefined);
+  userRows([{ count: 0 }]);
+});
+
+describe("needsSetup", () => {
+  it("is open on a fresh instance with no accounts", async () => {
+    expect(await needsSetup()).toBe(true);
+    expect(mockSetSystemSetting).not.toHaveBeenCalled();
+  });
+
+  it("latches shut the first time an account is seen", async () => {
+    userRows([{ count: 1 }]);
+
+    expect(await needsSetup()).toBe(false);
+    expect(mockSetSystemSetting).toHaveBeenCalledWith("setup_completed", expect.any(String));
+  });
+
+  it("stays shut when the user table is emptied after setup", async () => {
+    mockFindFirst.mockResolvedValue({ key: "setup_completed" });
+    userRows([{ count: 0 }]);
+
+    expect(await needsSetup()).toBe(false);
+  });
+
+  it("does not count users once latched", async () => {
+    mockFindFirst.mockResolvedValue({ key: "setup_completed" });
+
+    await needsSetup();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("throws when the account count is unreadable", async () => {
+    userRows([]);
+
+    await expect(needsSetup()).rejects.toThrow(/whether any accounts exist/);
+  });
+
+  it("throws when the latch cannot be read", async () => {
+    mockFindFirst.mockRejectedValue(new Error("connection refused"));
+
+    await expect(needsSetup()).rejects.toThrow("connection refused");
+  });
+});


### PR DESCRIPTION
Refs #788. Two questions raised by a survey of comparable products' CVEs, checked against our code.

## Q1 — the setup window: vulnerable, fixed

`needsSetup()` (`lib/setup.ts:5-10`, before this branch) answered "is first-run setup still open?" by counting rows in the `user` table on every call. Nothing was persisted, so the answer was re-derived from whatever the table looked like at that moment — the same shape as Portainer's CVE-2026-55761, minus the timer.

An empty-looking user table reopens all of this without authentication:

- `app/api/auth/[...all]/route.ts:59-62` — `/sign-up/email` is allowed through even when password auth is switched off, and `lib/auth/index.ts:82` re-enables the email/password endpoints entirely.
- `lib/organizations/create-default-org.ts:22-30` — the first account created is promoted to app admin.
- `app/api/setup/{auth,general,github,email,backup}/route.ts` — each skips `requireAdminAuth` while setup is pending, so GitHub OAuth credentials, SMTP config and backup storage config are writable by anyone.
- `app/api/v1/admin/mesh/join/route.ts:52` and `app/api/v1/admin/config/import/route.ts:86` — same bypass.

There is no user-delete endpoint, so this is not reachable through the app's own API. It is reachable through anything that empties or hides the table: a restore from a backup taken before the first account, `DATABASE_URL` repointed at a fresh database (`pnpm start` migrates on boot, so the table is created empty), a replica that has not caught up, or an operator wiping the table.

The database-unreachable case did **not** fail open. The count query threw and every caller propagated it; the one catch site, `lib/auth/index.ts:72`, defaults to `false` (closed).

**Fix**: the gate is now a persisted fact — a `setup_completed` row in `system_settings`, written the first time an account is observed. Once the row exists the user table is never counted again. Existing installs latch on their next call, so there is no migration. An unreadable count throws instead of reading as zero.

## Q2 — secret redaction on error paths: vulnerable, fixed

`ExecError` carries the full command line. Node builds a failed `execFile`'s message as `Command failed: <file> <args joined>` plus stderr, and also hangs the same string on `err.cmd`. Verified directly rather than from memory — see the last test in `tests/unit/lib/redact.test.ts`, which asserts the raw promisified `execFile` still leaks.

`lib/docker/registry-auth.ts` is clean: registry credentials go through a throwaway `DOCKER_CONFIG` directory, never argv. So do the SSH deploy key (`GIT_SSH_COMMAND` env plus a `0600` temp file), the WireGuard private key (generated inside the container), backup DB credentials on the non-legacy path (`lib/backups/dump-spec.ts` reads them from the target container's own environment) and S3/B2 credentials (SDK, no subprocess).

The GitHub App installation token is not. `lib/docker/deploy-steps/prepare-repo.ts:429` embeds it in the clone URL, which is then argv at lines 461 and 482. Those calls are inside a `try` with only a `finally`, so a clone failure propagates to `runDeployment`'s catch. From there `message` fanned out to five sinks, of which exactly one was redacted:

| sink | redacted before |
|---|---|
| `deploy.ts:545` `log(...)` to the deployment log | yes, via `deploy-logger.ts` `sanitize()` |
| `deploy.ts:578` `addEvent` to the org event feed (SSE) | no |
| `deploy.ts:589` `recordActivity` to the `activities` table, shown in the audit UI | no |
| `deploy.ts:596` `sendDeployNotification` to email and webhook channels | no |
| `deploy.ts:602` `return { error: message }` to the deploy API response | no |

Git also prints the tokenized URL in its own stderr, which `execFile` folds into the same message. So a private-repo clone failure mailed the installation token out through the notification channels.

**Fix**, applied where errors are constructed rather than at each log site:

- `lib/redact.ts` — `redactSecrets`, `redactValues`, `redactError`. Covers URL userinfo, provider token shapes, PEM private key bodies, `Authorization` headers, docker config `auth` blobs, secret-named env assignments and credential-carrying CLI flags. Every match is replaced with `[redacted]` in full: no length, no prefix, no last-four.
- `lib/utils/exec.ts` — `execFileAsync` redacts `message`, `cmd`, `stdout`, `stderr` and `stack` before the error propagates. All 27 modules that had their own `promisify(execFile)` now import this one, and a test fails the build if a new one appears.
- `lib/docker/deploy-logger.ts` — `sanitize()` was three hand-written patterns; it now runs the shared helper, plus the key-file name patterns (which point at a secret without being one). This covers streamed build output too, since `logs.push` is `log`.
- `lib/logger.ts` — string arguments are redacted on the way to the console, which is what Loki collects.
- `lib/docker/deploy.ts:442` — the failure message is redacted once, where it is built, which covers all five sinks above.

## Verified

`pnpm test` — typecheck clean, lint 0 errors (376 pre-existing warnings, one fewer than main), 4364 tests across 301 files.

New tests: `tests/unit/lib/setup-gate.test.ts` (the gate stays shut when the user table is emptied after setup, does not count users once latched, throws rather than defaulting when the count or the latch is unreadable) and `tests/unit/lib/redact.test.ts` (each pattern, no length or prefix recoverable, and the required case — a credential on an argv does not survive into the error message, its `cmd`, its `stack` or its stderr).

## Left alone, worth a look

- **Credentials on argv are visible to `ps`, independent of any error.** `prepare-repo.ts:461,482` puts the GitHub token on the git command line, and `prepare-repo.ts:267,286,300` puts the app's fully decrypted env map on the Nixpacks `--env`, Railpack `--env` and `docker build --build-arg` command lines. Redaction fixes the log leak but not `/proc/<pid>/cmdline`. The fixes differ per tool — `GIT_ASKPASS` or a credential helper for git, and `build.ts` already shows the `.env`-file pattern for the build args.
- `lib/docker/deploy-cancel.ts:411-416` writes an error straight to the `deployments.log` column, bypassing the deploy logger. Covered now for exec-derived errors because redaction happens at construction, but the path itself is unsanitized.
- `lib/backups/engine.ts:795,1271` logs `backupMeta.dumpCmd`/`restoreCmd` verbatim and interpolates them into `bash -c`. The only writer today builds password-free commands, so nothing leaks now, but nothing validates the field either.
