### PR TITLE
fix(security): stop the invitations list returning tokens to org members

### DIFF
--- a/app/api/v1/organizations/[orgId]/invitations/route.ts
+++ b/app/api/v1/organizations/[orgId]/invitations/route.ts
@@ -3,13 +3,14 @@ import { z } from "zod";
 import { handleRouteError } from "@/lib/api/error-response";
 import { db } from "@/lib/db";
 import { invitations, user } from "@/lib/db/schema";
-import { requireOrgAdmin } from "@/lib/auth/permissions";
+import { isOrgAdmin, requireOrgAdmin } from "@/lib/auth/permissions";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import crypto from "crypto";
 import { sendEmail, emailDelivery } from "@/lib/email/send";
 import { InviteEmail } from "@/lib/email/templates/invite";
 import { verifyOrgAccess } from "@/lib/api/verify-access";
+import { serializeInvitation } from "@/lib/invitations/serialize";
 import { requirePlugin } from "@/lib/api/require-plugin";
 
 import { withRateLimit } from "@/lib/api/with-rate-limit";
@@ -39,6 +40,17 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
         eq(invitations.targetId, orgId),
         eq(invitations.scope, "org"),
       ),
+      // The token is the invite. Selected explicitly so it is never serialized
+      // to a member, who could otherwise accept an admin invitation.
+      columns: {
+        id: true,
+        email: true,
+        role: true,
+        status: true,
+        token: true,
+        createdAt: true,
+        expiresAt: true,
+      },
       with: {
         inviter: {
           columns: { id: true, name: true, email: true },
@@ -47,7 +59,14 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       orderBy: (t, { desc }) => [desc(t.createdAt)],
     });
 
-    return NextResponse.json({ invitations: pending });
+    const canManage = isOrgAdmin(org.membership.role);
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+    const invitationList = pending.map((inv) =>
+      serializeInvitation(inv, { canManage, appUrl }),
+    );
+
+    return NextResponse.json({ invitations: invitationList });
   } catch (error) {
     return handleRouteError(error, "Error fetching invitations");
   }

--- a/lib/invitations/serialize.ts
+++ b/lib/invitations/serialize.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// Shaping an invitation for the client.
+//
+// The token is the invite. Anyone holding it can accept the role it carries,
+// so it never leaves the server — an admin gets a ready-made link instead.
+// ---------------------------------------------------------------------------
+
+export type InvitationRow = {
+  id: string;
+  email: string;
+  role: string;
+  status: string;
+  token: string;
+  createdAt: Date | string;
+  expiresAt: Date | string;
+};
+
+export type SerializedInvitation = Omit<InvitationRow, "token"> & {
+  inviteUrl: string | null;
+};
+
+/** Drops the token and adds a link only an admin can act on. */
+export function serializeInvitation<T extends InvitationRow>(
+  row: T,
+  { canManage, appUrl }: { canManage: boolean; appUrl: string },
+): Omit<T, "token"> & { inviteUrl: string | null } {
+  const { token, ...rest } = row;
+  return {
+    ...rest,
+    inviteUrl: canManage && row.status === "pending" ? `${appUrl}/invite/${token}` : null,
+  };
+}

--- a/tests/unit/lib/invitations/serialize.test.ts
+++ b/tests/unit/lib/invitations/serialize.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { serializeInvitation, type InvitationRow } from "@/lib/invitations/serialize";
+
+const APP_URL = "https://vardo.example.com";
+
+function row(over: Partial<InvitationRow> = {}): InvitationRow {
+  return {
+    id: "inv-1",
+    email: "someone@example.com",
+    role: "admin",
+    status: "pending",
+    token: "tok-secret-value",
+    createdAt: new Date("2026-08-01T00:00:00Z"),
+    expiresAt: new Date("2026-08-08T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("serializeInvitation", () => {
+  it("drops the token field whoever is asking", () => {
+    for (const canManage of [true, false]) {
+      expect(serializeInvitation(row(), { canManage, appUrl: APP_URL })).not.toHaveProperty("token");
+    }
+  });
+
+  it("leaves a member nothing to reconstruct the link from — the escalation this prevents", () => {
+    // A member reading a pending admin invitation could otherwise accept it.
+    const out = serializeInvitation(row({ role: "admin" }), { canManage: false, appUrl: APP_URL });
+    expect(out.inviteUrl).toBeNull();
+    expect(JSON.stringify(out)).not.toContain("tok-secret-value");
+  });
+
+  it("gives an admin a usable link", () => {
+    const out = serializeInvitation(row(), { canManage: true, appUrl: APP_URL });
+    expect(out.inviteUrl).toBe(`${APP_URL}/invite/tok-secret-value`);
+  });
+
+  it("withholds the link once the invitation is no longer pending", () => {
+    for (const status of ["accepted", "expired", "revoked"]) {
+      const out = serializeInvitation(row({ status }), { canManage: true, appUrl: APP_URL });
+      expect(out.inviteUrl).toBeNull();
+    }
+  });
+
+  it("keeps the fields the list actually renders", () => {
+    const out = serializeInvitation(row(), { canManage: false, appUrl: APP_URL });
+    expect(out).toMatchObject({ id: "inv-1", email: "someone@example.com", role: "admin", status: "pending" });
+  });
+});


### PR DESCRIPTION
`GET /api/v1/organizations/[orgId]/invitations` returned the whole invitation row, `token` included, to any org member.

A member could list pending invitations, read the token on a pending **admin** invitation, and accept it at `/invite/{token}`. Self-service role escalation.

## Why it was reachable

The route gates on `verifyOrgAccess` (any member), which is defensible for a list of who has been invited. The defect is the query:

```ts
const pending = await db.query.invitations.findMany({
  where: ...,
  with: { inviter: { columns: { id: true, name: true, email: true } } },
});
```

The nested `inviter` relation is column-filtered. The top-level select is not, so every column ships — including `token`.

The server-rendered settings page already got this right, with the reasoning in a comment:

> The token is the invite itself, so only admins — who can revoke it — see the link.

It maps explicit fields and gates `inviteUrl` on `isOrgAdmin`. The API route just never mirrored that.

## The fix

`serializeInvitation` in `lib/invitations/serialize.ts` — pure, drops the token, and returns an `inviteUrl` only for an admin looking at a pending invitation. The route selects explicit columns and maps through it.

Kept the member-level gate rather than raising it to admin: the invitations panel renders for non-admins with `inviteUrl: null`, so requiring admin would break their view for no security gain once the token is gone.

## Tests

`tests/unit/lib/invitations/serialize.test.ts` — the token field is dropped for both roles; a member gets no link to a pending admin invitation and nothing in the payload to reconstruct one; an admin does; the link is withheld once the invitation is no longer pending.

`pnpm test` green: typecheck clean, lint 0 errors, 4503 tests across 312 files.

## Not fixed here

Invitations revoked in an earlier session render a blank status badge — the DB writes `revoked`, and the panel's type union and `STATUS_LABELS` only know `pending` / `accepted` / `expired`. Pre-existing and cosmetic.

Found while reviewing #830. Related to #813, which covers the wider question of what a member should be able to do.
