### PR TITLE
style: express depth with surfaces instead of borders on settings and admin

### DIFF
--- a/app/(authenticated)/admin/[[...slug]]/loading.tsx
+++ b/app/(authenticated)/admin/[[...slug]]/loading.tsx
@@ -20,7 +20,7 @@ export default function AdminLoading() {
       {/* Overview cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 pt-2">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-xl border bg-card p-4 space-y-2">
+          <div key={i} className="rounded-xl bg-card p-4 space-y-2 shadow-card dark:border">
             <div className="h-3 w-20 bg-muted animate-pulse rounded-md" />
             <div className="h-8 w-16 bg-muted animate-pulse rounded-md" />
           </div>
@@ -28,7 +28,7 @@ export default function AdminLoading() {
       </div>
 
       {/* Table area */}
-      <div className="rounded-xl border overflow-hidden">
+      <div className="rounded-xl bg-card overflow-hidden shadow-card dark:border">
         <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
           {[120, 160, 100, 80].map((w, i) => (
             <div key={i} className="h-3 bg-muted animate-pulse rounded-md" style={{ width: `${w}px` }} />

--- a/app/(authenticated)/admin/admin-actions.tsx
+++ b/app/(authenticated)/admin/admin-actions.tsx
@@ -90,7 +90,7 @@ export function UserManagement() {
       </div>
 
       {/* Invite form */}
-      <div className="rounded-lg border bg-card p-4 space-y-4">
+      <div className="rounded-lg bg-card p-4 space-y-4 shadow-card dark:border">
         <div className="flex items-center gap-2">
           <UserPlus className="size-4 text-muted-foreground" />
           <p className="text-sm font-medium">Invite User</p>
@@ -149,7 +149,7 @@ export function UserManagement() {
           {users.map((u) => (
             <div
               key={u.id}
-              className="flex items-center justify-between rounded-lg border bg-card p-3"
+              className="flex items-center justify-between rounded-lg bg-card p-3 shadow-card dark:border"
             >
               <div className="flex items-center gap-3 min-w-0">
                 {u.isAppAdmin ? (

--- a/app/(authenticated)/admin/admin-organizations.tsx
+++ b/app/(authenticated)/admin/admin-organizations.tsx
@@ -78,7 +78,7 @@ export function AdminOrganizations() {
   }
 
   return (
-    <div className="squircle rounded-lg border bg-card overflow-x-auto">
+    <div className="squircle rounded-lg bg-card overflow-x-auto shadow-card dark:border">
       <div className="grid grid-cols-[1fr_70px_70px_70px_90px_100px_80px_80px] gap-3 px-4 py-2 border-b text-xs text-muted-foreground whitespace-nowrap min-w-[800px]">
         <span>Organization</span>
         <span className="text-right">Members</span>

--- a/app/(authenticated)/admin/admin-overview.tsx
+++ b/app/(authenticated)/admin/admin-overview.tsx
@@ -65,7 +65,7 @@ export function AdminOverview() {
             ? sparklines[stat.sparklineKey]?.map(([, v]) => v)
             : null;
           return (
-            <div key={stat.label} className="squircle relative rounded-lg border bg-card p-4 overflow-hidden">
+            <div key={stat.label} className="squircle relative rounded-lg bg-card p-4 overflow-hidden shadow-card dark:border">
               {sparklineData && sparklineData.length > 0 && (
                 <Sparkline
                   data={sparklineData}
@@ -91,7 +91,7 @@ export function AdminOverview() {
       <div className="grid gap-4 sm:grid-cols-3 mt-4">
         {resources ? (
           resources.map((res) => (
-            <div key={res.name} className="squircle rounded-lg border bg-card p-4">
+            <div key={res.name} className="squircle rounded-lg bg-card p-4 shadow-card dark:border">
               <div className="flex items-center justify-between mb-2">
                 <p className="text-xs text-muted-foreground">{res.name}</p>
                 <span className={`text-xs font-medium ${
@@ -118,7 +118,7 @@ export function AdminOverview() {
         ) : (
           // Skeleton cards
           ["CPU", "Memory", "Disk"].map((name) => (
-            <div key={name} className="squircle rounded-lg border bg-card p-4">
+            <div key={name} className="squircle rounded-lg bg-card p-4 shadow-card dark:border">
               <p className="text-xs text-muted-foreground mb-2">{name}</p>
               <div className="h-1.5 rounded-full bg-muted" />
               <div className="h-3 w-24 bg-muted rounded mt-2" />

--- a/app/(authenticated)/admin/settings/auth-settings.tsx
+++ b/app/(authenticated)/admin/settings/auth-settings.tsx
@@ -231,7 +231,7 @@ function SignInMethods() {
           <span className="sr-only">Loading sign-in methods</span>
         </div>
       ) : (
-        <div className="squircle divide-y rounded-lg border">
+        <div className="squircle divide-y rounded-lg bg-card shadow-card dark:border">
           {methods.map((m) => (
             <div key={m.method} className="flex items-start justify-between gap-4 p-4">
               <div className="space-y-1">

--- a/app/(authenticated)/admin/settings/core-services-settings.tsx
+++ b/app/(authenticated)/admin/settings/core-services-settings.tsx
@@ -143,7 +143,7 @@ export function CoreServicesSettings() {
         </p>
       </div>
 
-      <div className="squircle divide-y rounded-lg border">
+      <div className="squircle divide-y rounded-lg bg-card shadow-card dark:border">
         {services.map((service) => (
           <div key={service.name} className="flex items-start justify-between gap-4 p-4">
             <div className="space-y-1">

--- a/app/(authenticated)/admin/settings/feature-flags-settings.tsx
+++ b/app/(authenticated)/admin/settings/feature-flags-settings.tsx
@@ -145,7 +145,7 @@ export function FeatureFlagsSettings() {
               <p className="text-xs text-muted-foreground">{group.description}</p>
             </div>
 
-            <div className="squircle divide-y rounded-lg border">
+            <div className="squircle divide-y rounded-lg bg-card shadow-card dark:border">
               {groupFlags.map((f) => (
                 <div key={f.flag} className="flex items-start justify-between gap-4 p-4">
                   <div className="space-y-1">

--- a/app/(authenticated)/admin/settings/maintenance-settings.tsx
+++ b/app/(authenticated)/admin/settings/maintenance-settings.tsx
@@ -764,7 +764,7 @@ export function MaintenanceSettings() {
                   — an upper bound, since images share layers.
                 </span>
               </p>
-              <ul className="divide-y rounded-md border">
+              <ul className="divide-y rounded-md bg-background-deep">
                 {images.plan.candidates.map((c) => (
                   <li key={c.appId} className="flex items-start justify-between gap-4 px-3 py-2">
                     <div className="min-w-0 space-y-0.5">
@@ -808,7 +808,7 @@ export function MaintenanceSettings() {
           )}
 
           {images?.slotPlan && images.slotPlan.candidates.length > 0 && (
-            <div className="space-y-2 rounded-md border p-3">
+            <div className="space-y-2 rounded-md bg-background-deep p-3">
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
                   <p className="text-sm font-medium">Old slot generations</p>
@@ -828,7 +828,7 @@ export function MaintenanceSettings() {
                   {includeSlots ? "Included" : "Include"}
                 </Button>
               </div>
-              <ul className="divide-y rounded-md border">
+              <ul className="divide-y rounded-md bg-muted">
                 {images.slotPlan.candidates.map((c) => (
                   <li key={c.project} className="flex items-start justify-between gap-4 px-3 py-2">
                     <div className="min-w-0 space-y-0.5">
@@ -975,7 +975,7 @@ export function MaintenanceSettings() {
                   <p id="owner-gaps" className="text-xs font-medium">
                     Without an owner
                   </p>
-                  <ul aria-labelledby="owner-gaps" className="divide-y rounded-md border">
+                  <ul aria-labelledby="owner-gaps" className="divide-y rounded-md bg-background-deep">
                     {owners.gaps.map((g) => (
                       <li key={g.dir} className="px-3 py-2 space-y-0.5">
                         <p className="text-sm font-medium">{g.appName}</p>

--- a/app/(authenticated)/settings/invitations.tsx
+++ b/app/(authenticated)/settings/invitations.tsx
@@ -260,7 +260,7 @@ export function InvitationsPanel({
             }
           />
         ) : (
-          <div className="divide-y rounded-lg border">
+          <div className="divide-y rounded-lg bg-background-deep">
             {invitations.map((invitation) => {
               const isPending = invitation.status === "pending";
               const isAccepted = invitation.status === "accepted";

--- a/app/(authenticated)/settings/loading.tsx
+++ b/app/(authenticated)/settings/loading.tsx
@@ -21,7 +21,7 @@ export default function SettingsLoading() {
       {/* Tab content: key-value rows */}
       <div className="space-y-3 pt-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex items-center justify-between gap-4 rounded-lg border bg-card px-4 py-3">
+          <div key={i} className="flex items-center justify-between gap-4 rounded-lg bg-card px-4 py-3 shadow-card dark:border">
             <div className="space-y-1">
               <div className="h-4 w-32 bg-muted animate-pulse rounded-md" />
               <div className="h-3 w-48 bg-muted animate-pulse rounded-md" />

--- a/app/(authenticated)/settings/notification-channels.tsx
+++ b/app/(authenticated)/settings/notification-channels.tsx
@@ -97,7 +97,7 @@ function EventFilterEditor({
       </button>
 
       {expanded && (
-        <div className="border border-border rounded-lg p-3 space-y-3 bg-muted/30">
+        <div className="rounded-lg bg-muted p-3 space-y-3">
           <p className="text-xs text-muted-foreground">
             Select which events this channel receives. Leave all checked to receive everything.
           </p>
@@ -196,7 +196,7 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
         {!showForm && <Button size="sm" onClick={() => setShowForm(true)} className="squircle"><Plus className="h-4 w-4 mr-1" />Add channel</Button>}
       </div>
       {showForm && (
-        <div className="border border-border rounded-lg p-4 space-y-4 bg-card">
+        <div className="rounded-lg bg-background-deep p-4 space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2"><Label>Name</Label><Input value={name} onChange={e => setName(e.target.value)} placeholder="e.g. Team alerts" className="squircle" /></div>
             <div className="space-y-2"><Label>Type</Label><Select value={type} onValueChange={v => setType(v as ChannelType)}><SelectTrigger className="squircle"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="email">Email</SelectItem><SelectItem value="webhook">Webhook</SelectItem><SelectItem value="slack">Slack</SelectItem></SelectContent></Select></div>
@@ -221,7 +221,7 @@ export function NotificationChannelsEditor({ orgId }: { orgId: string }) {
         />
       ) : (
         <div className="space-y-2">{channels.map(ch => (
-          <div key={ch.id} className="border border-border rounded-lg p-3 bg-card space-y-2">
+          <div key={ch.id} className="rounded-lg bg-background-deep p-3 space-y-2">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3 min-w-0"><Switch checked={ch.enabled} onCheckedChange={checked => handleToggle(ch.id, checked)} /><div className="min-w-0"><div className="flex items-center gap-2"><span className="text-sm font-medium truncate">{ch.name}</span><span className="text-xs bg-muted px-1.5 py-0.5 rounded">{ch.type}</span></div></div></div>
               <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground hover:text-destructive" onClick={() => handleDelete(ch.id)}><Trash2 className="h-4 w-4" /></Button>

--- a/app/(authenticated)/settings/org-domain-editor.tsx
+++ b/app/(authenticated)/settings/org-domain-editor.tsx
@@ -215,7 +215,7 @@ export function OrgDomainEditor({
 
       {/* Default app domain */}
       {defaultDomainEntry && (
-        <div className="squircle rounded-lg border bg-card p-4">
+        <div className="squircle rounded-lg bg-background-deep p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3 min-w-0">
               <Globe className="size-4 text-muted-foreground shrink-0" />
@@ -251,7 +251,7 @@ export function OrgDomainEditor({
           {customDomains.map((domain) => (
             <div
               key={domain.id}
-              className="squircle rounded-lg border bg-card p-4"
+              className="squircle rounded-lg bg-background-deep p-4"
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3 min-w-0">

--- a/app/(authenticated)/settings/system-alerts.tsx
+++ b/app/(authenticated)/settings/system-alerts.tsx
@@ -182,7 +182,7 @@ export function SystemAlertsPanel() {
           <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             Services
           </h4>
-          <div className="rounded-lg border divide-y">
+          <div className="rounded-lg bg-card divide-y shadow-card dark:border">
             {healthData.services.map((service) => (
               <div
                 key={service.name}
@@ -222,7 +222,7 @@ export function SystemAlertsPanel() {
           <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             Resources
           </h4>
-          <div className="rounded-lg border divide-y">
+          <div className="rounded-lg bg-card divide-y shadow-card dark:border">
             {healthData.resources.map((resource) => (
               <div
                 key={resource.name}
@@ -270,12 +270,12 @@ export function SystemAlertsPanel() {
           </h4>
 
           {alertsData.active.length === 0 ? (
-            <div className="rounded-lg border px-4 py-6 text-center">
+            <div className="rounded-lg bg-card px-4 py-6 text-center shadow-card dark:border">
               <CheckCircle className="h-6 w-6 text-status-success mx-auto mb-2" />
               <p className="text-sm text-muted-foreground">No active alerts</p>
             </div>
           ) : (
-            <div className="rounded-lg border divide-y">
+            <div className="rounded-lg bg-card divide-y shadow-card dark:border">
               {alertsData.active.map((alert) => (
                 <div key={`${alert.type}:${alert.key}`} className="flex items-center justify-between px-4 py-3">
                   <div className="flex items-center gap-2.5">
@@ -310,7 +310,7 @@ export function SystemAlertsPanel() {
           <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
             Recent Alert History
           </h4>
-          <div className="rounded-lg border divide-y">
+          <div className="rounded-lg bg-card divide-y shadow-card dark:border">
             {alertsData.history.slice(0, 10).map((alert) => (
               <div
                 key={`${alert.type}:${alert.key}`}

--- a/app/(authenticated)/user/settings/[tab]/page.tsx
+++ b/app/(authenticated)/user/settings/[tab]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { getCurrentOrg } from "@/lib/auth/session";
 import { isFeatureEnabledAsync } from "@/lib/config/features";
 import { getAuthMethodStates } from "@/lib/config/auth-methods";
+import { Card, CardContent } from "@/components/ui/card";
 import {
   AccountInfo,
   PasswordManagement,
@@ -101,12 +102,14 @@ function TabContent({
             </p>
           </div>
           {!orgId ? (
-            <div className="rounded-xl border bg-card p-6 text-center">
-              <p className="text-sm text-muted-foreground">
-                No organization selected. Create or join an organization to manage
-                API tokens.
-              </p>
-            </div>
+            <Card className="squircle rounded-lg">
+              <CardContent className="text-center">
+                <p className="text-sm text-muted-foreground">
+                  No organization selected. Create or join an organization to manage
+                  API tokens.
+                </p>
+              </CardContent>
+            </Card>
           ) : (
             <ApiTokens orgId={orgId} />
           )}
@@ -135,12 +138,14 @@ function TabContent({
             </p>
           </div>
           {!orgId ? (
-            <div className="rounded-xl border bg-card p-6 text-center">
-              <p className="text-sm text-muted-foreground">
-                No organization selected. Create or join an organization to
-                configure notification preferences.
-              </p>
-            </div>
+            <Card className="squircle rounded-lg">
+              <CardContent className="text-center">
+                <p className="text-sm text-muted-foreground">
+                  No organization selected. Create or join an organization to
+                  configure notification preferences.
+                </p>
+              </CardContent>
+            </Card>
           ) : (
             <UserNotificationPreferences orgId={orgId} />
           )}

--- a/app/(authenticated)/user/settings/account-settings.tsx
+++ b/app/(authenticated)/user/settings/account-settings.tsx
@@ -558,7 +558,7 @@ export function PasskeyManager() {
             {passkeys.map((pk) => (
               <div
                 key={pk.id}
-                className="flex items-center justify-between rounded-lg border p-3"
+                className="flex items-center justify-between rounded-lg bg-background-deep p-3"
               >
                 <div className="flex items-center gap-3 min-w-0">
                   <KeyRound className="size-4 shrink-0 text-muted-foreground" />
@@ -678,7 +678,7 @@ export function LinkedAccounts() {
               return (
                 <div
                   key={acct.id}
-                  className="flex items-center justify-between rounded-lg border p-3"
+                  className="flex items-center justify-between rounded-lg bg-background-deep p-3"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <Icon className="size-4 shrink-0 text-muted-foreground" />
@@ -793,7 +793,7 @@ export function ActiveSessions() {
               return (
                 <div
                   key={s.id}
-                  className="flex items-center justify-between rounded-lg border p-3"
+                  className="flex items-center justify-between rounded-lg bg-background-deep p-3"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <Monitor className="size-4 shrink-0 text-muted-foreground" />
@@ -1049,7 +1049,7 @@ export function ApiTokens({ orgId }: { orgId: string }) {
             {tokens.map((token) => (
               <div
                 key={token.id}
-                className="flex items-center justify-between rounded-lg border p-3"
+                className="flex items-center justify-between rounded-lg bg-background-deep p-3"
               >
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">{token.name}</p>

--- a/app/(authenticated)/user/settings/github-connection.tsx
+++ b/app/(authenticated)/user/settings/github-connection.tsx
@@ -154,7 +154,7 @@ export function GitHubConnection() {
           {installations.map((installation) => (
             <div
               key={installation.id}
-              className="flex items-center gap-3 rounded-lg border p-3"
+              className="flex items-center gap-3 rounded-lg bg-background-deep p-3"
             >
               {installation.accountAvatarUrl ? (
                 <img

--- a/app/(authenticated)/user/settings/loading.tsx
+++ b/app/(authenticated)/user/settings/loading.tsx
@@ -15,7 +15,7 @@ export default function UserSettingsLoading() {
       </div>
 
       {/* Content card */}
-      <div className="rounded-xl border bg-card p-6 space-y-4">
+      <div className="rounded-xl bg-card p-6 space-y-4 shadow-card dark:border">
         <div className="h-5 w-36 bg-muted animate-pulse rounded-md" />
         <div className="space-y-3">
           {Array.from({ length: 3 }).map((_, i) => (

--- a/components/mesh/project-instances.tsx
+++ b/components/mesh/project-instances.tsx
@@ -255,7 +255,7 @@ export function ProjectInstances({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border overflow-x-auto">
+      <div className="rounded-lg bg-card overflow-x-auto shadow-card dark:border">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b">

--- a/components/ssl/domain-settings.tsx
+++ b/components/ssl/domain-settings.tsx
@@ -306,7 +306,7 @@ export function DomainSettings() {
                   const isFirst = activeIssuers[0] === issuer;
 
                   return (
-                    <div key={issuer} className="squircle rounded-lg border bg-card p-4">
+                    <div key={issuer} className="squircle rounded-lg bg-background-deep p-4">
                       <div className="flex items-start justify-between gap-4">
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-2">
@@ -336,7 +336,7 @@ export function DomainSettings() {
                       </div>
 
                       {issuer === "zerossl" && isEnabled && (
-                        <div className="mt-4 space-y-3 rounded-md border bg-muted/30 p-3">
+                        <div className="mt-4 space-y-3 rounded-md bg-muted p-3">
                           <p className="text-xs font-medium">
                             ZeroSSL requires External Account Binding (EAB) credentials.{" "}
                             <a
@@ -428,7 +428,7 @@ export function DomainSettings() {
               </div>
 
               {challengeType === "dns" && (
-                <div className="max-w-md space-y-4 rounded-lg border bg-muted/30 p-4">
+                <div className="max-w-md space-y-4 rounded-lg bg-background-deep p-4">
                   <div className="space-y-2">
                     <Label htmlFor="dns-provider">DNS provider</Label>
                     <Select value={dnsProvider} disabled>

--- a/components/ssl/external-routes-settings.tsx
+++ b/components/ssl/external-routes-settings.tsx
@@ -490,7 +490,7 @@ function RouteFormFields({ form, onChange, error }: RouteFormFieldsProps) {
         </p>
       </div>
 
-      <div className="flex items-center justify-between rounded-lg border p-3">
+      <div className="flex items-center justify-between rounded-lg bg-background-deep p-3">
         <div className="space-y-0.5">
           <Label htmlFor="tls" className="text-sm font-normal">
             Enable TLS
@@ -508,7 +508,7 @@ function RouteFormFields({ form, onChange, error }: RouteFormFieldsProps) {
       </div>
 
       {!isRedirect && (
-        <div className="flex items-center justify-between rounded-lg border p-3">
+        <div className="flex items-center justify-between rounded-lg bg-background-deep p-3">
           <div className="space-y-0.5">
             <Label htmlFor="insecureSkipVerify" className="text-sm font-normal">
               Skip TLS verification
@@ -529,7 +529,7 @@ function RouteFormFields({ form, onChange, error }: RouteFormFieldsProps) {
       )}
 
       {isRedirect && (
-        <div className="flex items-center justify-between rounded-lg border p-3">
+        <div className="flex items-center justify-between rounded-lg bg-background-deep p-3">
           <div className="space-y-0.5">
             <Label htmlFor="redirectPermanent" className="text-sm font-normal">
               Permanent redirect

--- a/components/ssl/traefik-settings.tsx
+++ b/components/ssl/traefik-settings.tsx
@@ -87,7 +87,7 @@ export function TraefikSettings() {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="flex items-center justify-between rounded-lg border p-4">
+        <div className="flex items-center justify-between rounded-lg bg-card p-4 shadow-card dark:border">
           <div className="space-y-0.5">
             <Label htmlFor="external-routing" className="text-sm font-medium">
               Route to external containers
@@ -115,7 +115,7 @@ export function TraefikSettings() {
       </form>
 
       {restartPending && (
-        <div className="rounded-lg border p-4 flex items-center justify-between gap-4">
+        <div className="rounded-lg bg-card p-4 flex items-center justify-between gap-4 shadow-card dark:border">
           <div className="space-y-0.5">
             <p className="text-sm font-medium">Traefik restart required to apply changes</p>
             <p className="text-xs text-muted-foreground">
@@ -137,7 +137,7 @@ export function TraefikSettings() {
       )}
 
       {restarted && (
-        <div className="rounded-lg border p-4">
+        <div className="rounded-lg bg-card p-4 shadow-card dark:border">
           <p className="text-sm font-medium">Traefik restart initiated</p>
           <p className="text-xs text-muted-foreground">
             The container is restarting and will be back up momentarily.
@@ -146,7 +146,7 @@ export function TraefikSettings() {
       )}
 
       {config.externalRouting && (
-        <div className="rounded-lg border p-4 space-y-3">
+        <div className="rounded-lg bg-card p-4 space-y-3 shadow-card dark:border">
           <div className="space-y-0.5">
             <p className="text-sm font-medium">Making external containers reachable</p>
             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Removes border overuse from the settings, admin, SSL, notification and mesh screens and lets the surface ladder carry depth instead. Cleanup of the existing style — no new tokens, colors, spacing or layout.

`components/ui/card.tsx` already states the rule: *"Layers over borders — the surface and its shadow define the card. Dark keeps a hairline because shadows barely read on a dark ground."* Hand-built panels weren't following it.

## What changed

**46 borders removed across 21 files**, in four classes:

| Was | Now | Count |
|---|---|---|
| Panel on the page ground — `rounded-* border [bg-card]` | `bg-card` + `shadow-card` + `dark:border` | 23 |
| Box nested inside a card or dialog | `bg-background-deep` (tray, no outline) | 18 |
| Box nested one level below a tray | `bg-muted` (opaque, no outline) | 3 |
| Hand-built panel reproducing Card's classes | the `Card` component | 2 |

The ladder used is the one already in `app/styles/tokens.css`: `--background` → `--background-deep` → `--card` → `--popover`, plus `--muted` one step under the tray. No element carries a border and `shadow-card` together in light mode, and no bordered panel sits inside another.

## Borders kept

`dark:border` on cards; `divide-y` and `border-t` dividers inside containers; the `border-b` under tab bars and table headers; table row rules; `surface-terminal` and popover edges; dashed empty states and dropzones; and both `surface-danger` blocks.

## Destructive zones

Left untouched. `settings/system-alerts.tsx` and `components/notifications/settings.tsx` both use `.surface-danger`, which sets its own tinted background and a `--border` derived from `--destructive` — the outline there is a warning, not decoration, and it never pairs with `shadow-card`.

## Deliberately left

- **Status callouts** — `account-settings.tsx` and `admin-actions.tsx` use `border-status-success/30` with `bg-status-success-muted`. The codebase is split between bordered and borderless status callouts, and this is close enough to the `-edge` family that removing it is a guess.
- **Dashed borders** — empty states, loading placeholders and the config dropzone. Dashed signals a different thing than the outlined-box overuse this targets.
- **`instances-settings.tsx:304`** — `<Card className="squircle rounded-lg border-dashed">`. `border-dashed` sets style without width, so it does nothing in light mode and only dashes Card's `dark:border`. Latent, but fixing it changes appearance.
- **`org-domain-editor.tsx:359`** — dashed DNS instructions callout in a bottom sheet.
- **`digest-settings.tsx:150`** — `border-l` indent guide under the digest toggle, doing the same job as a divider.

## Not verified

Rendered appearance. Every change is a class swap on existing tokens, checked against the light and dark values in `tokens.css`, but nothing was viewed in a browser — worth a pass over the settings and admin screens in both themes, particularly the three-level nesting in `notification-channels.tsx` and `ssl/domain-settings.tsx` where `bg-muted` inverts direction between themes (darker than the tray in light, lighter in dark).

## Test plan

`pnpm test` — typecheck clean, lint 0 errors, 4503 tests passing.
