### PR TITLE
fix: five first-run audit defects where the UI promised what the code did not do

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
@@ -291,7 +291,10 @@ export function AppDeployPanel({
         appStatus === "deploying")
   );
 
-  const showRollbackAction = slotStatus?.standbyAvailable && appStatus === "active";
+  // A crashed app is when the swap back to the standby matters most, so "error"
+  // shows this card rather than hiding it.
+  const showRollbackAction =
+    slotStatus?.standbyAvailable && (appStatus === "active" || appStatus === "error");
 
   const instantRollbackDeploy = showRollbackAction
     ? completedDeployments.find(

--- a/app/(authenticated)/apps/[...slug]/app-detail.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-detail.tsx
@@ -78,6 +78,7 @@ import { ComposeDetail } from "./compose-detail";
 import { AppSecurity } from "./app-security";
 import { SystemBadge } from "@/components/system-badge";
 import { extractDeployError } from "@/lib/ui/deploy-error";
+import { deployFailureBanner } from "@/lib/ui/deploy-banner";
 import { currentStageLabel } from "@/lib/ui/deploy-stage";
 import { tabPanelSurface } from "@/lib/ui/tab-panel";
 import { cn } from "@/lib/utils";
@@ -644,31 +645,46 @@ export function AppDetail({ app, orgId, userRole, allTags = [], allParentApps = 
         )}
       </PageToolbar>
 
-      {/* Error banner — only show if the current environment has a failed deploy */}
-      {app.status === "error" && (() => {
-        const failedDeploy = filteredDeployments.find((d) => d.status === "failed");
-        if (!failedDeploy) return null;
-        const errorMessage =
-          extractDeployError(failedDeploy.log) || "App crashed — check the deploy log for details";
+      {/* Failure banner — the app is down, or a deploy failed and the previous release absorbed it */}
+      {(() => {
+        const banner = deployFailureBanner(app.status, filteredDeployments);
+        if (!banner) return null;
+        const { variant, deployment: failedDeploy } = banner;
+        const recovered = variant === "recovered";
+        const errorMessage = recovered
+          ? "Deploy failed. The previous release is still running."
+          : extractDeployError(failedDeploy.log) || "App crashed — check the deploy log for details";
         return (
-          <div className="flex items-start gap-2 rounded-lg bg-status-error-muted px-4 py-2.5 text-sm text-status-error">
-            <X className="size-4 shrink-0 mt-0.5" />
+          <div
+            className={cn(
+              "flex items-start gap-2 rounded-lg px-4 py-2.5 text-sm",
+              recovered
+                ? "bg-status-warning-muted text-status-warning"
+                : "bg-status-error-muted text-status-error"
+            )}
+          >
+            {recovered ? (
+              <AlertTriangle className="size-4 shrink-0 mt-0.5" aria-hidden="true" />
+            ) : (
+              <X className="size-4 shrink-0 mt-0.5" />
+            )}
             <span
-              className="flex-1 line-clamp-3 break-words font-mono text-xs leading-relaxed"
+              className={cn(
+                "flex-1 line-clamp-3 break-words leading-relaxed",
+                !recovered && "font-mono text-xs"
+              )}
               title={errorMessage}
             >
               {errorMessage}
             </span>
             <div className="flex items-center gap-2 shrink-0 mt-0.5">
-              {failedDeploy && (
-                <button
-                  type="button"
-                  onClick={() => { setActiveTab("deployments"); deploy.setViewingLogId(failedDeploy.id); }}
-                  className="text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
-                >
-                  View log
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => { setActiveTab("deployments"); deploy.setViewingLogId(failedDeploy.id); }}
+                className="text-xs underline underline-offset-2 opacity-80 hover:opacity-100"
+              >
+                View log
+              </button>
               <button
                 type="button"
                 disabled={deploy.deploying}

--- a/app/(authenticated)/apps/[...slug]/app-networking.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-networking.tsx
@@ -119,8 +119,8 @@ export function AppNetworking({
           ...prev,
           [domain.id]: data.configured ? "resolving" : "not-configured",
         }));
-        if (data.serverIPs?.length) {
-          setServerIP(data.serverIPs[0]);
+        if (data.serverIp) {
+          setServerIP(data.serverIp);
         }
       } catch {
         setDomainStatuses((prev) => ({ ...prev, [domain.id]: "not-configured" }));

--- a/app/(authenticated)/apps/[...slug]/compose-detail.tsx
+++ b/app/(authenticated)/apps/[...slug]/compose-detail.tsx
@@ -81,6 +81,7 @@ import { ComposeReview } from "@/components/compose-review";
 import { SystemBadge } from "@/components/system-badge";
 import { statusDotColor } from "@/lib/ui/status-colors";
 import { crashSummary, extractDeployError } from "@/lib/ui/deploy-error";
+import { deployFailureBanner } from "@/lib/ui/deploy-banner";
 import { currentStageLabel } from "@/lib/ui/deploy-stage";
 import { rollupHealth, rollupUptimeSince } from "@/lib/ui/health-rollup";
 import { tabPanelSurface } from "@/lib/ui/tab-panel";
@@ -1084,18 +1085,38 @@ export function ComposeDetail({
 
       {/* Failure detail — the stack's own deploy log when it failed, otherwise
           the services that are actually down, each linked to its page. */}
-      {app.status === "error" && (() => {
-        const failedDeploy = app.deployments.find((d) => d.status === "failed");
-        const crash = crashSummary(services);
-        const message =
-          extractDeployError(failedDeploy?.log) ||
-          crash?.message ||
-          "Stack crashed — check the service logs for details";
+      {(() => {
+        const banner = deployFailureBanner(app.status, app.deployments);
+        if (!banner) return null;
+        const recovered = banner.variant === "recovered";
+        const failedDeploy = recovered
+          ? banner.deployment
+          : app.deployments.find((d) => d.status === "failed");
+        const crash = recovered ? null : crashSummary(services);
+        const message = recovered
+          ? "Deploy failed. The previous release is still running."
+          : extractDeployError(failedDeploy?.log) ||
+            crash?.message ||
+            "Stack crashed — check the service logs for details";
         return (
-          <div className="flex items-start gap-2 rounded-lg bg-status-error-muted px-4 py-2.5 text-sm text-status-error">
-            <X className="size-4 shrink-0 mt-0.5" />
+          <div
+            className={cn(
+              "flex items-start gap-2 rounded-lg px-4 py-2.5 text-sm",
+              recovered
+                ? "bg-status-warning-muted text-status-warning"
+                : "bg-status-error-muted text-status-error"
+            )}
+          >
+            {recovered ? (
+              <AlertTriangle className="size-4 shrink-0 mt-0.5" aria-hidden="true" />
+            ) : (
+              <X className="size-4 shrink-0 mt-0.5" />
+            )}
             <span
-              className="flex-1 line-clamp-3 break-words font-mono text-xs leading-relaxed"
+              className={cn(
+                "flex-1 line-clamp-3 break-words leading-relaxed",
+                !recovered && "font-mono text-xs"
+              )}
               title={message}
             >
               {message}

--- a/app/(authenticated)/apps/new/new-app-flow.tsx
+++ b/app/(authenticated)/apps/new/new-app-flow.tsx
@@ -485,7 +485,8 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
       }
 
       // Trigger deploy via API so the app detail page can pick up the SSE stream
-      if (autoDeploy && repoReady) {
+      const deploying = autoDeploy && repoReady;
+      if (deploying) {
         fetch(`/api/v1/organizations/${orgId}/apps/${app.id}/deploy`, {
           method: "POST",
         }).catch(() => {
@@ -495,7 +496,10 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
       } else {
         toast.success("App created");
       }
-      router.push(projectName ? `/projects/${projectName}` : `/apps/${app.name}`);
+      // The app page is the only one that streams the deploy log.
+      router.push(
+        deploying || !projectName ? `/apps/${app.name}` : `/projects/${projectName}`
+      );
     } catch (err) { toast.error(err instanceof Error ? err.message : "Failed to create app"); }
     finally { setCreating(false); }
   }

--- a/app/(authenticated)/settings/[tab]/page.tsx
+++ b/app/(authenticated)/settings/[tab]/page.tsx
@@ -12,6 +12,8 @@ import { TeamMembers } from "@/app/(authenticated)/team/team-members";
 import { InvitationsPanel } from "../invitations";
 import { OrgGeneralSettings } from "../org-general-settings";
 import { BackupPage } from "@/components/backups/backup-page";
+import { isOrgAdmin } from "@/lib/auth/permissions";
+import { getEmailProviderConfig } from "@/lib/system-settings";
 
 const VALID_TABS = ["general", "variables", "domains", "backups", "notifications", "team", "invitations"] as const;
 type ValidTab = (typeof VALID_TABS)[number];
@@ -133,6 +135,10 @@ export default async function OrgSettingsTabPage({
         orderBy: (t, { desc }) => [desc(t.createdAt)],
       });
 
+      // The token is the invite itself, so only admins — who can revoke it — see the link.
+      const canManage = isOrgAdmin(orgData.membership.role);
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
       const invitationList = orgInvitations.map((inv) => ({
         id: inv.id,
         email: inv.email,
@@ -143,6 +149,10 @@ export default async function OrgSettingsTabPage({
         inviter: inv.inviter
           ? { id: inv.inviter.id, name: inv.inviter.name }
           : null,
+        inviteUrl:
+          canManage && inv.status === "pending"
+            ? `${appUrl}/invite/${inv.token}`
+            : null,
       }));
 
       return (
@@ -151,6 +161,7 @@ export default async function OrgSettingsTabPage({
           orgName={orgData.organization.name}
           currentRole={orgData.membership.role}
           invitations={invitationList}
+          emailConfigured={!!(await getEmailProviderConfig())}
         />
       );
     }

--- a/app/(authenticated)/settings/invitations.tsx
+++ b/app/(authenticated)/settings/invitations.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "@/lib/messenger";
-import { Plus, Mail, MoreHorizontal, RefreshCw, XCircle, CheckCircle2 } from "lucide-react";
+import { Plus, Mail, MoreHorizontal, RefreshCw, XCircle, CheckCircle2, Copy, Check, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -36,6 +36,8 @@ type Invitation = {
   createdAt: string;
   expiresAt: string;
   inviter: { id: string; name: string | null } | null;
+  /** Null for non-admins and for invitations that can no longer be used. */
+  inviteUrl?: string | null;
 };
 
 type InvitationsPanelProps = {
@@ -43,6 +45,7 @@ type InvitationsPanelProps = {
   orgName: string;
   currentRole: string;
   invitations: Invitation[];
+  emailConfigured: boolean;
 };
 
 const ROLE_LABELS: Record<string, string> = {
@@ -61,18 +64,35 @@ export function InvitationsPanel({
   orgId,
   orgName,
   currentRole,
-  invitations: initialInvitations,
+  invitations: serverInvitations,
+  emailConfigured,
 }: InvitationsPanelProps) {
   const router = useRouter();
-  const [invitations, setInvitations] = useState(initialInvitations);
+  const [revokedIds, setRevokedIds] = useState<string[]>([]);
   const [inviteOpen, setInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<"member" | "admin">("member");
   const [inviting, setInviting] = useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<{ id: string; email: string } | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  // Read from props so a refresh after invite or revoke shows up.
+  const invitations = serverInvitations.map((inv) =>
+    revokedIds.includes(inv.id) ? { ...inv, status: "expired" as const } : inv
+  );
 
   const canManage = isOrgAdmin(currentRole);
+
+  async function copyInviteLink(invitationId: string, url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(invitationId);
+      setTimeout(() => setCopiedId((id) => (id === invitationId ? null : id)), 2000);
+    } catch {
+      toast.error("Failed to copy invite link");
+    }
+  }
 
   async function handleInvite() {
     const trimmedEmail = inviteEmail.trim();
@@ -103,7 +123,18 @@ export function InvitationsPanel({
         return;
       }
 
-      toast.success(`Invitation sent to ${inviteEmail.trim()}`);
+      if (!data.email?.configured) {
+        toast.warning(`Invitation created for ${trimmedEmail}`, {
+          description: "Email is not configured, so no message was sent. Copy the invite link to share it.",
+        });
+      } else if (!data.email.sent) {
+        toast.warning(`Invitation created for ${trimmedEmail}`, {
+          description: `The email failed to send${data.email.error ? ` (${data.email.error})` : ""}. Copy the invite link to share it.`,
+        });
+      } else {
+        toast.success(`Invitation sent to ${trimmedEmail}`);
+      }
+
       setInviteOpen(false);
       setInviteEmail("");
       setInviteRole("member");
@@ -135,11 +166,8 @@ export function InvitationsPanel({
       }
 
       toast.success("Invitation revoked");
-      setInvitations((prev) =>
-        prev.map((inv) =>
-          inv.id === invitationId ? { ...inv, status: "expired" as const } : inv
-        )
-      );
+      setRevokedIds((prev) => [...prev, invitationId]);
+      router.refresh();
     } catch {
       toast.error("Failed to revoke invitation");
     } finally {
@@ -163,7 +191,17 @@ export function InvitationsPanel({
         return;
       }
 
-      toast.success(`Invitation resent to ${email}`);
+      if (!data.email?.configured) {
+        toast.warning("No email was sent", {
+          description: "Email is not configured. Copy the invite link to share it.",
+        });
+      } else if (!data.email.sent) {
+        toast.error(`Failed to resend to ${email}`, {
+          description: data.email.error,
+        });
+      } else {
+        toast.success(`Invitation resent to ${email}`);
+      }
       router.refresh();
     } catch {
       toast.error("Failed to resend invitation");
@@ -186,6 +224,15 @@ export function InvitationsPanel({
 
       <Card className="squircle rounded-lg">
         <CardContent className="space-y-4">
+        {canManage && !emailConfigured && (
+          <div className="flex items-start gap-2 rounded-lg bg-status-warning-muted px-4 py-2.5 text-sm text-status-warning">
+            <AlertTriangle className="size-4 shrink-0 mt-0.5" aria-hidden="true" />
+            <span className="flex-1">
+              Email is not configured, so invitations are not delivered. Copy each invite link and send it yourself, or set up a provider in notification settings.
+            </span>
+          </div>
+        )}
+
         <div className="flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
             {invitations.filter((i) => i.status === "pending").length} pending
@@ -240,6 +287,21 @@ export function InvitationsPanel({
                   </div>
 
                   <div className="flex items-center gap-3 shrink-0">
+                    {isPending && invitation.inviteUrl && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 gap-1.5 text-xs"
+                        onClick={() => copyInviteLink(invitation.id, invitation.inviteUrl!)}
+                      >
+                        {copiedId === invitation.id ? (
+                          <><Check className="size-3.5" />Copied</>
+                        ) : (
+                          <><Copy className="size-3.5" />Copy link</>
+                        )}
+                      </Button>
+                    )}
+
                     <Badge variant="secondary">
                       {ROLE_LABELS[invitation.role] || invitation.role}
                     </Badge>
@@ -295,7 +357,9 @@ export function InvitationsPanel({
           <BottomSheetHeader>
             <BottomSheetTitle>Invite to {orgName}</BottomSheetTitle>
             <BottomSheetDescription>
-              Send an invitation email. They&apos;ll get a link to join the organization.
+              {emailConfigured
+                ? "Send an invitation email. They'll get a link to join the organization."
+                : "Email is not configured, so nothing will be sent. You'll get a link to share yourself."}
             </BottomSheetDescription>
           </BottomSheetHeader>
           <div className="flex-1 overflow-y-auto px-6 pb-6">
@@ -360,7 +424,9 @@ export function InvitationsPanel({
               onClick={handleInvite}
               disabled={inviting || !inviteEmail.trim()}
             >
-              {inviting ? "Sending..." : "Send invitation"}
+              {inviting
+                ? emailConfigured ? "Sending..." : "Creating..."
+                : emailConfigured ? "Send invitation" : "Create invitation"}
             </Button>
           </BottomSheetFooter>
         </BottomSheetContent>

--- a/app/api/v1/organizations/[orgId]/invitations/[invitationId]/route.ts
+++ b/app/api/v1/organizations/[orgId]/invitations/[invitationId]/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { invitations, user } from "@/lib/db/schema";
 import { requireOrgAdmin } from "@/lib/auth/permissions";
 import { eq, and } from "drizzle-orm";
-import { sendEmail } from "@/lib/email/send";
+import { sendEmail, emailDelivery } from "@/lib/email/send";
 import { InviteEmail } from "@/lib/email/templates/invite";
 import { verifyOrgAccess } from "@/lib/api/verify-access";
 import { requirePlugin } from "@/lib/api/require-plugin";
@@ -105,7 +105,7 @@ async function handlePatch(
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
     const inviteUrl = `${appUrl}/invite/${invitation.token}`;
 
-    await sendEmail({
+    const sent = await sendEmail({
       to: invitation.email,
       subject: `You've been invited to ${org.organization.name}`,
       template: InviteEmail({
@@ -116,7 +116,7 @@ async function handlePatch(
       }),
     });
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, inviteUrl, email: emailDelivery(sent) });
   } catch (error) {
     if (error instanceof Error && error.message === "Forbidden") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/app/api/v1/organizations/[orgId]/invitations/route.ts
+++ b/app/api/v1/organizations/[orgId]/invitations/route.ts
@@ -7,7 +7,7 @@ import { requireOrgAdmin } from "@/lib/auth/permissions";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import crypto from "crypto";
-import { sendEmail } from "@/lib/email/send";
+import { sendEmail, emailDelivery } from "@/lib/email/send";
 import { InviteEmail } from "@/lib/email/templates/invite";
 import { verifyOrgAccess } from "@/lib/api/verify-access";
 import { requirePlugin } from "@/lib/api/require-plugin";
@@ -133,7 +133,7 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
     const inviteUrl = `${appUrl}/invite/${token}`;
 
-    await sendEmail({
+    const sent = await sendEmail({
       to: normalizedEmail,
       subject: `You've been invited to ${org.organization.name}`,
       template: InviteEmail({
@@ -144,7 +144,10 @@ async function handlePost(request: NextRequest, { params }: RouteParams) {
       }),
     });
 
-    return NextResponse.json({ invitation }, { status: 201 });
+    return NextResponse.json(
+      { invitation: { ...invitation, inviteUrl }, email: emailDelivery(sent) },
+      { status: 201 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message === "Forbidden") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -15,6 +15,17 @@ type SendEmailOpts = {
 
 type SendResult = { success: boolean; dev?: boolean; error?: string };
 
+/** What a client is told about a send. `configured` false means nothing left the server. */
+export type EmailDelivery = { sent: boolean; configured: boolean; error?: string };
+
+export function emailDelivery(result: SendResult): EmailDelivery {
+  return {
+    sent: result.success && !result.dev,
+    configured: !result.dev,
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
 export async function sendEmail({ to, subject, template, from, replyTo }: SendEmailOpts): Promise<SendResult> {
   const config = await getEmailProviderConfig();
 

--- a/lib/ui/deploy-banner.ts
+++ b/lib/ui/deploy-banner.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Which failure banner the app header shows
+//
+// "crashed" is the app itself being down. "recovered" is a failed deploy that
+// blue/green absorbed — the previous release kept serving, so the status never
+// left active and nothing else in the header says the deploy failed.
+// ---------------------------------------------------------------------------
+
+export type DeployFailureVariant = "crashed" | "recovered";
+
+type DeployLike = { status: string };
+
+export type DeployFailureBanner<T> = { variant: DeployFailureVariant; deployment: T };
+
+/** Deployments must be newest first. */
+export function deployFailureBanner<T extends DeployLike>(
+  appStatus: string,
+  deployments: T[],
+): DeployFailureBanner<T> | null {
+  if (appStatus === "error") {
+    const failed = deployments.find((d) => d.status === "failed");
+    return failed ? { variant: "crashed", deployment: failed } : null;
+  }
+
+  const latest = deployments[0];
+  if (appStatus === "active" && latest?.status === "failed") {
+    return { variant: "recovered", deployment: latest };
+  }
+
+  return null;
+}

--- a/tests/unit/lib/email/delivery.test.ts
+++ b/tests/unit/lib/email/delivery.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { emailDelivery } from "@/lib/email/send";
+
+describe("emailDelivery", () => {
+  it("does not claim a send when no provider is configured", () => {
+    expect(emailDelivery({ success: true, dev: true })).toEqual({
+      sent: false,
+      configured: false,
+    });
+  });
+
+  it("reports a real send", () => {
+    expect(emailDelivery({ success: true })).toEqual({ sent: true, configured: true });
+  });
+
+  it("reports a provider failure with its reason", () => {
+    expect(emailDelivery({ success: false, error: "Resend: 422" })).toEqual({
+      sent: false,
+      configured: true,
+      error: "Resend: 422",
+    });
+  });
+});

--- a/tests/unit/lib/ui/deploy-banner.test.ts
+++ b/tests/unit/lib/ui/deploy-banner.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { deployFailureBanner } from "@/lib/ui/deploy-banner";
+
+const failed = { id: "d3", status: "failed" };
+const success = { id: "d2", status: "success" };
+const running = { id: "d1", status: "running" };
+
+describe("deployFailureBanner", () => {
+  it("reports a crash when the app is down and a deploy failed", () => {
+    expect(deployFailureBanner("error", [failed, success])).toEqual({
+      variant: "crashed",
+      deployment: failed,
+    });
+  });
+
+  it("stays silent when the app is down with no failed deploy", () => {
+    expect(deployFailureBanner("error", [success])).toBeNull();
+  });
+
+  it("reports a recovered failure when the latest deploy failed but the app still serves", () => {
+    expect(deployFailureBanner("active", [failed, success])).toEqual({
+      variant: "recovered",
+      deployment: failed,
+    });
+  });
+
+  it("stays silent once a later deploy succeeds", () => {
+    expect(deployFailureBanner("active", [success, failed])).toBeNull();
+  });
+
+  it("stays silent while a new deploy is in flight", () => {
+    expect(deployFailureBanner("active", [running, failed])).toBeNull();
+  });
+
+  it("stays silent for a stopped app", () => {
+    expect(deployFailureBanner("stopped", [failed])).toBeNull();
+  });
+
+  it("stays silent with no deployments", () => {
+    expect(deployFailureBanner("active", [])).toBeNull();
+    expect(deployFailureBanner("error", [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Five defects from the first-run audit, each one a place the UI promised something the code did not deliver. All five reproduced against the code before changing anything.

## 1. DNS panel handed the user nothing

`app-networking.tsx` read `data.serverIPs` (plural, array). `/api/v1/dns-check` returns `serverIp` (singular, string) and always has. The field never populated, so the "Required DNS Record" panel rendered the literal `your server IP` and its copy button copied an empty string.

The client was the wrong side: `serverIp` is the convention everywhere else — the config schema, `lib/server-ip.ts`, `getDnsRecords`, the admin dns-check endpoint, and `domain-settings.tsx` all use it. No other caller reads the plural form, so nothing else changed. The only other consumer of this endpoint, `org-domain-editor.tsx`, reads `configured` and was unaffected.

## 2. Invitations reported success without sending

`sendEmail` returns `{ success: true, dev: true }` with no provider configured. Neither invitation route inspected the result, so a fresh install could invite a whole team, see success toasts, and nobody could join — the invite link appeared nowhere in the UI and "Resend email" no-opped identically.

- `emailDelivery()` in `lib/email/send.ts` turns a send result into `{ sent, configured, error? }`. `configured: false` means nothing left the server.
- POST and PATCH now return it, and POST returns the `inviteUrl` alongside the invitation.
- The panel toasts the truth in all three cases: sent, not configured, or provider error.
- Each pending invitation row gets a **Copy link** button — useful even when email works. The link is built server-side and passed only to org admins, who can already revoke it.
- A standing notice appears when no provider is configured, and the invite sheet no longer promises an email it won't send.

One change beyond the brief was needed for the fix to be visible: the panel seeded `useState` from props and never resynced, so a newly created invitation did not appear after `router.refresh()` — the copy link would have had no row to sit on. It now reads from props and keeps a local revoked-id override.

## 3. User navigated away from the deploy they just started

`new-app-flow.tsx` triggered the deploy, then routed to the project page whenever the app belonged to a project. `project-detail.tsx` filters `queued` and `running` out of its list and does not mount `useDeploy`, so the first deploy showed as a status dot with no log and its failure toast never fired. With auto-deploy on, the flow now routes to the app page, which is the only one that streams the log.

## 4. An auto-recovered deploy failure said nothing

The header banner was gated on `app.status === "error"`. Under blue/green auto-rollback the previous release keeps serving and the status stays `active`, so the most common failure outcome was the silent one.

`deployFailureBanner()` (`lib/ui/deploy-banner.ts`) returns `crashed`, `recovered`, or nothing. The `recovered` variant renders in warning tone with "Deploy failed. The previous release is still running." and keeps **View log** and **Retry**. It stays quiet once a later deploy succeeds and while a new deploy is in flight.

Applied to both `app-detail.tsx` and `compose-detail.tsx` — the same gate, the same promise, and stacks roll back the same way.

## 5. Instant rollback hid exactly when it was needed

`app-deploy-panel.tsx` gated the instant-rollback card on `appStatus === "active"`, hiding it after a failed deploy. That is inverted: `appActionMenu` in `lib/ui/app-actions.ts` already ranks instant rollback **first** for `error` status, commented "A swap back to the standby beats rebuilding the version that crashed." The card now shows for `active` and `error`, matching the menu. The card's own rendering was already status-agnostic, so nothing else moved.

## Tests

`tests/unit/lib/ui/deploy-banner.test.ts` (7) and `tests/unit/lib/email/delivery.test.ts` (3) cover the banner condition and the email `dev` path.

`pnpm test` passes: typecheck clean, lint 0 errors, 4498 tests green.

## Adjacent, not fixed

Reported rather than folded into this diff:

- **`GET /api/v1/organizations/[orgId]/invitations` returns invite tokens to any org member.** It uses `verifyOrgAccess`, not `requireOrgAdmin`, and `findMany` with no column filter returns the whole row. A plain member can read a pending admin invite's token and accept it, escalating their own role. This PR does not widen the exposure — the settings page is a server component and passes the link only to admins — but the endpoint predates it and should be narrowed.
- **Invitations revoked in an earlier session render a blank status badge.** The DB writes status `revoked`; the panel's type union and `STATUS_LABELS` only know `pending`, `accepted`, and `expired`. Pre-existing, and unchanged here.
