### PR TITLE
style(ui): express panel depth through surfaces instead of borders

### DIFF
--- a/components/app-status.tsx
+++ b/components/app-status.tsx
@@ -233,7 +233,7 @@ export function ChartCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="squircle rounded-lg border bg-card overflow-hidden">
+    <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
       <div className="flex items-center justify-between gap-3 px-4 py-3 border-b">
         <div className="flex items-center gap-2 min-w-0">
           <Icon className="size-4 text-muted-foreground shrink-0" />

--- a/components/compose-review.tsx
+++ b/components/compose-review.tsx
@@ -274,7 +274,7 @@ export function ComposeReview({
 
 function FindingRow({ finding }: { finding: Finding }) {
   return (
-    <div className="flex items-start gap-2 rounded-md border px-3 py-2 text-sm">
+    <div className="flex items-start gap-2 rounded-md bg-background-deep px-3 py-2 text-sm">
       {severityIcon[finding.severity]}
       <div className="min-w-0">
         <p className="text-sm">{finding.message}</p>
@@ -301,7 +301,7 @@ function EnvFindingRow({
 }) {
   return (
     <div
-      className="flex items-start gap-2 rounded-md border px-3 py-2 text-sm cursor-pointer hover:bg-accent/50 transition-colors"
+      className="flex items-start gap-2 rounded-md bg-background-deep px-3 py-2 text-sm cursor-pointer hover:bg-accent/50 transition-colors"
       onClick={selectable ? onToggle : undefined}
     >
       {selectable ? (

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -58,7 +58,9 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+          // The scrim and the shadow define the panel. Dark keeps a hairline
+          // because shadows barely read on a dark ground.
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg dark:border",
           className
         )}
         {...props}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -27,6 +27,15 @@ const badgeVariants = cva(
         info: "border-status-info-edge bg-status-info-muted text-status-info",
         neutral:
           "border-status-neutral-edge bg-status-neutral-muted text-status-neutral",
+        disposable:
+          "border-status-disposable-edge bg-status-disposable-muted text-status-disposable",
+        update:
+          "border-status-update-edge bg-status-update-muted text-status-update",
+        critical:
+          "border-status-critical-edge bg-status-critical-muted text-status-critical",
+
+        // Classification, not health — which environment this belongs to.
+        "env-tier": "border-env-tier-edge bg-env-tier-muted text-env-tier",
       },
     },
     defaultVariants: {

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -63,7 +63,9 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          // The scrim and the shadow define the panel. Dark keeps a hairline
+          // because shadows barely read on a dark ground.
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg p-6 shadow-lg duration-200 outline-none sm:max-w-lg dark:border",
           size === "full" && "sm:max-w-5xl w-[calc(100vw-4rem)] h-[80vh] overflow-hidden",
           className
         )}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -60,15 +60,17 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
+          // The scrim and the shadow define the drawer. Dark keeps a hairline
+          // on the edge facing the page, where shadows barely read.
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 sm:max-w-sm dark:border-l",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 sm:max-w-sm dark:border-r",
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto dark:border-b",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto dark:border-t",
           className
         )}
         {...props}

--- a/components/volumes-panel.tsx
+++ b/components/volumes-panel.tsx
@@ -714,7 +714,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
             {volumes.map((vol) => (
               <div
                 key={`${vol.name}-${vol.mountPath}`}
-                className="squircle rounded-lg border bg-background-deep p-4"
+                className="squircle rounded-lg bg-background-deep p-4"
               >
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex items-center gap-4 min-w-0 flex-1">
@@ -857,7 +857,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
           </div>
 
           {limitEditing ? (
-            <div className="squircle rounded-lg border bg-background-deep p-4 space-y-4">
+            <div className="squircle rounded-lg bg-background-deep p-4 space-y-4">
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="grid gap-2">
                   <Label htmlFor="limit-size">Max Size</Label>
@@ -952,7 +952,7 @@ export function VolumesPanel({ appId, orgId }: Props) {
               </div>
             </div>
           ) : limit ? (
-            <div className="squircle rounded-lg border bg-background-deep p-4 space-y-3">
+            <div className="squircle rounded-lg bg-background-deep p-4 space-y-3">
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
                   <p className="text-sm">


### PR DESCRIPTION
Cleanup pass over `components/ui/**` and the top-level shared components, applying the rule `card.tsx` already states: the surface and its shadow define a panel, and dark keeps a hairline because shadows barely read on a dark ground. Nothing under `app/` is touched. No new tokens, colors, spacing or layout.

## Borders removed (12)

**Card panel → surface + shadow (1)**

- `components/app-status.tsx` — `ChartCard` was `rounded-lg border bg-card`. Now `bg-card shadow-card dark:border`, matching `Card` and the same pattern already used in `app-grid.tsx`. Its `border-b` header rule stays.

**Outlined tray → the ground step alone (3)**

- `components/volumes-panel.tsx` ×3 — `rounded-lg border bg-background-deep` panels sit directly on the page ground, so `--background-deep` is already a visible step up (94.2% → 97.6% light, 16% → 20% dark). The outline was doing the tray's job twice.

**Bordered rows inside a bordered dialog → tray (2)**

- `components/compose-review.tsx` — `FindingRow` and `EnvFindingRow` were `rounded-md border` inside `DialogContent`. Now `bg-background-deep`, which steps above the dialog's `bg-background`. Hover state unchanged.

**Overlay surfaces → scrim + shadow, hairline in dark only (6)**

- `components/ui/dialog.tsx`, `components/ui/alert-dialog.tsx` — both had `border` *and* `shadow-lg` in light mode over a `bg-black/50` scrim. Now `dark:border`.
- `components/ui/sheet.tsx` ×4 — the per-side `border-l` / `border-r` / `border-b` / `border-t` on the drawer's page-facing edge, same reasoning, now `dark:border-*`. `BottomSheetContent` already shipped without a border, so this brings the two drawers into line.

## Badge variants added (4)

`disposable`, `update`, `critical` and `env-tier` — each had a full `-muted`/`-edge`/base token triad and no variant, so call sites had to hand-roll the chip. All four use the existing tokens and the existing edge-carries-the-shape pattern.

## Deliberately left

- **Status-toned panels** — `ui/callout.tsx`, `app-conditions-panel.tsx`, `app-exit-reason.tsx`, and the two warning banners in `env-editor.tsx`. Their `-muted` fill lands within ~1% of the page ground (e.g. warning-muted 95.3% vs background 94.2%), so the hairline is the only thing separating them. Their borders are alpha tints of the stop (`/20`, `/30`, `/40`) rather than the `-edge` token — worth normalizing, but that would strengthen borders, not remove them, so it is out of scope here.
- **Popover-family surfaces** — `popover.tsx`, `dropdown-menu.tsx`, `select.tsx`, and the chart tooltip in `metrics-chart.tsx`. `--popover` is 99.4% against a 100% card; with no scrim behind them the border is the only edge.
- **Terminal panels** — `log-viewer.tsx`, `env-editor.tsx`. In dark mode the terminal ground (14.1%) and the page ground (16%) are nearly the same value, so the border is load-bearing there.
- **`danger-zone.tsx`** — `surface-danger` fills at 5% destructive over card; the destructive border is what reads as the danger zone, and `prefers-contrast: more` promotes it to full `--destructive`.
- **Dividers, header rules, control edges** — `border-t` / `border-b` / `divide-y` between siblings (`app-metrics-card`, `app-row-card`, `keyboard-shortcuts`, `detail-modal`, `discussion-panel`, `entity-comments`, `table`), `border-field-edge` on inputs and selects, the dashed empty-state block, the `kbd` keycaps, and the `app-row.tsx` tree connector.
- **`volumes-panel.tsx` diff box** (`rounded-md border bg-muted/30`) — nested inside a tray it now sits on; `bg-muted/30` resolves to roughly the tray's own value, so removing the border needs a ground change I did not want to guess at.
- **`ui/list-row.tsx` `ListContainer`** (`bg-card/30 ring-1 ring-border/40`) — an outlined container, but it has no call sites anywhere in the repo.

## Testing

`pnpm test` passes — typecheck clean, lint 0 errors, 4503 unit tests.

Not verified visually: the app needs Postgres, Redis and Docker to boot, so every judgement here is from the token values rather than a rendered screenshot. The two worth a look are the dialog and sheet in light mode (borderless over the scrim) and the compose-review finding rows, where `bg-background-deep` replaced an outline inside the dialog.
