### PR TITLE
style(ui): express depth with surfaces instead of borders

### DIFF
--- a/app/(authenticated)/activity/activity-feed.tsx
+++ b/app/(authenticated)/activity/activity-feed.tsx
@@ -76,7 +76,7 @@ function WindowHeader({
   const withoutWindow = filtersToQuery({ ...filters, since: null });
 
   return (
-    <div className="squircle rounded-lg border border-border bg-muted/40 px-4 py-3">
+    <div className="squircle rounded-lg bg-card px-4 py-3 shadow-card dark:border">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
         <h2 className="text-sm font-medium">
           While you were away

--- a/app/(authenticated)/activity/activity-row.tsx
+++ b/app/(authenticated)/activity/activity-row.tsx
@@ -111,7 +111,7 @@ export function ActivityRow({ group }: { group: ActivityGroup }) {
         </p>
 
         {failed && group.error && (
-          <p className="squircle rounded border border-status-error/20 bg-background/60 px-2 py-1 font-mono text-xs text-status-error">
+          <p className="squircle rounded bg-background-deep px-2 py-1 font-mono text-xs text-status-error">
             <span className="line-clamp-2 break-words">{group.error}</span>
           </p>
         )}

--- a/app/(authenticated)/backups/loading.tsx
+++ b/app/(authenticated)/backups/loading.tsx
@@ -8,7 +8,7 @@ export default function BackupsLoading() {
       </div>
 
       {/* Table skeleton */}
-      <div className="rounded-xl border overflow-hidden">
+      <div className="rounded-xl bg-card shadow-card dark:border overflow-hidden">
         {/* Table header */}
         <div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-3">
           {[100, 80, 120, 80, 60].map((w, i) => (

--- a/app/(authenticated)/discover/compose-group-card.tsx
+++ b/app/(authenticated)/discover/compose-group-card.tsx
@@ -17,7 +17,7 @@ export function ComposeGroupCard({
   onImport,
 }: ComposeGroupCardProps) {
   return (
-    <div className="squircle border bg-card/50 p-4 space-y-3">
+    <div className="squircle bg-card p-4 space-y-3 shadow-card dark:border">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="font-medium text-sm">{composeProject}</span>
@@ -40,6 +40,7 @@ export function ComposeGroupCard({
           <ContainerCard
             key={container.id}
             container={container}
+            nested
           />
         ))}
       </div>

--- a/app/(authenticated)/discover/container-card.tsx
+++ b/app/(authenticated)/discover/container-card.tsx
@@ -9,11 +9,17 @@ import { containerStateVariant } from "@/lib/ui/container-state";
 type ContainerCardProps = {
   container: DiscoveredContainer;
   onImport?: (container: DiscoveredContainer) => void;
+  /** Inside a compose group card: sits on the tray ground instead of lifting. */
+  nested?: boolean;
 };
 
-export function ContainerCard({ container, onImport }: ContainerCardProps) {
+export function ContainerCard({ container, onImport, nested }: ContainerCardProps) {
   return (
-    <div className="squircle border bg-card p-4 space-y-3">
+    <div
+      className={`squircle p-4 space-y-3 ${
+        nested ? "bg-background-deep" : "bg-card shadow-card dark:border"
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">

--- a/app/(authenticated)/discover/import-dialog.tsx
+++ b/app/(authenticated)/discover/import-dialog.tsx
@@ -325,7 +325,7 @@ export function ImportDialog({
                 <p className="text-xs text-muted-foreground">No environment variables found.</p>
               )}
               {envVars.length > 0 && (
-                <div className="max-h-48 overflow-y-auto space-y-1.5 rounded-lg border p-2">
+                <div className="max-h-48 overflow-y-auto space-y-1.5 rounded-lg bg-background-deep p-2">
                   {envVars.map((v, i) => (
                     <div key={`${v.key}-${i}`} className="flex items-center gap-2 text-xs font-mono">
                       <span className="text-muted-foreground min-w-0 flex-1 truncate">
@@ -372,7 +372,7 @@ export function ImportDialog({
                   </div>
                 </div>
 
-                <div className="space-y-1.5 rounded-lg border p-2">
+                <div className="space-y-1.5 rounded-lg bg-background-deep p-2">
                   {mounts.map((m) => {
                     const isBind = m.type === "bind";
                     const isSelected = mountToggles[m.destination] ?? true;

--- a/app/(authenticated)/metrics/loading.tsx
+++ b/app/(authenticated)/metrics/loading.tsx
@@ -18,7 +18,7 @@ export default function MetricsLoading() {
         {/* Metric cards */}
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-xl border bg-card p-4 space-y-2">
+            <div key={i} className="rounded-xl bg-card p-4 space-y-2 shadow-card dark:border">
               <div className="h-3 w-16 bg-muted animate-pulse rounded-md" />
               <div className="h-7 w-24 bg-muted animate-pulse rounded-md" />
             </div>
@@ -26,7 +26,7 @@ export default function MetricsLoading() {
         </div>
 
         {/* Main chart area */}
-        <div className="rounded-xl border bg-card p-6 space-y-4">
+        <div className="rounded-xl bg-card p-6 space-y-4 shadow-card dark:border">
           <div className="flex items-center justify-between">
             <div className="h-5 w-20 bg-muted animate-pulse rounded-md" />
             <div className="flex gap-2">

--- a/app/(authenticated)/metrics/org-metrics.tsx
+++ b/app/(authenticated)/metrics/org-metrics.tsx
@@ -122,7 +122,7 @@ function ShareBar({ title, subtitle, total, totalLabel, slices, footnote }: {
 }) {
   const sum = slices.reduce((s, sl) => s + sl.value, 0);
   return (
-    <div className="squircle rounded-lg border bg-card overflow-hidden">
+    <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
       <div className="flex items-center justify-between gap-2 px-4 py-2 border-b">
         <h3 className="text-sm font-medium">{title}</h3>
         {subtitle && <span className="text-[10px] text-muted-foreground text-right">{subtitle}</span>}
@@ -391,7 +391,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
 
       {/* Summary cards with sparklines */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-        <div className="squircle relative rounded-lg border bg-card px-4 py-3 overflow-hidden">
+        <div className="squircle relative rounded-lg bg-card px-4 py-3 shadow-card dark:border overflow-hidden">
           {points.length > 1 && (
             <Sparkline data={cpuSparkData} className="absolute inset-0 w-full h-full pointer-events-none" style={{ color: CHART_COLORS.cpu }} />
           )}
@@ -406,7 +406,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             {cpu.detail ?? `summed across containers · ${scopeNote}`}
           </p>
         </div>
-        <div className="squircle relative rounded-lg border bg-card px-4 py-3 overflow-hidden">
+        <div className="squircle relative rounded-lg bg-card px-4 py-3 shadow-card dark:border overflow-hidden">
           {points.length > 1 && (
             <Sparkline data={memSparkData} className="absolute inset-0 w-full h-full pointer-events-none" style={{ color: CHART_COLORS.memory }} />
           )}
@@ -423,7 +423,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
               : `running containers · ${scopeNote}`}
           </p>
         </div>
-        <div className="squircle relative rounded-lg border bg-card px-4 py-3 overflow-hidden">
+        <div className="squircle relative rounded-lg bg-card px-4 py-3 shadow-card dark:border overflow-hidden">
           {points.length > 1 && (
             <Sparkline data={diskSparkData} className="absolute inset-0 w-full h-full pointer-events-none" style={{ color: CHART_COLORS.disk }} />
           )}
@@ -442,7 +442,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </p>
           )}
         </div>
-        <div className="squircle relative rounded-lg border bg-card px-4 py-3 overflow-hidden">
+        <div className="squircle relative rounded-lg bg-card px-4 py-3 shadow-card dark:border overflow-hidden">
           {points.length > 1 && (<>
             <Sparkline data={netRxSparkData} className="absolute inset-0 w-full h-full pointer-events-none" style={{ color: CHART_COLORS.networkRx }} />
             <Sparkline data={netTxSparkData} className="absolute inset-0 w-full h-full pointer-events-none" style={{ color: CHART_COLORS.networkTx }} />
@@ -460,7 +460,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
             </p>
           )}
         </div>
-        <div className="squircle rounded-lg border bg-card px-4 py-3">
+        <div className="squircle rounded-lg bg-card px-4 py-3 shadow-card dark:border">
           <div className="flex items-center gap-2">
             <Box className="size-4 text-muted-foreground shrink-0" />
             <p className="text-xs text-muted-foreground">Containers</p>
@@ -478,7 +478,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
 
       {/* Aggregate charts */}
       <div className="grid md:grid-cols-2 gap-4">
-          <div className="squircle rounded-lg border bg-card overflow-hidden">
+          <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-3 border-b">
               <Cpu className="size-4 text-muted-foreground" />
               <h3 className="text-sm font-medium">CPU</h3>
@@ -502,7 +502,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
               </ResponsiveContainer>
             </div>
           </div>
-          <div className="squircle rounded-lg border bg-card overflow-hidden">
+          <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-3 border-b">
               <MemoryStick className="size-4 text-muted-foreground" />
               <h3 className="text-sm font-medium">Memory</h3>
@@ -525,7 +525,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
               </ResponsiveContainer>
             </div>
           </div>
-          <div className="squircle rounded-lg border bg-card overflow-hidden">
+          <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-3 border-b">
               <Network className="size-4 text-muted-foreground" />
               <h3 className="text-sm font-medium">Network</h3>
@@ -534,7 +534,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
               <NetworkChart data={chartPoints} height={180} />
             </div>
           </div>
-          <div className="squircle rounded-lg border bg-card overflow-hidden">
+          <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
             <div className="flex items-center gap-2 px-4 py-3 border-b">
               <HardDrive className="size-4 text-muted-foreground" />
               <h3 className="text-sm font-medium">Disk Usage</h3>
@@ -652,7 +652,7 @@ export function OrgMetrics({ orgId, apps, projectCount, adminMode }: OrgMetricsP
           </Button>
         </div>
       ) : (
-        <div className="squircle rounded-lg border bg-card overflow-x-auto">
+        <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-x-auto">
           <div className="flex items-center justify-between gap-2 px-4 py-2 border-b">
             <h3 className="text-sm font-medium">Apps</h3>
             <span className="text-[10px] text-muted-foreground">

--- a/app/(authenticated)/projects/[...slug]/project-detail.tsx
+++ b/app/(authenticated)/projects/[...slug]/project-detail.tsx
@@ -281,7 +281,7 @@ function ProjectDeployments({ apps, color }: { apps: ProjectApp[]; color: string
                   : "bg-card";
 
           return (
-            <div key={deployment.id} className={`squircle rounded-lg border ${bgColor} overflow-hidden`}>
+            <div key={deployment.id} className={`squircle rounded-lg ${bgColor} shadow-card dark:border overflow-hidden`}>
               <button
                 type="button"
                 onClick={() => setViewingLogId(viewingLogId === deployment.id ? null : deployment.id)}
@@ -406,7 +406,7 @@ function ProjectVariables({ apps, orgId }: { apps: ProjectApp[]; orgId: string }
   return (
     <div className="space-y-2">
       {apps.map((app) => (
-        <div key={app.id} className="squircle rounded-lg border bg-card overflow-hidden">
+        <div key={app.id} className="squircle rounded-lg bg-card shadow-card dark:border overflow-hidden">
           <button
             type="button"
             onClick={() => setExpandedApp(expandedApp === app.id ? null : app.id)}

--- a/app/(authenticated)/projects/app-grid.tsx
+++ b/app/(authenticated)/projects/app-grid.tsx
@@ -539,7 +539,7 @@ export function AppGrid({
       </div>
 
       {projectCards.length === 0 && (apps.length > 0 || emptyProjects.length > 0) && (
-        <div className="squircle lining flex flex-col items-center justify-center gap-3 rounded-lg border bg-card p-12">
+        <div className="squircle lining flex flex-col items-center justify-center gap-3 rounded-lg bg-card p-12 shadow-card dark:border">
           <p className="text-sm text-muted-foreground">
             No apps match the current filters.
           </p>

--- a/app/(authenticated)/projects/first-run.tsx
+++ b/app/(authenticated)/projects/first-run.tsx
@@ -55,7 +55,7 @@ export function FirstRun({ canImportContainers }: { canImportContainers: boolean
             <Link
               key={card.href}
               href={card.href}
-              className="squircle flex flex-col gap-2 rounded-lg border bg-card p-5 transition-colors hover:bg-accent/50"
+              className="squircle flex flex-col gap-2 rounded-lg bg-card p-5 shadow-card dark:border transition-colors hover:bg-accent/50"
             >
               <Icon className="size-6 text-muted-foreground" aria-hidden="true" />
               <span className="text-sm font-medium">{card.title}</span>

--- a/app/(authenticated)/projects/loading.tsx
+++ b/app/(authenticated)/projects/loading.tsx
@@ -28,7 +28,7 @@ export default function ProjectsLoading() {
               {Array.from({ length: group === 1 ? 3 : 2 }).map((_, i) => (
                 <div
                   key={i}
-                  className="rounded-xl border bg-card p-4 space-y-3"
+                  className="rounded-xl bg-card p-4 space-y-3 shadow-card dark:border"
                 >
                   {/* App header: icon + name + status */}
                   <div className="flex items-center justify-between">

--- a/app/(authenticated)/updates/fleet-updates.tsx
+++ b/app/(authenticated)/updates/fleet-updates.tsx
@@ -304,7 +304,7 @@ export function FleetUpdates({ orgId }: { orgId: string }) {
       {report && <BatchOutcome report={report} />}
 
       {data.apps.length === 0 && data.selfManaged.length === 0 ? (
-        <section className="squircle rounded-lg border bg-card px-4 py-10 text-center">
+        <section className="squircle rounded-lg bg-card px-4 py-10 text-center shadow-card dark:border">
           <CircleCheck className="mx-auto size-6 text-status-success" aria-hidden="true" />
           <p className="type-body mt-2 text-muted-foreground">
             Every image across the fleet is up to date.
@@ -320,7 +320,7 @@ export function FleetUpdates({ orgId }: { orgId: string }) {
           <section
             key={app.appId}
             aria-label={`Image updates for ${app.displayName}`}
-            className="squircle rounded-lg border bg-card divide-y"
+            className="squircle rounded-lg bg-card divide-y shadow-card dark:border"
           >
             <header className="flex items-center gap-2 px-4 py-2.5">
               <Link
@@ -404,7 +404,7 @@ function IgnoredList({
   onRestore: (entry: FleetIgnoredUpdate) => void;
 }) {
   return (
-    <details className="squircle rounded-lg border bg-card">
+    <details className="squircle rounded-lg bg-card shadow-card dark:border">
       <summary className="type-body-sm flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 text-muted-foreground transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
         <BellOff className="size-3.5" aria-hidden="true" />
         Ignored ({entries.length})
@@ -446,8 +446,10 @@ function BatchOutcome({ report }: { report: BatchReport }) {
   return (
     <section
       aria-label="Batch update result"
-      className={`squircle rounded-lg border p-4 space-y-2 ${
-        report.failed > 0 ? "border-status-warning/30 bg-status-warning-muted/30" : "bg-card"
+      className={`squircle rounded-lg p-4 space-y-2 ${
+        report.failed > 0
+          ? "border border-status-warning/30 bg-status-warning-muted/30"
+          : "bg-card shadow-card dark:border"
       }`}
     >
       <p className="type-body-sm flex items-center gap-2">

--- a/components/backups/auto-backup-banner.tsx
+++ b/components/backups/auto-backup-banner.tsx
@@ -33,7 +33,7 @@ export function AutoBackupBanner({
   const healthy = failures.length === 0 && lastRun?.status === "success";
 
   return (
-    <div className="squircle space-y-4 rounded-lg border bg-card p-5">
+    <div className="squircle space-y-4 rounded-lg bg-card p-5 shadow-card dark:border">
       <div className="flex items-start gap-3">
         {running.length > 0 ? (
           <Loader2 className="mt-0.5 size-5 shrink-0 animate-spin text-status-warning" aria-hidden="true" />

--- a/components/backups/backup-history.tsx
+++ b/components/backups/backup-history.tsx
@@ -79,7 +79,7 @@ export function BackupHistory({
   }
 
   return (
-    <div className="rounded-lg border overflow-x-auto">
+    <div className="rounded-lg bg-background-deep overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b">

--- a/components/backups/job-card.tsx
+++ b/components/backups/job-card.tsx
@@ -95,7 +95,7 @@ export function JobCard({
 
   return (
     <>
-      <div className="squircle rounded-lg border bg-card p-4 space-y-2">
+      <div className="squircle rounded-lg bg-background-deep p-4 space-y-2">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2 min-w-0">
             <p className="text-sm font-medium">{job.name}</p>

--- a/components/backups/job-form.tsx
+++ b/components/backups/job-form.tsx
@@ -179,7 +179,7 @@ export function JobForm({
             ) : (
               <div className="grid gap-2">
                 <Label>Apps to back up</Label>
-                <div className="space-y-1 max-h-48 overflow-y-auto rounded-md border p-2">
+                <div className="space-y-1 max-h-48 overflow-y-auto rounded-md bg-background-deep p-2">
                   {apps.length === 0 ? (
                     <p className="text-xs text-muted-foreground py-2 text-center">No apps available</p>
                   ) : (

--- a/components/backups/target-card.tsx
+++ b/components/backups/target-card.tsx
@@ -48,7 +48,7 @@ export function TargetCard({
 
   return (
     <>
-      <div className="squircle rounded-lg border bg-card p-4">
+      <div className="squircle rounded-lg bg-background-deep p-4">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 min-w-0">
             <TargetIcon type={target.type} />


### PR DESCRIPTION
Cleanup pass on the densest screens — projects, metrics, activity, updates, discover and backups. No new tokens, colors, spacing or layout; only the mechanism that separates one surface from another.

## The rule

`components/ui/card.tsx` already states it: *"Layers over borders — the surface and its shadow define the card. Dark keeps a hairline because shadows barely read on a dark ground."* Hand-built panels in these routes reproduced the outline instead.

**34 outlines removed**, in three groups:

| Was | Now | Count |
|---|---|---|
| `rounded-lg border bg-card` panel on the page ground | `bg-card shadow-card dark:border` | 26 |
| Bordered panel nested inside another panel | tray on `bg-background-deep` | 7 |
| Table wrapped in its own outline | tray ground; header rule + row dividers carry it | 1 |

Per file: `metrics/org-metrics.tsx` 11 (5 summary tiles, 4 chart panels, the ShareBar, the apps table), `updates/fleet-updates.tsx` 4, `projects/*` 5, `discover/*` 4, `components/backups/*` 5, `activity/*` 2, loading skeletons 3.

## Nesting

Three places had a bordered box directly inside another one. Each inner box became a tray rather than a second outline:

- `TargetCard` / `JobCard` — both render inside a `<Card>` on the backups page, so they now sit on `bg-background-deep`.
- `ContainerCard` — takes a `nested` prop. Standalone in Discover it's a card; inside `ComposeGroupCard` it's a tray. The group card itself moves from `bg-card/50` to a real card.
- The failed-activity row's error block — was outlined inside an already-outlined row.

Two scroll containers (`import-dialog`, `job-form`) were outlined only to group checkboxes already sitting on the sheet ground; they step the ground instead.

`BackupHistory` renders both inside a `<Card>` (backups page) and directly on the page ground (app and project backup tabs), so its wrapper takes the tray ground — one class list that reads correctly in both.

## Kept

`dark:border` on every card. Row dividers and `divide-y`. `border-b` under headers and toolbars. Table header rules on the raw `<table>` elements. Control and chip edges. Status hairlines (`border-status-*`), `surface-danger` zones, and the dashed empty-state idiom used app-wide.

Never applied: border plus `shadow-card` on the same element in light mode.

## Verified

`pnpm test` green — typecheck, lint (0 errors), 4503 unit tests.

Screenshotted against a live instance in both themes: projects, metrics, discover, updates, backups, and the project detail Apps/Deployments/Variables tabs. The dark hairline reads correctly and the tray steps are legible in both.

Not exercisable on this instance (no seed data): activity rows, backup target/job cards, the backup history table, deployment rows, and the loading skeletons.

## Follow-up, out of scope

`components/image-updates/self-managed-updates.tsx:22` carries the identical `squircle rounded-lg border bg-card divide-y` and renders directly beside the converted panels on `/updates`, so that page currently mixes both treatments. It lives outside this PR's scope.
