### PR TITLE
style: finish the surfaces pass across scope boundaries

### DIFF
--- a/app/(authenticated)/apps/[...slug]/app-metrics.tsx
+++ b/app/(authenticated)/apps/[...slug]/app-metrics.tsx
@@ -129,7 +129,7 @@ function NoSamples() {
 
 function ContainerTable({ containers }: { containers: ContainerPoint[] }) {
   return (
-    <div className="squircle rounded-lg border bg-card overflow-x-auto">
+    <div className="squircle rounded-lg bg-card shadow-card dark:border overflow-x-auto">
       <div className="flex items-center gap-2 px-4 py-3 border-b">
         <Container className="size-4 text-muted-foreground" />
         <h3 className="text-sm font-medium">Containers</h3>
@@ -449,7 +449,7 @@ export function AppMetrics({ orgId, appId, environmentName, gpuEnabled, cpuLimit
       {containers.length > 0 ? (
         <ContainerTable containers={containers} />
       ) : awaitingFirstFrame ? (
-        <div className="squircle rounded-lg border bg-card">
+        <div className="squircle rounded-lg bg-card shadow-card dark:border">
           <div className="flex items-center gap-2 px-4 py-3 border-b">
             <Container className="size-4 text-muted-foreground" />
             <h3 className="text-sm font-medium">Containers</h3>

--- a/app/(authenticated)/apps/new/new-app-flow.tsx
+++ b/app/(authenticated)/apps/new/new-app-flow.tsx
@@ -534,7 +534,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
                     key={opt.id}
                     type="button"
                     onClick={() => selectSource(opt.id)}
-                    className="squircle flex flex-col items-center gap-2 rounded-lg border bg-card p-4 text-center transition-colors hover:bg-accent/50"
+                    className="squircle flex flex-col items-center gap-2 rounded-lg bg-background-deep p-4 text-center transition-colors hover:bg-accent/50"
                   >
                     <Icon className="size-6 text-muted-foreground" />
                     <span className="text-sm font-medium">{opt.label}</span>
@@ -547,7 +547,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
               {containerImportEnabled && (
                 <Link
                   href="/discover"
-                  className="squircle flex flex-col items-center gap-2 rounded-lg border bg-card p-4 text-center transition-colors hover:bg-accent/50"
+                  className="squircle flex flex-col items-center gap-2 rounded-lg bg-background-deep p-4 text-center transition-colors hover:bg-accent/50"
                 >
                   <Boxes className="size-6 text-muted-foreground" aria-hidden="true" />
                   <span className="text-sm font-medium">Existing containers</span>
@@ -571,7 +571,7 @@ export function NewAppFlow({ orgId, orgSlug, templates, parentApps = [], baseDom
                     key={tmpl.id}
                     type="button"
                     onClick={() => selectTemplate(tmpl)}
-                    className="squircle flex items-center gap-3 rounded-lg border bg-card p-3 text-left transition-colors hover:bg-accent/50"
+                    className="squircle flex items-center gap-3 rounded-lg bg-background-deep p-3 text-left transition-colors hover:bg-accent/50"
                   >
                     {tmpl.icon ? (
                       <img

--- a/components/image-updates/self-managed-updates.tsx
+++ b/components/image-updates/self-managed-updates.tsx
@@ -19,7 +19,7 @@ export function SelfManagedUpdates({
   return (
     <section
       aria-label={`Vardo-managed images for ${title}`}
-      className="squircle rounded-lg border bg-card divide-y"
+      className="squircle rounded-lg bg-card shadow-card dark:border divide-y"
     >
       <header className="flex items-center gap-2 px-4 py-2.5">
         <Lock className="size-3.5 text-muted-foreground/50" aria-hidden="true" />


### PR DESCRIPTION
Four agents ran the surfaces-over-borders pass on disjoint paths. That left seams where the scopes met — panels sitting flat next to lifted ones on the same screen.

Closing them, plus the last of the pattern.

- `app-metrics.tsx` (×2) — the container tables render beside `ChartCard`, which converted in #832. The metrics tab was split down the middle.
- `self-managed-updates.tsx` — byte-identical to the panels converted in #835 and rendered directly beside them on `/updates`.
- `new-app-flow.tsx` (×3) — the source and template pickers. These went to a **tray** rather than a lifted card: twenty-four shadowed tiles in a grid is noise, and `hover:bg-accent/50` already carries the affordance.

`rounded-lg border bg-card` is now **zero occurrences** app-wide.

## Why this matters more than the diff suggests

From the DigitalOcean research that ran alongside this work — their console is described by users as "three slightly different consoles depending on which page you're in," from an incremental migration that started in 2020 and still shows the seam. A partial surfaces migration is worse than none, because the inconsistency reads as broken rather than as a style.

## Verified in a browser

Both themes, on a local instance with real data.

**Light** — project cards lift off the bone ground with no outline; the raised-header / recessed-ledger / metrics-footer bands read clearly; hairlines survive only inside the card separating metric cells.

**Dark** — panels separate, the nested-outline-inside-outline violation on maintenance settings is gone, row dividers and input edges intact.

One honest caveat: **separation in dark is subtle.** Shadows do not render on a dark ground, so `dark:border` carries it alone at low contrast. It reads fine but it is the weak side of this approach, and worth a look if panels ever start to feel flat.

Screenshots in `~/working/vardo-ui-audit/shots/after/`.
