### PR TITLE
style(apps): express panel depth with surfaces instead of borders

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-connect.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-connect.tsx
@@ -44,7 +44,7 @@ export function AppConnect({
               ? "Showing variable references — paste these into other apps."
               : "Showing resolved values — toggle to see variable references."}
           </p>
-          <div className="rounded-lg border bg-card divide-y">
+          <div className="rounded-lg bg-card divide-y shadow-card dark:border">
             {connectionInfo.map((info) => {
               const resolved = info.value
                 .replace(/\$\{project\.name\}/g, appName)
@@ -94,7 +94,7 @@ export function AppConnect({
             <p className="text-xs text-muted-foreground">
               Use these to connect from outside Docker (e.g. database tools, local development).
             </p>
-            <div className="rounded-lg border bg-card divide-y">
+            <div className="rounded-lg bg-card divide-y shadow-card dark:border">
               {exposedPorts
                 .filter((p) => p.external)
                 .map((p) => (

--- a/app/(authenticated)/apps/[...slug]/app-cron.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-cron.tsx
@@ -276,7 +276,7 @@ export function CronManager({ appId, orgId }: Props) {
             {jobs.map((job) => (
               <div
                 key={job.id}
-                className="squircle rounded-lg border bg-background-deep p-4"
+                className="squircle rounded-lg bg-background-deep p-4"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0 space-y-1.5">

--- a/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-deploy-panel.tsx
@@ -342,7 +342,7 @@ export function AppDeployPanel({
       : variant === "live"
       ? isLive ? "bg-status-success-muted" : isStopped ? "bg-status-neutral-muted" : isErrored ? "bg-status-error-muted" : "bg-card"
       : variant === "rollback"
-      ? "bg-status-warning-muted border-status-warning-edge"
+      ? "bg-status-warning-muted"
       : ({
           success: "bg-card",
           failed: "bg-status-error-muted",
@@ -373,7 +373,7 @@ export function AppDeployPanel({
         key={deployment.id}
         ref={variant === "live" ? liveCardRef : undefined}
         tabIndex={variant === "live" ? -1 : undefined}
-        className={`squircle rounded-lg border ${bgColor} overflow-hidden`}
+        className={`squircle rounded-lg ${bgColor} shadow-card overflow-hidden dark:border`}
       >
         <div className="flex items-center justify-between gap-4 p-4 cursor-pointer hover:bg-accent/50 transition-colors"
           onClick={() => toggleLog(deployment.id)}
@@ -514,7 +514,7 @@ export function AppDeployPanel({
           <>
             {/* A compose child never deploys on its own — these are all it has. */}
             {lifecycleEvents.length > 0 && (
-              <div className="squircle rounded-lg border py-1">
+              <div className="squircle rounded-lg bg-card py-1 shadow-card dark:border">
                 {lifecycleEvents.map((event) => (
                   <LifecycleLine key={event.id} event={event} />
                 ))}
@@ -603,7 +603,7 @@ export function AppDeployPanel({
                     return (
                       <div
                         key={deployment.id}
-                        className="squircle rounded-lg border bg-status-neutral-muted overflow-hidden"
+                        className="squircle rounded-lg bg-status-neutral-muted shadow-card overflow-hidden dark:border"
                       >
                         <div className="flex items-center justify-between gap-4 p-4">
                           <div className="flex items-center gap-3 min-w-0">
@@ -726,7 +726,7 @@ export function AppDeployPanel({
               <>
                 <div className="space-y-2">
                   <p className="text-sm font-medium">Rolling back to:</p>
-                  <div className="squircle rounded-lg border bg-muted/50 p-3 space-y-1">
+                  <div className="squircle rounded-lg bg-background-deep p-3 space-y-1">
                     <p className="text-sm">{rollbackPreview.gitMessage || "Manual deploy"}</p>
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       {rollbackPreview.gitSha && (
@@ -741,7 +741,7 @@ export function AppDeployPanel({
                 {rollbackPreview.configChanges.length > 0 && (
                   <div className="space-y-2">
                     <p className="text-sm font-medium">Config changes</p>
-                    <div className="squircle rounded-lg border divide-y text-xs">
+                    <div className="squircle rounded-lg bg-background-deep divide-y text-xs">
                       {rollbackPreview.configChanges.map((change) => (
                         <div key={change.field} className="flex items-center justify-between px-3 py-2">
                           <span className="text-muted-foreground">{change.field}</span>
@@ -771,7 +771,7 @@ export function AppDeployPanel({
                       </Label>
                     </div>
                     {rollbackIncludeEnv && rollbackPreview.envKeyChanges && (
-                      <div className="squircle rounded-lg border bg-muted/50 p-3 space-y-2 text-xs">
+                      <div className="squircle rounded-lg bg-background-deep p-3 space-y-2 text-xs">
                         {rollbackPreview.envKeyChanges.added.length > 0 && (
                           <div>
                             <span className="text-status-success font-medium">Added: </span>

--- a/app/(authenticated)/apps/[...slug]/app-networking.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-networking.tsx
@@ -289,7 +289,7 @@ export function AppNetworking({
         </div>
 
         {domainOpen && (
-          <div className="flex items-end gap-3 rounded-lg border bg-background-deep p-4">
+          <div className="flex items-end gap-3 rounded-lg bg-background-deep p-4">
             <div className="grid gap-1.5 flex-1">
               <label className="text-xs text-muted-foreground">Domain</label>
               <input
@@ -375,7 +375,7 @@ export function AppNetworking({
 
                 if (isEditing) {
                   return (
-                    <div key={domain.id} className="flex items-end gap-3 rounded-lg border bg-background-deep p-4">
+                    <div key={domain.id} className="flex items-end gap-3 rounded-lg bg-background-deep p-4">
                       <div className="grid gap-1.5 flex-1">
                         <label className="text-xs text-muted-foreground">Domain</label>
                         <input
@@ -447,7 +447,7 @@ export function AppNetworking({
                 return (
               <div
                 key={domain.id}
-                className={`squircle rounded-lg border bg-background-deep overflow-hidden ${domain.isPrimary ? "border-primary/30" : ""}`}
+                className={`squircle rounded-lg bg-background-deep overflow-hidden ${domain.isPrimary ? "border border-primary/30" : ""}`}
               >
                 <div className="flex items-center justify-between gap-4 p-4">
                   <div className="flex items-center gap-3 min-w-0">
@@ -635,7 +635,7 @@ export function AppNetworking({
                     <div className="space-y-3">
                       <h3 className="text-sm font-medium">Required DNS Record</h3>
                       <p className="text-xs text-muted-foreground">Use one of the following options:</p>
-                      <div className="rounded-lg border bg-muted/30 divide-y">
+                      <div className="rounded-lg bg-background-deep divide-y">
                         <div className="grid grid-cols-3 gap-4 px-4 py-2 text-xs text-muted-foreground">
                           <span>Type</span>
                           <span>Name</span>

--- a/app/(authenticated)/apps/[...slug]/app-security.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-security.tsx
@@ -32,17 +32,17 @@ function severityIcon(severity: SecurityFinding["severity"]) {
 function severityClass(severity: SecurityFinding["severity"]) {
   switch (severity) {
     case "critical":
-      return "border-status-error/20 bg-status-error-muted";
+      return "bg-status-error-muted";
     case "warning":
-      return "border-status-warning/20 bg-status-warning-muted";
+      return "bg-status-warning-muted";
     case "info":
-      return "border-status-info/20 bg-status-info-muted";
+      return "bg-status-info-muted";
   }
 }
 
 function FindingCard({ finding }: { finding: SecurityFinding }) {
   return (
-    <div className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${severityClass(finding.severity)}`}>
+    <div className={`flex items-start gap-3 rounded-lg px-4 py-3 ${severityClass(finding.severity)}`}>
       {severityIcon(finding.severity)}
       <div className="flex-1 min-w-0 space-y-0.5">
         <p className="text-sm font-medium leading-snug">{finding.title}</p>

--- a/app/(authenticated)/apps/[...slug]/app-stability.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-stability.tsx
@@ -125,7 +125,7 @@ export function AppStability({
             Nothing recorded. History starts when Vardo first saw this app, not when the container was built.
           </p>
         ) : (
-          <ul className="mt-3 divide-y rounded-lg border">
+          <ul className="mt-3 divide-y rounded-lg bg-card shadow-card dark:border">
             {incidents.map((incident) => (
               <li
                 key={`${incident.kind}-${incident.at}`}

--- a/app/(authenticated)/apps/[...slug]/app-updates.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-updates.tsx
@@ -216,7 +216,7 @@ export function AppUpdatesPanel({
     return (
       <section
         aria-label="Image updates"
-        className="squircle rounded-lg border bg-card px-4 py-6 text-center"
+        className="squircle rounded-lg bg-card px-4 py-6 text-center shadow-card dark:border"
       >
         {gateSurface && <div className="mb-3 text-left">{gateSurface}</div>}
         <p className="type-body text-muted-foreground">Every image in compose is up to date.</p>
@@ -290,7 +290,7 @@ export function AppUpdatesPanel({
   }
 
   return (
-    <section aria-label="Image updates" className="squircle rounded-lg border bg-card divide-y">
+    <section aria-label="Image updates" className="squircle rounded-lg bg-card divide-y shadow-card dark:border">
       <header className="flex items-center gap-2 px-4 py-2.5">
         <h2 className="type-label text-muted-foreground/60">Image updates</h2>
         <button
@@ -406,7 +406,7 @@ function BlockedDeployNote({
   const label = entry.service ? `${entry.service} (${entry.image})` : entry.image;
 
   return (
-    <div className="squircle flex flex-wrap items-center gap-2 rounded-md border border-status-warning/30 bg-status-warning-muted p-2.5 type-body-sm text-muted-foreground">
+    <div className="squircle flex flex-wrap items-center gap-2 rounded-md bg-status-warning-muted p-2.5 type-body-sm text-muted-foreground">
       <TriangleAlert className="size-3.5 shrink-0 text-status-warning" aria-hidden="true" />
       <span>
         Deploy stopped — {label} moved from major {entry.from} to {entry.to}. {block.appName} is
@@ -432,7 +432,7 @@ function UndeployedNote({
   deploying: boolean;
 }) {
   return (
-    <div className="squircle flex flex-wrap items-center justify-center gap-2 rounded-md border border-status-warning/30 bg-status-warning-muted p-2.5 type-body-sm text-muted-foreground">
+    <div className="squircle flex flex-wrap items-center justify-center gap-2 rounded-md bg-status-warning-muted p-2.5 type-body-sm text-muted-foreground">
       <TriangleAlert className="size-3.5 shrink-0 text-status-warning" aria-hidden="true" />
       <span>
         {count} image{count === 1 ? " is" : "s are"} pinned in compose but not deployed.

--- a/app/(authenticated)/apps/[...slug]/compose-detail.tsx
+++ b/app/(authenticated)/apps/[...slug]/compose-detail.tsx
@@ -29,6 +29,7 @@ import {
 import { toast } from "@/lib/messenger";
 import { PageToolbar } from "@/components/page-toolbar";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import {
@@ -447,9 +448,9 @@ function PerService({
 
   if (!selected) {
     return (
-      <div className="squircle lining flex flex-col items-center justify-center gap-4 rounded-lg border bg-card p-12">
+      <Card className="squircle lining items-center justify-center rounded-lg p-12">
         <p className="text-sm text-muted-foreground">{emptyMessage}</p>
-      </div>
+      </Card>
     );
   }
 
@@ -509,7 +510,7 @@ function ComposeNetworking({
               <Link
                 key={`${service.id}-${domain}`}
                 href={`/apps/${service.name}/networking`}
-                className="squircle flex items-center justify-between gap-4 rounded-lg border bg-background-deep p-4 transition-colors hover:bg-accent"
+                className="squircle flex items-center justify-between gap-4 rounded-lg bg-background-deep p-4 transition-colors hover:bg-accent"
               >
                 <span className="truncate font-mono text-sm font-medium">{domain}</span>
                 <span className="shrink-0 text-xs text-muted-foreground">
@@ -559,7 +560,7 @@ function ComposeSecurity({
               <Link
                 key={service.id}
                 href={`/apps/${service.name}/security`}
-                className="squircle flex items-center justify-between gap-4 rounded-lg border bg-background-deep p-4 transition-colors hover:bg-accent"
+                className="squircle flex items-center justify-between gap-4 rounded-lg bg-background-deep p-4 transition-colors hover:bg-accent"
               >
                 <span className="truncate text-sm font-medium">{service.displayName}</span>
                 <span className="shrink-0 font-mono text-xs text-muted-foreground">
@@ -1245,7 +1246,7 @@ export function ComposeDetail({
 
         <TabsContent value="services">
           {services.length === 0 ? (
-            <div className="squircle lining flex flex-col items-center justify-center gap-4 rounded-lg border bg-card p-12">
+            <Card className="squircle lining items-center justify-center rounded-lg p-12">
               <Container className="size-8 text-muted-foreground/50" />
               <div className="text-center space-y-1">
                 <p className="text-sm font-medium">No services</p>
@@ -1253,7 +1254,7 @@ export function ComposeDetail({
                   Deploy the stack to see its services here.
                 </p>
               </div>
-            </div>
+            </Card>
           ) : (
             <ComposeServices appId={app.id} services={services} orgId={orgId} />
           )}

--- a/app/(authenticated)/apps/[...slug]/in-progress-deploy-card.tsx
+++ b/app/(authenticated)/apps/[...slug]/in-progress-deploy-card.tsx
@@ -71,7 +71,7 @@ export function InProgressDeployCard({
         : "";
 
   return (
-    <div className="squircle rounded-lg border bg-status-info-muted overflow-hidden">
+    <div className="squircle rounded-lg bg-status-info-muted shadow-card overflow-hidden dark:border">
       <span className="sr-only" aria-live="assertive" aria-atomic="true">{liveAnnouncement}</span>
       <div
         role="button"

--- a/app/(authenticated)/apps/[...slug]/loading.tsx
+++ b/app/(authenticated)/apps/[...slug]/loading.tsx
@@ -30,7 +30,7 @@ export default function AppDetailLoading() {
       {/* Content area: deployment list placeholder */}
       <div className="space-y-3">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 rounded-lg border bg-card px-4 py-3">
+          <div key={i} className="flex items-center gap-4 rounded-lg bg-card px-4 py-3 shadow-card dark:border">
             <div className="h-4 w-4 bg-muted animate-pulse rounded-full shrink-0" />
             <div className="flex-1 space-y-1.5">
               <div className="h-4 w-64 bg-muted animate-pulse rounded-md" />

--- a/app/(authenticated)/apps/[...slug]/ports-manager.tsx
+++ b/app/(authenticated)/apps/[...slug]/ports-manager.tsx
@@ -84,7 +84,7 @@ export function PortsManager({
       </div>
 
       {adding && (
-        <div className="flex items-end gap-3 rounded-lg border bg-card p-4">
+        <div className="flex items-end gap-3 rounded-lg bg-background-deep p-4">
           <div className="grid gap-1.5">
             <label htmlFor="port-container" className="text-xs text-muted-foreground">Container Port</label>
             <input
@@ -134,7 +134,7 @@ export function PortsManager({
           body="Container ports are reachable inside the Docker network by default. Expose one to reach this service directly."
         />
       ) : ports.length > 0 && (
-        <div className="divide-y rounded-lg border">
+        <div className="divide-y rounded-lg bg-background-deep">
           {ports.map((port, i) => (
             <div key={i} className="flex items-center justify-between gap-4 px-4 py-3">
               <div className="flex items-center gap-4">

--- a/lib/ui/tab-panel.ts
+++ b/lib/ui/tab-panel.ts
@@ -1,2 +1,2 @@
 /** Surface for app detail tab panels whose content doesn't bring its own card. */
-export const tabPanelSurface = "squircle rounded-lg border bg-card p-4 sm:p-6";
+export const tabPanelSurface = "squircle rounded-lg bg-card p-4 sm:p-6 shadow-card dark:border";


### PR DESCRIPTION
Border cleanup across `app/(authenticated)/apps/**`. Panels that were `rounded-lg border bg-card` now express depth the way `components/ui/card.tsx` already states it — the surface and its shadow define the panel, dark keeps a hairline. Boxes nested inside a panel step down to `bg-background-deep` rather than drawing a second outline.

No new tokens, colors, spacing or layout.

## What changed

**`lib/ui/tab-panel.ts`** — `tabPanelSurface` is now `squircle rounded-lg bg-card p-4 sm:p-6 shadow-card dark:border`. One edit covers 26 tab panels across app detail and compose detail. It is also used by the project detail page, which picks up the same treatment.

**Panels → `bg-card` + `shadow-card` + `dark:border`** — connection info lists, image updates section and its empty state, stability history, deploy/queued/in-progress/lifecycle cards, compose service empty states, loading skeleton rows.

**Nested boxes → `bg-background-deep`, border dropped** — cron job rows, domain add/edit forms, ports add form and list, DNS record table, rollback preview boxes, compose service domain and scan links.

**Status surfaces → fill only** — security finding cards and the blocked/undeployed update notes dropped their `/20`–`/30` outlines. Their `-muted` fills are opaque and already clear the card and page grounds in both themes, matching the banners at the top of the app detail page.

**Two hand-built cards became `<Card>`** — the compose "no services" and per-service empty states.

## Kept

Dividers inside containers (`border-t`, `divide-y`), input and control edges, table header rules, dashed borders on empty and collecting states, and the `border-primary/30` marker on the primary domain row — that one previously had no width of its own, so it now sets `border` explicitly and is the only bordered row in the list.

## Left alone

- `app-terminal.tsx`, `app-debug.tsx`, the compose editor and the cron log `<pre>` — out of scope for this pass.
- `app-metrics.tsx` container tables. Same `border bg-card` pattern, but they sit beside `ChartCard` in `components/app-status.tsx`, which is out of scope. Changing one without the other would split the metrics tab.
- `lib/ui/error-rate.ts` and `lib/ui/stability.ts` verdict surfaces. Their fills are `-muted/40`, so the border is the only thing making the band; tests also assert the `border-` prefix.
- The service tooltip in compose detail. It is a floating layer, not a panel.
- `apps/new/new-app-flow.tsx`. Source and template picker tiles, a separate call from the detail panels.

## Testing

`pnpm test` — typecheck, lint (0 errors) and 4503 unit tests pass. Not verified visually; the shadow weight on the deploy history list and the loss of the `border-status-warning-edge` outline on the standby rollback card are the two worth a look in the browser.
